### PR TITLE
test: fix failing IAM integration tests using IP addresses

### DIFF
--- a/wrapper/src/test/java/integration/container/aurora/mysql/mariadbdriver/AuroraMysqlAwsIamIntegrationTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/mariadbdriver/AuroraMysqlAwsIamIntegrationTest.java
@@ -62,7 +62,7 @@ public class AuroraMysqlAwsIamIntegrationTest extends MariadbAuroraMysqlBaseTest
     final String hostIp = hostToIP(MYSQL_CLUSTER_URL);
     props.setProperty("iamHost", MYSQL_CLUSTER_URL);
 
-    final Connection conn =  connectToInstance(hostIp, AURORA_MYSQL_PORT, props);
+    final Connection conn = DriverManager.getConnection(DB_CONN_STR_PREFIX + hostIp + "?permitMysqlScheme", props);
     Assertions.assertDoesNotThrow(conn::close);
   }
 

--- a/wrapper/src/test/java/integration/container/aurora/mysql/mysqldriver/AuroraMysqlAwsIamIntegrationTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/mysqldriver/AuroraMysqlAwsIamIntegrationTest.java
@@ -62,7 +62,7 @@ public class AuroraMysqlAwsIamIntegrationTest extends MysqlAuroraMysqlBaseTest {
     final String hostIp = hostToIP(MYSQL_CLUSTER_URL);
     props.setProperty("iamHost", MYSQL_CLUSTER_URL);
 
-    final Connection conn =  connectToInstance(hostIp, AURORA_MYSQL_PORT, props);
+    final Connection conn = DriverManager.getConnection(DB_CONN_STR_PREFIX + hostIp + ":" + AURORA_MYSQL_PORT, props);
     Assertions.assertDoesNotThrow(conn::close);
   }
 


### PR DESCRIPTION
### Summary

Fix IAM integration tests that use IP addresses to establish connections.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

@alecc-bq 