### PR TITLE
feat: track the current connection's prepared transaction state

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PluginManagerService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginManagerService.java
@@ -21,4 +21,6 @@ public interface PluginManagerService {
   void setReadOnly(boolean readOnly);
 
   void setInTransaction(boolean inTransaction);
+
+  void setInPreparedTransaction(boolean inPreparedTransaction);
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -55,6 +55,8 @@ public interface PluginService {
 
   boolean isInTransaction();
 
+  boolean isInPreparedTransaction();
+
   HostListProvider getHostListProvider();
 
   void refreshHostList() throws SQLException;

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -53,6 +53,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources, Ho
   protected HostSpec currentHostSpec;
   protected HostSpec initialConnectionHostSpec;
   private boolean isInTransaction;
+  private boolean isInPreparedTransaction;
   private boolean explicitReadOnly;
 
   public PluginServiceImpl(
@@ -279,6 +280,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources, Ho
   }
 
   @Override
+  public boolean isInPreparedTransaction() {
+    return this.isInPreparedTransaction;
+  }
+
+  @Override
   public void setReadOnly(final boolean readOnly) {
     this.explicitReadOnly = readOnly;
   }
@@ -286,6 +292,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources, Ho
   @Override
   public void setInTransaction(final boolean inTransaction) {
     this.isInTransaction = inTransaction;
+  }
+
+  @Override
+  public void setInPreparedTransaction(final boolean inPreparedTransaction) {
+    this.isInPreparedTransaction = inPreparedTransaction;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
@@ -48,4 +48,9 @@ public class SubscribedMethodHelper {
       "CallableStatement.executeUpdate",
       "CallableStatement.executeLargeUpdate"
   );
+
+  public static final List<String> XA_PREPARE_TRANSACTION = Arrays.asList(
+      "MysqlXAConnection.prepare",
+      "PGXAConnection.prepare"
+  );
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -305,6 +305,11 @@ public class ConcurrencyTests {
     }
 
     @Override
+    public boolean isInPreparedTransaction() {
+      return false;
+    }
+
+    @Override
     public HostListProvider getHostListProvider() {
       return null;
     }


### PR DESCRIPTION
### Summary

Keep track of the connection's transaction state and skip querying topology if it is in the `PREPARED` state.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@sergiyvamz @congoamz @joyc-bq @alecc-bq 