### PR TITLE
refactor: make topology queries more consistent between different databases

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -82,7 +82,8 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
   static final String MYSQL_RETRIEVE_TOPOLOGY_SQL =
       "SELECT SERVER_ID, SESSION_ID"
           + "FROM information_schema.replica_host_status "
-          + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID'" // 5 min
+          // filter out nodes that haven't been updated in the last 5 minutes
+          + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID'"
           + "ORDER BY LAST_UPDATE_TIMESTAMP";
   static final int DEFAULT_CACHE_EXPIRE_MS = 5 * 60 * 1000; // 5 min
   static final String MYSQL_GET_INSTANCE_NAME_SQL = "SELECT @@aurora_server_id";

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -80,9 +80,9 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
           + "ORDER BY LAST_UPDATE_TIMESTAMP";
 
   static final String MYSQL_RETRIEVE_TOPOLOGY_SQL =
-      "SELECT SERVER_ID, SESSION_ID, LAST_UPDATE_TIMESTAMP, REPLICA_LAG_IN_MILLISECONDS "
+      "SELECT SERVER_ID, SESSION_ID"
           + "FROM information_schema.replica_host_status "
-          + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 " // 5 min
+          + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID'" // 5 min
           + "ORDER BY LAST_UPDATE_TIMESTAMP";
   static final int DEFAULT_CACHE_EXPIRE_MS = 5 * 60 * 1000; // 5 min
   static final String MYSQL_GET_INSTANCE_NAME_SQL = "SELECT @@aurora_server_id";


### PR DESCRIPTION
### Summary

Modify the queries used by MySQL and PostgreSQL to query topologies so they are more consistent

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->