### PR TITLE
fix: add more connection exception codes for PostgreSQL exception handler

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/exceptions/PgExceptionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/exceptions/PgExceptionHandler.java
@@ -29,6 +29,7 @@ public class PgExceptionHandler implements ExceptionHandler {
       "57P02", // crash shutdown
       "57P03", // cannot connect now
       "58", // system error (backend)
+      "08", // connection error
       "99", // unexpected error
       "F0", // configuration file error (backend)
       "XX" // internal error (backend)


### PR DESCRIPTION
### Summary

Check for exception codes starting with "08" in PGExceptionHandler

### Description

<!--- Details of what you changed -->

### Additional Reviewers
@sergiyvamz 