### PR TITLE
HikariCP documentation improvements

### DIFF
--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -77,6 +77,8 @@ To use the AWS JDBC Driver with a connection pool, you must:
    targetDataSourceProps.setProperty("serverName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
    targetDataSourceProps.setProperty("databaseName", "postgres");
    targetDataSourceProps.setProperty("port", "5432");
+   
+   ds.addDataSourceProperty("targetDataSourceProps", targetDataSourceProps);
    ```
 
 See [here](./sample-code/HikariSample.java) for a complete sample.

--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -78,7 +78,7 @@ To use the AWS JDBC Driver with a connection pool, you must:
    targetDataSourceProps.setProperty("databaseName", "postgres");
    targetDataSourceProps.setProperty("port", "5432");
    
-   ds.addDataSourceProperty("targetDataSourceProps", targetDataSourceProps);
+   ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
    ```
 
 See [here](./sample-code/HikariSample.java) for a complete sample.

--- a/docs/using-the-jdbc-driver/sample-code/HikariSample.java
+++ b/docs/using-the-jdbc-driver/sample-code/HikariSample.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import com.zaxxer.hikari.HikariDataSource;
 import software.amazon.jdbc.ds.AwsWrapperDataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -49,7 +50,8 @@ public class HikariSample {
     targetDataSourceProps.setProperty("serverPropertyName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
     targetDataSourceProps.setProperty("databasePropertyName", "postgres");
     targetDataSourceProps.setProperty("portPropertyName", "5432");
-    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    
+    ds.addDataSourceProperty("targetDataSourceProps", targetDataSourceProps);
 
     // Try and make a connection:
     try (final Connection conn = ds.getConnection();

--- a/docs/using-the-jdbc-driver/sample-code/HikariSample.java
+++ b/docs/using-the-jdbc-driver/sample-code/HikariSample.java
@@ -51,7 +51,7 @@ public class HikariSample {
     targetDataSourceProps.setProperty("databaseName", "postgres");
     targetDataSourceProps.setProperty("portNumber", "5432");
     
-    ds.addDataSourceProperty("targetDataSourceProps", targetDataSourceProps);
+    ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
 
     // Try and make a connection:
     try (final Connection conn = ds.getConnection();

--- a/docs/using-the-jdbc-driver/sample-code/HikariSample.java
+++ b/docs/using-the-jdbc-driver/sample-code/HikariSample.java
@@ -47,9 +47,9 @@ public class HikariSample {
 
     // Configuring PGSimpleDataSource:
     Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty("serverPropertyName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
-    targetDataSourceProps.setProperty("databasePropertyName", "postgres");
-    targetDataSourceProps.setProperty("portPropertyName", "5432");
+    targetDataSourceProps.setProperty("serverName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
+    targetDataSourceProps.setProperty("databaseName", "postgres");
+    targetDataSourceProps.setProperty("portNumber", "5432");
     
     ds.addDataSourceProperty("targetDataSourceProps", targetDataSourceProps);
 


### PR DESCRIPTION
### Summary

HikariCP documentation improvements

### Description

I tried setting up the driver and ran into some issues following the docs. I don't know how HikariCP works that well so it took me a couple hours to understand what was intended. 

What threw me off was that this [file](https://github.com/awslabs/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/sample-code/HikariSample.java#L52) simply doesn't compile for a few reasons
* Its missing imports
* Its calling a method on a `HikariDataSource` that simply doesn't exist. 

I have updated it to configure the target data source properties correctly so they will be correctly configured on the AWS wrapper data source using [reflection](https://github.com/openbouquet/HikariCP/blob/master/src/main/java/com/zaxxer/hikari/util/PropertyElf.java). 

### Additional Reviewers

<!-- Any additional reviewers -->