### PR TITLE
fix: DataSourceConnectionProvider to not remove user/password properties on connect

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -99,7 +99,7 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
               urlProperties));
     }
 
-    PropertyDefinition.removeAll(copy);
+    PropertyDefinition.removeAllExceptCredentials(copy);
     PropertyUtils.applyProperties(this.dataSource, copy);
     return this.dataSource.getConnection();
   }
@@ -124,7 +124,7 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       copy.put(this.databasePropertyName, PropertyDefinition.DATABASE.getString(props));
     }
 
-    PropertyDefinition.removeAll(copy);
+    PropertyDefinition.removeAllExceptCredentials(copy);
     PropertyUtils.applyProperties(this.dataSource, copy);
     return this.dataSource.getConnection();
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
@@ -98,4 +98,19 @@ public class PropertyDefinition {
   public static void removeAll(Properties props) {
     PROPS_BY_NAME.keySet().forEach(props::remove);
   }
+
+  public static void removeAllExceptCredentials(Properties props) {
+    String user = props.getProperty(PropertyDefinition.USER.name, null);
+    String password = props.getProperty(PropertyDefinition.PASSWORD.name, null);
+
+    PROPS_BY_NAME.keySet().forEach(props::remove);
+
+    if (user != null) {
+      props.setProperty(PropertyDefinition.USER.name, user);
+    }
+
+    if (password != null) {
+      props.setProperty(PropertyDefinition.PASSWORD.name, password);
+    }
+  }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/PropertyDefinitionTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/PropertyDefinitionTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class PropertyDefinitionTests {
+
+  @Test
+  public void testRemoveAllExceptCredentials() {
+
+    final String expectedKeyToBeRemoved = PropertyDefinition.DATABASE.name;
+    final String expectedOtherKeyToBeRemoved = PropertyDefinition.PROFILE_NAME.name;
+    final String expectedKeyToRemain = "someKeyToRemain";
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.USER.name, "someUsername");
+    props.setProperty(PropertyDefinition.PASSWORD.name, "somePassword");
+    props.setProperty(expectedKeyToBeRemoved, "someValue");
+    props.setProperty(expectedOtherKeyToBeRemoved, "someOtherValue");
+    props.setProperty(expectedKeyToRemain, "someValue");
+    PropertyDefinition.removeAllExceptCredentials(props);
+
+    assertFalse(props.containsKey(expectedKeyToBeRemoved));
+    assertFalse(props.containsKey(expectedOtherKeyToBeRemoved));
+    assertTrue(props.containsKey(PropertyDefinition.USER.name));
+    assertTrue(props.containsKey(PropertyDefinition.PASSWORD.name));
+    assertTrue(props.containsKey(expectedKeyToRemain));
+    assertEquals(3, props.size());
+  }
+
+  @Test
+  public void testRemoveAllExceptCredentialsGivenNoUserProperty() {
+    final String expectedKeyToBeRemoved = PropertyDefinition.DATABASE.name;
+    final String expectedOtherKeyToBeRemoved = PropertyDefinition.PROFILE_NAME.name;
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PASSWORD.name, "somePassword");
+    props.setProperty(expectedKeyToBeRemoved, "someValue");
+    props.setProperty(expectedOtherKeyToBeRemoved, "someOtherValue");
+
+    PropertyDefinition.removeAllExceptCredentials(props);
+    assertTrue(props.containsKey(PropertyDefinition.PASSWORD.name));
+    assertEquals(1, props.size());
+  }
+
+  @Test
+  public void testRemoveAllExceptCredentialsGivenNoPasswordProperty() {
+    final String expectedKeyToBeRemoved = PropertyDefinition.DATABASE.name;
+    final String expectedOtherKeyToBeRemoved = PropertyDefinition.PROFILE_NAME.name;
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.USER.name, "someUser");
+    props.setProperty(expectedKeyToBeRemoved, "someValue");
+    props.setProperty(expectedOtherKeyToBeRemoved, "someOtherValue");
+
+    PropertyDefinition.removeAllExceptCredentials(props);
+    assertTrue(props.containsKey(PropertyDefinition.USER.name));
+    assertEquals(1, props.size());
+  }
+
+  @Test
+  public void testRemoveAllExceptCredentialsGivenNoUserAndPasswordProperty() {
+    final String expectedKeyToBeRemoved = PropertyDefinition.DATABASE.name;
+    final String expectedOtherKeyToBeRemoved = PropertyDefinition.PROFILE_NAME.name;
+    final Properties props = new Properties();
+    props.setProperty(expectedKeyToBeRemoved, "someValue");
+    props.setProperty(expectedOtherKeyToBeRemoved, "someOtherValue");
+
+    PropertyDefinition.removeAllExceptCredentials(props);
+
+    assertTrue(props.isEmpty());
+  }
+}


### PR DESCRIPTION

### Summary

DataSourceConnectionProvider to not remove user/password properties on connect
This is to address https://github.com/awslabs/aws-advanced-jdbc-wrapper/issues/288

### Description

Changed PropertyDefinition removeAll() static method to removeAllExceptCredentials().
Updated DataSourceConnectionProvider to switch from removeAll() to removevAllExceptCredentials(). 
Added unit tests for PropertyDefinition
Added integration test to AuroraMysqlAwsIamIntegrationTest to test this case. 

### Additional Reviewers
@sergiyv-improving 