### PR TITLE
Fix bug where failoverTimeoutMs was not obeyed

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
@@ -106,13 +106,13 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
     try {
       final long startTimeNano = System.nanoTime();
       WriterFailoverResult result = getNextResult(executorService, completionService, this.maxFailoverTimeoutMs);
-      final long endTimeNano = System.nanoTime();
       if (result.isConnected() || result.getException() != null) {
         return result;
       }
 
-      final int durationMs = (int) TimeUnit.NANOSECONDS.toMillis(endTimeNano - startTimeNano);
-      final int remainingTimeMs = this.maxFailoverTimeoutMs - durationMs;
+      final long endTimeNano = System.nanoTime();
+      final long durationMs = TimeUnit.NANOSECONDS.toMillis(endTimeNano - startTimeNano);
+      final long remainingTimeMs = this.maxFailoverTimeoutMs - durationMs;
 
       if (remainingTimeMs > 0) {
         result = getNextResult(executorService, completionService, remainingTimeMs);
@@ -158,7 +158,7 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
   private WriterFailoverResult getNextResult(
       final ExecutorService executorService,
       final CompletionService<WriterFailoverResult> completionService,
-      final int timeoutMs) throws SQLException {
+      final long timeoutMs) throws SQLException {
     try {
       final Future<WriterFailoverResult> firstCompleted = completionService.poll(
           timeoutMs, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
### Summary

RDS-1199: Fix bug where failoverTimeoutMs was not obeyed

### Description

- Before this commit, failover could take up to two times the length of
failoverTimeoutMs before giving up. This commit adds changes to
limit failover to run for a maximum of failoverTimeoutMs
milliseconds

### Additional Reviewers

@karenc-bq 
@congoamz 