### PR TITLE
Fix cluster DNS resolution in testing logic

### DIFF
--- a/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
@@ -238,7 +238,7 @@ public abstract class AuroraMysqlBaseTest {
     TestPluginServiceImpl.clearHostAvailabilityCache();
   }
 
-  protected Properties initDefaultPropsNoTimeouts() {
+  protected static Properties initDefaultPropsNoTimeouts() {
     final Properties props = new Properties();
     props.setProperty(PropertyDefinition.USER.name, AURORA_MYSQL_USERNAME);
     props.setProperty(PropertyDefinition.PASSWORD.name, AURORA_MYSQL_PASSWORD);
@@ -248,7 +248,7 @@ public abstract class AuroraMysqlBaseTest {
     return props;
   }
 
-  protected Properties initDefaultProps() {
+  protected static Properties initDefaultProps() {
     final Properties props = initDefaultPropsNoTimeouts();
     props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
     props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
@@ -256,7 +256,7 @@ public abstract class AuroraMysqlBaseTest {
     return props;
   }
 
-  protected Properties initDefaultProxiedProps() {
+  protected static Properties initDefaultProxiedProps() {
     final Properties props = initDefaultProps();
     AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(props, PROXIED_CLUSTER_TEMPLATE);
 

--- a/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
@@ -19,6 +19,7 @@ package integration.container.aurora.mysql;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.mysql.cj.conf.PropertyKey;
 import eu.rekawek.toxiproxy.Proxy;
@@ -237,7 +238,7 @@ public abstract class AuroraMysqlBaseTest {
     TestPluginServiceImpl.clearHostAvailabilityCache();
   }
 
-  protected static Properties initDefaultPropsNoTimeouts() {
+  protected Properties initDefaultPropsNoTimeouts() {
     final Properties props = new Properties();
     props.setProperty(PropertyDefinition.USER.name, AURORA_MYSQL_USERNAME);
     props.setProperty(PropertyDefinition.PASSWORD.name, AURORA_MYSQL_PASSWORD);
@@ -247,7 +248,7 @@ public abstract class AuroraMysqlBaseTest {
     return props;
   }
 
-  protected static Properties initDefaultProps() {
+  protected Properties initDefaultProps() {
     final Properties props = initDefaultPropsNoTimeouts();
     props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
     props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
@@ -255,7 +256,7 @@ public abstract class AuroraMysqlBaseTest {
     return props;
   }
 
-  protected static Properties initDefaultProxiedProps() {
+  protected Properties initDefaultProxiedProps() {
     final Properties props = initDefaultProps();
     AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(props, PROXIED_CLUSTER_TEMPLATE);
 
@@ -292,9 +293,15 @@ public abstract class AuroraMysqlBaseTest {
     return DriverManager.getConnection(url, props);
   }
 
-  protected String hostToIP(String hostname) throws UnknownHostException {
-    final InetAddress inet = InetAddress.getByName(hostname);
-    return inet.getHostAddress();
+  protected String hostToIP(String hostname) {
+    try {
+      final InetAddress inet;
+      inet = InetAddress.getByName(hostname);
+      return inet.getHostAddress();
+    } catch (UnknownHostException e) {
+      fail("The IP address of host " + hostname + " could not be determined");
+      return null;
+    }
   }
 
   // Return list of instance endpoints.
@@ -456,8 +463,10 @@ public abstract class AuroraMysqlBaseTest {
   // Helpers
   protected void failoverClusterAndWaitUntilWriterChanged(String clusterWriterId)
       throws InterruptedException {
+    waitUntilClusterHasRightState();
+    String initialWriterClusterIP = hostToIP(MYSQL_CLUSTER_URL);
     failoverCluster();
-    waitUntilWriterInstanceChanged(clusterWriterId);
+    waitUntilWriterInstanceChanged(initialWriterClusterIP, clusterWriterId);
   }
 
   protected void failoverCluster() throws InterruptedException {
@@ -475,8 +484,10 @@ public abstract class AuroraMysqlBaseTest {
   protected void failoverClusterToATargetAndWaitUntilWriterChanged(
       String clusterWriterId,
       String targetInstanceId) throws InterruptedException {
+    waitUntilClusterHasRightState();
+    String initialWriterClusterIP = hostToIP(MYSQL_CLUSTER_URL);
     failoverClusterWithATargetInstance(targetInstanceId);
-    waitUntilWriterInstanceChanged(clusterWriterId);
+    waitUntilWriterInstanceChanged(initialWriterClusterIP, clusterWriterId);
   }
 
   protected void failoverClusterWithATargetInstance(String targetInstanceId)
@@ -495,13 +506,15 @@ public abstract class AuroraMysqlBaseTest {
     }
   }
 
-  protected void waitUntilWriterInstanceChanged(String initialWriterInstanceId)
+  protected void waitUntilWriterInstanceChanged(String initialWriterClusterIP, String initialWriterInstanceId)
       throws InterruptedException {
     String nextClusterWriterId = getDBClusterWriterInstanceId();
-    while (initialWriterInstanceId.equals(nextClusterWriterId)) {
+    String nextClusterIP = hostToIP(MYSQL_CLUSTER_URL);
+    while (initialWriterInstanceId.equals(nextClusterWriterId) || initialWriterClusterIP.equals(nextClusterIP)) {
       TimeUnit.MILLISECONDS.sleep(3000);
       // Calling the RDS API to get writer Id.
       nextClusterWriterId = getDBClusterWriterInstanceId();
+      nextClusterIP = hostToIP(MYSQL_CLUSTER_URL);
     }
   }
 

--- a/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
@@ -295,8 +295,7 @@ public abstract class AuroraMysqlBaseTest {
 
   protected String hostToIP(String hostname) {
     try {
-      final InetAddress inet;
-      inet = InetAddress.getByName(hostname);
+      final InetAddress inet = InetAddress.getByName(hostname);
       return inet.getHostAddress();
     } catch (UnknownHostException e) {
       fail("The IP address of host " + hostname + " could not be determined");

--- a/wrapper/src/test/java/integration/container/aurora/mysql/mariadbdriver/AuroraMysqlReadWriteSplittingTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/mariadbdriver/AuroraMysqlReadWriteSplittingTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import eu.rekawek.toxiproxy.Proxy;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -134,8 +133,7 @@ public class AuroraMysqlReadWriteSplittingTest extends MariadbAuroraMysqlBaseTes
 
   @ParameterizedTest(name = "test_connectToReaderIP_setReadOnlyTrueFalse")
   @MethodSource("testParameters")
-  public void test_connectToReaderIP_setReadOnlyTrueFalse(final Properties props)
-      throws SQLException, UnknownHostException {
+  public void test_connectToReaderIP_setReadOnlyTrueFalse(final Properties props) throws SQLException {
     final String instanceHostPattern = "?" + DB_CONN_STR_SUFFIX;
     AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(props, instanceHostPattern);
     final String hostIp = hostToIP(MYSQL_RO_CLUSTER_URL);
@@ -237,7 +235,6 @@ public class AuroraMysqlReadWriteSplittingTest extends MariadbAuroraMysqlBaseTes
     }
   }
 
-  @Disabled("Failing on graalvm at the first assertEquals")
   @ParameterizedTest(name = "test_setReadOnlyFalseInTransaction_setAutocommitZero")
   @MethodSource("testParameters")
   public void test_setReadOnlyFalseInTransaction_setAutocommitZero(final Properties props) throws SQLException {
@@ -413,7 +410,6 @@ public class AuroraMysqlReadWriteSplittingTest extends MariadbAuroraMysqlBaseTes
     }
   }
 
-  @Disabled("Failing on graalvm at the first assertEquals")
   @ParameterizedTest(name = "test_readerLoadBalancing_switchAutoCommitInTransaction")
   @MethodSource("testParameters")
   public void test_readerLoadBalancing_switchAutoCommitInTransaction(final Properties props) throws SQLException {

--- a/wrapper/src/test/java/integration/container/aurora/mysql/mysqldriver/AuroraMysqlReadWriteSplittingTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/mysqldriver/AuroraMysqlReadWriteSplittingTest.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import eu.rekawek.toxiproxy.Proxy;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -36,7 +35,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -133,8 +131,7 @@ public class AuroraMysqlReadWriteSplittingTest extends MysqlAuroraMysqlBaseTest 
 
   @ParameterizedTest(name = "test_connectToReaderIP_setReadOnlyTrueFalse")
   @MethodSource("testParameters")
-  public void test_connectToReaderIP_setReadOnlyTrueFalse(final Properties props)
-      throws SQLException, UnknownHostException {
+  public void test_connectToReaderIP_setReadOnlyTrueFalse(final Properties props) throws SQLException {
     final String instanceHostPattern = "?" + DB_CONN_STR_SUFFIX;
     AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(props, instanceHostPattern);
     final String hostIp = hostToIP(MYSQL_RO_CLUSTER_URL);
@@ -236,7 +233,6 @@ public class AuroraMysqlReadWriteSplittingTest extends MysqlAuroraMysqlBaseTest 
     }
   }
 
-  @Disabled("Failing on graalvm only at the first assertEquals")
   @ParameterizedTest(name = "test_setReadOnlyFalseInTransaction_setAutocommitZero")
   @MethodSource("testParameters")
   public void test_setReadOnlyFalseInTransaction_setAutocommitZero(final Properties props) throws SQLException {
@@ -412,7 +408,6 @@ public class AuroraMysqlReadWriteSplittingTest extends MysqlAuroraMysqlBaseTest 
     }
   }
 
-  @Disabled("Failing on graalvm only at the first assertEquals")
   @ParameterizedTest(name = "test_readerLoadBalancing_switchAutoCommitInTransaction")
   @MethodSource("testParameters")
   public void test_readerLoadBalancing_switchAutoCommitInTransaction(final Properties props) throws SQLException {

--- a/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresBaseTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresBaseTest.java
@@ -300,8 +300,7 @@ public abstract class AuroraPostgresBaseTest {
 
   protected String hostToIP(String hostname) {
     try {
-      final InetAddress inet;
-      inet = InetAddress.getByName(hostname);
+      final InetAddress inet = InetAddress.getByName(hostname);
       return inet.getHostAddress();
     } catch (UnknownHostException e) {
       fail("The IP address of host " + hostname + " could not be determined");

--- a/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresReadWriteSplittingTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/postgres/AuroraPostgresReadWriteSplittingTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import eu.rekawek.toxiproxy.Proxy;
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -132,8 +131,7 @@ public class AuroraPostgresReadWriteSplittingTest extends AuroraPostgresBaseTest
 
   @ParameterizedTest(name = "test_connectToReaderIP_setReadOnlyTrueFalse")
   @MethodSource("testParameters")
-  public void test_connectToReaderIP_setReadOnlyTrueFalse(final Properties props)
-      throws SQLException, UnknownHostException {
+  public void test_connectToReaderIP_setReadOnlyTrueFalse(final Properties props) throws SQLException {
     final String instanceHostPattern = "?" + DB_CONN_STR_SUFFIX;
     AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(props, instanceHostPattern);
     final String hostIp = hostToIP(POSTGRES_RO_CLUSTER_URL);

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -58,7 +58,7 @@ import org.testcontainers.utility.TestEnvironment;
 
 public class ContainerHelper {
   private static final String TEST_CONTAINER_IMAGE_NAME_OPENJDK = "openjdk:8-jdk-alpine";
-  private static final String TEST_CONTAINER_IMAGE_NAME_GRAALVM = "ghcr.io/graalvm/jdk:22.2.0";
+  private static final String TEST_CONTAINER_IMAGE_NAME_GRAALVM = "ghcr.io/graalvm/jdk:java8-21.2.0";
   private static final String MYSQL_CONTAINER_IMAGE_NAME = "mysql:8.0.28";
   private static final String POSTGRES_CONTAINER_IMAGE_NAME = "postgres:latest";
   private static final String MARIADB_CONTAINER_IMAGE_NAME = "mariadb:latest";


### PR DESCRIPTION
- This commit fixes a bug in the testing logic where some tests would fail after cluster failover because the cluster URL did not resolve to the new writer IP yet. These failures were flaky and seemed to only occur on GraalVM, likely due to the specific timing and DNS settings required to run into this problem
- After failover, the tests will now wait until the cluster URL resolves to the new writer IP before continuing with verification logic
- Also changed the GraalVM image to use java 8. Previously the image was using java 17