### PR TITLE
Fix bug where inTransaction was not set to false when autocommit was switched from false to true

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -42,7 +42,7 @@ Once this parameter is enabled and `setReadOnly(true)` has been called on the `C
 - After executing `COMMIT`, `ROLLBACK` or `ABORT` as a SQL statement
 - After executing any SQL statement while autocommit is on, with the following exceptions:
     - The statement started a transaction via `BEGIN` or `START TRANSACTION`
-    - The statement began with `SET` (eg `SET time_zone = "+00:00"`)
+    - The statement began with `SET`, `USE`, or `SHOW`
 
 ### Limitations with Reader Load Balancing
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -110,6 +110,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
       this.pluginManagerService.setInTransaction(true);
     } else if (
         sqlMethodAnalyzer.doesCloseTransaction(currentConn, methodName, jdbcMethodArgs)
+            // According to the JDBC spec, transactions are committed if autocommit is switched from false to true.
             || sqlMethodAnalyzer.doesSwitchAutoCommitFalseTrue(currentConn, methodName,
             jdbcMethodArgs)) {
       this.pluginManagerService.setInTransaction(false);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -106,10 +106,10 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
       return result;
     }
 
-    if (sqlMethodAnalyzer.doesOpenTransaction(this.pluginService, methodName, jdbcMethodArgs)) {
+    if (sqlMethodAnalyzer.doesOpenTransaction(currentConn, methodName, jdbcMethodArgs)) {
       this.pluginManagerService.setInTransaction(true);
     } else if (
-        sqlMethodAnalyzer.doesCloseTransaction(this.pluginService, methodName, jdbcMethodArgs)
+        sqlMethodAnalyzer.doesCloseTransaction(currentConn, methodName, jdbcMethodArgs)
             || sqlMethodAnalyzer.doesSwitchAutoCommitFalseTrue(currentConn, methodName,
             jdbcMethodArgs)) {
       this.pluginManagerService.setInTransaction(false);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-
 import software.amazon.jdbc.ConnectionPlugin;
 import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.HostAvailability;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -306,7 +306,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
   }
 
   private boolean isTransactionBoundary(final String methodName, final Object[] args) {
-    if (sqlMethodAnalyzer.doesCloseTransaction(methodName, args)) {
+    if (sqlMethodAnalyzer.doesCloseTransaction(this.pluginService, methodName, args)) {
       return true;
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -306,7 +306,8 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
   }
 
   private boolean isTransactionBoundary(final String methodName, final Object[] args) {
-    if (sqlMethodAnalyzer.doesCloseTransaction(this.pluginService, methodName, args)) {
+    final Connection currentConnection = this.pluginService.getCurrentConnection();
+    if (sqlMethodAnalyzer.doesCloseTransaction(currentConnection, methodName, args)) {
       return true;
     }
 
@@ -316,7 +317,6 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
 
     final boolean autocommit;
     try {
-      final Connection currentConnection = this.pluginService.getCurrentConnection();
       autocommit = currentConnection.getAutoCommit();
     } catch (final SQLException e) {
       return false;

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import software.amazon.jdbc.PluginService;
-
 public class SqlMethodAnalyzer {
 
   public boolean doesOpenTransaction(final Connection conn, final String methodName,
@@ -101,11 +99,9 @@ public class SqlMethodAnalyzer {
   public boolean isStatementDml(final String statement) {
     return !isStatementStartingTransaction(statement)
         && !isStatementClosingTransaction(statement)
-        && !isStatementSettingState(statement);
-  }
-
-  public boolean isStatementSettingState(final String statement) {
-    return statement.startsWith("SET ");
+        && !statement.startsWith("SET ")
+        && !statement.startsWith("USE ")
+        && !statement.startsWith("SHOW ");
   }
 
   public boolean isStatementStartingTransaction(final String statement) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -132,7 +132,7 @@ public class SqlMethodAnalyzer {
       return false;
     }
 
-    Boolean oldAutoCommitVal;
+    boolean oldAutoCommitVal;
     Boolean newAutoCommitVal = null;
     try {
       oldAutoCommitVal = conn.getAutoCommit();
@@ -146,7 +146,7 @@ public class SqlMethodAnalyzer {
       newAutoCommitVal = getAutoCommitValueFromSqlStatement(jdbcMethodArgs);
     }
 
-    return Boolean.FALSE.equals(oldAutoCommitVal) && Boolean.TRUE.equals(newAutoCommitVal);
+    return oldAutoCommitVal == false && Boolean.TRUE.equals(newAutoCommitVal);
   }
 
   public Boolean getAutoCommitValueFromSqlStatement(final Object[] args) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -27,12 +27,8 @@ import software.amazon.jdbc.PluginService;
 
 public class SqlMethodAnalyzer {
 
-  public boolean doesOpenTransaction(final PluginService pluginService, final String methodName,
+  public boolean doesOpenTransaction(final Connection conn, final String methodName,
       final Object[] args) {
-    if (pluginService.isInTransaction()) {
-      return false;
-    }
-
     if (!(methodName.contains("execute") && args != null && args.length >= 1)) {
       return false;
     }
@@ -42,7 +38,6 @@ public class SqlMethodAnalyzer {
       return true;
     }
 
-    final Connection conn = pluginService.getCurrentConnection();
     final boolean autocommit;
     try {
       autocommit = conn.getAutoCommit();
@@ -75,18 +70,13 @@ public class SqlMethodAnalyzer {
     return Arrays.stream(query.split(";")).collect(Collectors.toList());
   }
 
-  public boolean doesCloseTransaction(final PluginService pluginService, final String methodName,
+  public boolean doesCloseTransaction(final Connection conn, final String methodName,
       final Object[] args) {
-    if (!pluginService.isInTransaction()) {
-      return false;
-    }
-
     if (methodName.equals("Connection.commit") || methodName.equals("Connection.rollback")
         || methodName.equals("Connection.close") || methodName.equals("Connection.abort")) {
       return true;
     }
 
-    final Connection conn = pluginService.getCurrentConnection();
     if (doesSwitchAutoCommitFalseTrue(conn, methodName, args)) {
       return true;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -146,7 +146,7 @@ public class SqlMethodAnalyzer {
       newAutoCommitVal = getAutoCommitValueFromSqlStatement(jdbcMethodArgs);
     }
 
-    return oldAutoCommitVal == false && Boolean.TRUE.equals(newAutoCommitVal);
+    return !oldAutoCommitVal && Boolean.TRUE.equals(newAutoCommitVal);
   }
 
   public Boolean getAutoCommitValueFromSqlStatement(final Object[] args) {

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,10 +32,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.stream.Stream;
 
 class SqlMethodAnalyzerTest {
 
@@ -205,6 +204,8 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Statement.execute", " begin ; ", false),
         Arguments.of("Statement.execute", " rollback ; ", false),
         Arguments.of("Statement.execute", "   SET autocommit = 0 ; ", false),
+        Arguments.of("Statement.execute", "   SHOW DATABASES ; ", false),
+        Arguments.of("Statement.execute", "   USE mydatabase ; ", false),
         Arguments.of("Statement.executeQuery", "   SELECT 1; ", true),
         Arguments.of("Statement.executeUpdate", "INSERT INTO test_table VALUES (1)", true)
     );


### PR DESCRIPTION
- According to the Connection#setAutoCommit documentation, transactions are committed when autocommit is switched from false to true. This commit fixes a bug where inTransaction was not set to false when this occurred