### PR TITLE
fix: runtime exception thrown for PgArray

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -315,6 +315,10 @@ public class WrapperUtils {
 
     for (final Class<?> iface : clazz.getInterfaces()) {
       if (isJdbcInterface(iface)) {
+        if (isJdbcInterfaceCache.containsKey(iface)) {
+          return false;
+        }
+
         isJdbcInterfaceCache.putIfAbsent(clazz, true);
         return true;
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -254,7 +254,7 @@ public class WrapperUtils {
       return toProxy;
     }
 
-    final Class<?> wrapperClass = availableWrappers.get(resultClass);
+    Class<?> wrapperClass = availableWrappers.get(resultClass);
 
     if (wrapperClass != null) {
       return createInstance(
@@ -263,6 +263,20 @@ public class WrapperUtils {
           new Class<?>[] {resultClass, ConnectionPluginManager.class},
           toProxy,
           pluginManager);
+    }
+
+    for (final Class<?> iface : toProxy.getClass().getInterfaces()) {
+      if (isJdbcInterface(iface)) {
+        wrapperClass = availableWrappers.get(iface);
+        if (wrapperClass != null) {
+          return createInstance(
+              wrapperClass,
+              resultClass,
+              new Class<?>[] {iface, ConnectionPluginManager.class},
+              toProxy,
+              pluginManager);
+        }
+      }
     }
 
     if (isJdbcInterface(toProxy.getClass())) {
@@ -315,10 +329,6 @@ public class WrapperUtils {
 
     for (final Class<?> iface : clazz.getInterfaces()) {
       if (isJdbcInterface(iface)) {
-        if (isJdbcInterfaceCache.containsKey(iface)) {
-          return false;
-        }
-
         isJdbcInterfaceCache.putIfAbsent(clazz, true);
         return true;
       }


### PR DESCRIPTION
### Summary

Fix runtime exceptions thrown as reported in #284 

### Description

In the original implementation the following exception gets thrown when retrieving a `PgArray` object 
```
Exception in thread "main" java.lang.RuntimeException: No wrapper class exists for 'org.postgresql.jdbc.PgArray'.
	at software.amazon.jdbc.util.WrapperUtils.wrapWithProxyIfNeeded(WrapperUtils.java:270)
	at software.amazon.jdbc.util.WrapperUtils.executeWithPlugins(WrapperUtils.java:230)
	at software.amazon.jdbc.wrapper.ResultSetWrapper.getObject(ResultSetWrapper.java:708)
	at com.zaxxer.hikari.pool.HikariProxyResultSet.getObject(HikariProxyResultSet.java)
	at software.amazon.PG.getResult(PG.java:84)
	at software.amazon.PG.main(PG.java:73)
```

This is because the class name passed to WrapperUtils is a database-specific implementation of the SQL standard `Array.class`, and does not match the driver's list of standard JDBC classes.

The solution is to check again in `isJdbcInterface` to see if the interface exists in the driver's list of standard JDBC classes again before directly returning.

### Additional Reviewers

@congoamz 
@sergiyvamz 