### PR TITLE
Revert change to default mysql socket timeout

### DIFF
--- a/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
+++ b/wrapper/src/test/java/integration/container/aurora/mysql/AuroraMysqlBaseTest.java
@@ -251,7 +251,7 @@ public abstract class AuroraMysqlBaseTest {
   protected static Properties initDefaultProps() {
     final Properties props = initDefaultPropsNoTimeouts();
     props.setProperty(PropertyKey.connectTimeout.getKeyName(), "3000");
-    props.setProperty(PropertyKey.socketTimeout.getKeyName(), "1000");
+    props.setProperty(PropertyKey.socketTimeout.getKeyName(), "3000");
 
     return props;
   }


### PR DESCRIPTION
- the new value seemed to cause flaky test failures