### PR TITLE
Integration test suite refactoring

### DIFF
--- a/.github/workflows/mysql_performance.yml
+++ b/.github/workflows/mysql_performance.yml
@@ -1,4 +1,4 @@
-name: Run Performance Tests
+name: Run Aurora Mysql Performance Tests
 
 on:
   workflow_dispatch:
@@ -38,17 +38,14 @@ jobs:
           echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
       - name: 'Run performance tests (OpenJDK)'
         run: |
-          ./gradlew --no-parallel --no-daemon test-performance-aurora-mysql
+          ./gradlew --no-parallel --no-daemon test-aurora-mysql-performance
         env:
-          AURORA_MYSQL_CLUSTER_IDENTIFIER: ${{ secrets.AURORA_MYSQL_CLUSTER_IDENTIFIER }}-perf-${{ github.run_id }}
-          AURORA_MYSQL_USERNAME: ${{ secrets.AURORA_MYSQL_USERNAME }}
-          AURORA_MYSQL_PASSWORD: ${{ secrets.AURORA_MYSQL_PASSWORD }}
-          AURORA_MYSQL_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
+          AURORA_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
-          REPEAT_TIMES: ${{ secrets.REPEAT_TIMES }}
-      - name: 'Archive JUnit Results MySQL Performance'
+      - name: 'Archive Performance Results'
         if: always()
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pg_performance.yml
+++ b/.github/workflows/pg_performance.yml
@@ -1,4 +1,4 @@
-name: Run Performance Tests
+name: Run Aurora Postgres Performance Tests
 
 on:
   workflow_dispatch:
@@ -38,17 +38,14 @@ jobs:
           echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
       - name: 'Run performance tests (OpenJDK)'
         run: |
-          ./gradlew --no-parallel --no-daemon test-performance-aurora-postgres
+          ./gradlew --no-parallel --no-daemon test-aurora-pg-performance
         env:
-          AURORA_POSTGRES_CLUSTER_IDENTIFIER: ${{ secrets.AURORA_POSTGRES_CLUSTER_IDENTIFIER }}-perf-${{ github.run_id }}
-          AURORA_POSTGRES_USERNAME: ${{ secrets.AURORA_POSTGRES_USERNAME }}
-          AURORA_POSTGRES_PASSWORD: ${{ secrets.AURORA_POSTGRES_PASSWORD }}
-          AURORA_POSTGRES_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
+          AURORA_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
-          REPEAT_TIMES: ${{ secrets.REPEAT_TIMES }}
-      - name: 'Archive JUnit Results PostgreSQL Performance'
+      - name: 'Archive Performance Results'
         if: always()
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -11,18 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  aurora-postgres-integration-tests:
-    name: 'Run Aurora Postgres container integration tests'
+  all-integration-tests:
+    name: 'Run integration tests on all environments'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      max-parallel: 1
-      matrix:
-        vm:
-          [
-            openjdk,
-            graalvm
-          ]
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@v2
@@ -51,165 +42,26 @@ jobs:
           echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
           echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
           echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
-      - name: Run integration tests (${{ matrix.vm }})
+      - name: Run integration tests
         run: |
-          ./gradlew --no-parallel --no-daemon test-integration-aurora-postgres
+          ./gradlew --no-parallel --no-daemon test-all-environments
         env:
-          AURORA_POSTGRES_CLUSTER_IDENTIFIER: ${{ secrets.AURORA_POSTGRES_CLUSTER_IDENTIFIER }}-${{ github.run_id }}
-          AURORA_POSTGRES_USERNAME: ${{ secrets.AURORA_POSTGRES_USERNAME }}
-          AURORA_POSTGRES_PASSWORD: ${{ secrets.AURORA_POSTGRES_PASSWORD }}
-          AURORA_POSTGRES_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
+          AURORA_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
-          DB_CONN_SUFFIX: ${{ secrets.DB_CONN_SUFFIX }}
-      - name: 'Get Github Action IP'
-        id: ip
-        uses: haythem/public-ip@v1.2
-      - name: 'Remove IP address'
-        if: always()
-        run: |
-          aws ec2 revoke-security-group-ingress --group-name ${{ secrets.AWS_SG_NAME }} \
-            --protocol all \
-            --port all \
-            --cidr ${{ steps.ip.outputs.ipv4 }}/32 \
-          2>&1 > /dev/null;
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Archive junit results (${{ matrix.vm }})
+      - name: 'Archive junit results'
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: junit-report-postgres-${{ matrix.vm }}
-          path: ./wrapper/build/reports/tests/
+          name: junit-report
+          path: ./wrapper/build/test-results
           retention-days: 5
-
-  aurora-mysql-integration-tests:
-    name: 'Run Aurora MySQL container integration tests'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      max-parallel: 1
-      matrix:
-        vm:
-          [
-            openjdk,
-            graalvm
-          ]
-    steps:
-      - name: 'Clone repository'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 50
-      - name: 'Set up JDK 8'
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: 'Configure AWS credentials'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: 'Set up temp AWS credentials'
-        run: |
-          creds=($(aws sts get-session-token \
-            --duration-seconds 21600 \
-            --query 'Credentials.[AccessKeyId, SecretAccessKey, SessionToken]' \
-            --output text \
-          | xargs));
-          echo "::add-mask::${creds[0]}"
-          echo "::add-mask::${creds[1]}"
-          echo "::add-mask::${creds[2]}"
-          echo "TEMP_AWS_ACCESS_KEY_ID=${creds[0]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SECRET_ACCESS_KEY=${creds[1]}" >> $GITHUB_ENV
-          echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
-      - name: Run integration tests (${{ matrix.vm }})
-        run: |
-          ./gradlew --no-parallel --no-daemon test-integration-aurora-mysql
-        env:
-          AURORA_MYSQL_CLUSTER_IDENTIFIER: ${{ secrets.AURORA_MYSQL_CLUSTER_IDENTIFIER }}-${{ github.run_id }}
-          AURORA_MYSQL_USERNAME: ${{ secrets.AURORA_MYSQL_USERNAME }}
-          AURORA_MYSQL_PASSWORD: ${{ secrets.AURORA_MYSQL_PASSWORD }}
-          AURORA_MYSQL_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_ACCESS_KEY_ID: ${{ env.TEMP_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ env.TEMP_AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ env.TEMP_AWS_SESSION_TOKEN }}
-          TEST_CONTAINER_TYPE: ${{ matrix.vm }}
-          DB_CONN_SUFFIX: ${{ secrets.DB_CONN_SUFFIX }}
-      - name: 'Get Github Action IP'
-        id: ip
-        uses: haythem/public-ip@v1.2
-      - name: 'Remove IP address'
-        if: always()
-        run: |
-          aws ec2 revoke-security-group-ingress --group-name ${{ secrets.AWS_SG_NAME }} \
-            --protocol all \
-            --port all \
-            --cidr ${{ steps.ip.outputs.ipv4 }}/32 \
-          2>&1 > /dev/null;
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Archive junit results (${{ matrix.vm }})
+      - name: 'Archive html summary report'
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: junit-report-mysql-${{ matrix.vm }}
-          path: ./wrapper/build/reports/tests/
+          name: html-summary-report
+          path: ./wrapper/build/report
           retention-days: 5
-
-  clean-up-mysql:
-    name: 'Clean up AWS Aurora MySQL clusters'
-    runs-on: ubuntu-latest
-    if: always()
-    needs: [ aurora-mysql-integration-tests ]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-    steps:
-      - name: 'Delete Instances'
-        run: |
-          for i in {1..5}; \
-            do \
-            aws rds delete-db-instance \
-              --db-instance-identifier ${{ secrets.AURORA_MYSQL_CLUSTER_IDENTIFIER }}-${{ github.run_id }}-$i \
-              --skip-final-snapshot \
-            2>&1 > /dev/null; \
-          done;
-      - name: 'Delete Cluster'
-        run: |
-          aws rds delete-db-cluster \
-            --db-cluster-identifier ${{ secrets.AURORA_MYSQL_CLUSTER_IDENTIFIER }}-${{ github.run_id }} \
-            --skip-final-snapshot \
-          2>&1 > /dev/null;
-
-  clean-up-postgres:
-    name: 'Clean up AWS Aurora Postgres clusters'
-    runs-on: ubuntu-latest
-    if: always()
-    needs: [ aurora-postgres-integration-tests ]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-    steps:
-      - name: 'Delete Instances'
-        run: |
-          for i in {1..5}; \
-            do \
-            aws rds delete-db-instance \
-              --db-instance-identifier ${{ secrets.AURORA_POSTGRES_CLUSTER_IDENTIFIER }}-${{ github.run_id }}-$i \
-              --skip-final-snapshot \
-            2>&1 > /dev/null; \
-          done;
-      - name: 'Delete Cluster'
-        run: |
-          aws rds delete-db-cluster \
-            --db-cluster-identifier ${{ secrets.AURORA_POSTGRES_CLUSTER_IDENTIFIER }}-${{ github.run_id }} \
-            --skip-final-snapshot \
-          2>&1 > /dev/null;

--- a/.github/workflows/run-standard-integration-tests.yml
+++ b/.github/workflows/run-standard-integration-tests.yml
@@ -22,12 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        databases:
-          [
-            postgres,
-            mysql
-          ]
     steps:
       - name: 'Clone repository'
         uses: actions/checkout@v2
@@ -39,11 +33,18 @@ jobs:
           java-version: 8
       - name: 'Run standard integration tests'
         run: |
-          ./gradlew --no-parallel --no-daemon test-integration-standard-${{ matrix.databases }}
+          ./gradlew --no-parallel --no-daemon test-all-docker
       - name: 'Archive junit results'
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: junit-report-standard-${{ matrix.databases }}
-          path: ./wrapper/build/reports/tests/
+          name: junit-report
+          path: ./wrapper/build/test-results
+          retention-days: 5
+      - name: 'Archive html summary report'
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-summary-report
+          path: ./wrapper/build/report
           retention-days: 5

--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -83,10 +83,13 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       copy.setProperty(this.databasePropertyName, PropertyDefinition.DATABASE.getString(props));
     }
 
-    if (!isNullOrEmpty(this.urlPropertyName) && !isNullOrEmpty(props.getProperty(this.urlPropertyName))) {
+    if (!isNullOrEmpty(this.urlPropertyName)) {
       Properties urlProperties = PropertyUtils.copyProperties(copy);
-      // Remove the current url property to replace with a new url built from updated HostSpec and properties
-      urlProperties.remove(this.urlPropertyName);
+
+      if (!isNullOrEmpty(props.getProperty(this.urlPropertyName))) {
+        // Remove the current url property to replace with a new url built from updated HostSpec and properties
+        urlProperties.remove(this.urlPropertyName);
+      }
 
       copy.setProperty(
           this.urlPropertyName,

--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -22,6 +22,8 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
@@ -69,7 +71,18 @@ public class Driver implements java.sql.Driver {
   }
 
   public static boolean isRegistered() {
-    return registeredDriver != null;
+    if (registeredDriver != null) {
+      List<java.sql.Driver> registeredDrivers = Collections.list(DriverManager.getDrivers());
+      for (java.sql.Driver d : registeredDrivers) {
+        if (d == registeredDriver) {
+          return true;
+        }
+      }
+
+      // Driver isn't registered with DriverManager.
+      registeredDriver = null;
+    }
+    return false;
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -19,13 +19,13 @@ package software.amazon.jdbc;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
-import java.util.Set;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.util.PropertyUtils;
 
 /**
- * This class is a basic implementation of {@link ConnectionProvider} interface. It creates and returns a connection
- * provided by a target driver or a data source.
+ * This class is a basic implementation of {@link ConnectionProvider} interface. It creates and
+ * returns a connection provided by a target driver or a data source.
  */
 public class DriverConnectionProvider implements ConnectionProvider {
 
@@ -42,7 +42,7 @@ public class DriverConnectionProvider implements ConnectionProvider {
    *
    * @param protocol The connection protocol (example "jdbc:mysql://")
    * @param hostSpec The HostSpec containing the host-port information for the host to connect to
-   * @param props    The Properties to use for the connection
+   * @param props The Properties to use for the connection
    * @return {@link Connection} resulting from the given connection information
    * @throws SQLException if an error occurs
    */
@@ -52,19 +52,22 @@ public class DriverConnectionProvider implements ConnectionProvider {
       final @NonNull HostSpec hostSpec,
       final @NonNull Properties props)
       throws SQLException {
-    final String databaseName = PropertyDefinition.DATABASE.getString(props) != null
-        ? PropertyDefinition.DATABASE.getString(props)
-        : "";
+    final String databaseName =
+        PropertyDefinition.DATABASE.getString(props) != null
+            ? PropertyDefinition.DATABASE.getString(props)
+            : "";
     final StringBuilder urlBuilder = new StringBuilder();
     urlBuilder.append(protocol).append(hostSpec.getUrl()).append(databaseName);
 
     // In the case where we are connecting to MySQL using MariaDB driver,
     // we need to append "?permitMysqlScheme" to the connection URL
-    if (protocol.startsWith("jdbc:mysql:") && props.stringPropertyNames().contains("permitMysqlScheme")) {
+    if (protocol.startsWith("jdbc:mysql:")
+        && props.stringPropertyNames().contains("permitMysqlScheme")) {
       urlBuilder.append("?permitMysqlScheme");
     }
 
     LOGGER.finest(() -> "Connecting to " + urlBuilder);
+    LOGGER.finest(() -> PropertyUtils.logProperties(props, "Connecting with properties: \n"));
 
     return this.driver.connect(urlBuilder.toString(), props);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/IamAuthConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/IamAuthConnectionPlugin.java
@@ -172,7 +172,7 @@ public class IamAuthConnectionPlugin extends AbstractConnectionPlugin {
     return String.format("%s:%s:%d:%s", region, hostname, port, user);
   }
 
-  static void clearCache() {
+  public static void clearCache() {
     tokenCache.clear();
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/util/PropertyUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/PropertyUtils.java
@@ -16,17 +16,15 @@
 
 package software.amazon.jdbc.util;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import software.amazon.jdbc.PropertyDefinition;
 
 public class PropertyUtils {
   private static final Logger LOGGER = Logger.getLogger(PropertyUtils.class.getName());
@@ -77,30 +75,39 @@ public class PropertyUtils {
 
     if (writeMethod == null) {
       LOGGER.finest(
-          () -> Messages.get(
-              "PropertyUtils.setMethodDoesNotExistOnTarget",
-              new Object[] {propName, target.getClass()}));
+          () ->
+              Messages.get(
+                  "PropertyUtils.setMethodDoesNotExistOnTarget",
+                  new Object[] {propName, target.getClass()}));
       return;
     }
 
     try {
       Class<?> paramClass = writeMethod.getParameterTypes()[0];
-      if (paramClass == int.class) {
+      if (paramClass == String.class) {
+        writeMethod.invoke(target, propValue.toString());
+      } else if (paramClass == int.class) {
         writeMethod.invoke(target, Integer.parseInt(propValue.toString()));
       } else if (paramClass == long.class) {
         writeMethod.invoke(target, Long.parseLong(propValue.toString()));
       } else if (paramClass == boolean.class || paramClass == Boolean.class) {
         writeMethod.invoke(target, Boolean.parseBoolean(propValue.toString()));
-      } else if (paramClass == String.class) {
-        writeMethod.invoke(target, propValue.toString());
       } else {
         writeMethod.invoke(target, propValue);
       }
+    } catch (InvocationTargetException ex) {
+      LOGGER.warning(
+          () ->
+              Messages.get(
+                  "PropertyUtils.failedToSetPropertyWithReason",
+                  new Object[] {propName, target.getClass(), ex.getCause().getMessage()}));
+      throw new RuntimeException(ex.getCause());
     } catch (Exception e) {
       LOGGER.warning(
-          () -> Messages.get(
-              "PropertyUtils.failedToSetProperty",
-              new Object[] {propName, target.getClass()}));
+          () ->
+              Messages.get(
+                  "PropertyUtils.failedToSetProperty", new Object[] {propName, target.getClass()}));
+      throw new RuntimeException(e);
     }
   }
 
@@ -115,5 +122,22 @@ public class PropertyUtils {
       copy.setProperty(entry.getKey().toString(), entry.getValue().toString());
     }
     return copy;
+  }
+
+  public static String logProperties(final Properties props, final String caption) {
+    StringBuilder sb = new StringBuilder();
+    for (Object key : props.keySet()) {
+      if (sb.length() > 0) {
+        sb.append("\n");
+      }
+      sb.append("[").append(key.toString()).append("] ").append(props.get(key).toString());
+    }
+    if (sb.length() == 0) {
+      sb.append("<empty>");
+    }
+    if (caption != null) {
+      sb.insert(0, caption);
+    }
+    return sb.toString();
   }
 }

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -164,8 +164,9 @@ PluginServiceImpl.hostListException=Exception while getting a host list.
 PluginServiceImpl.hostAliasNotFound=Can't find any host by the following aliases: {0}
 
 # Property Utils
-PropertyUtils.setMethodDoesNotExistOnTarget=Set method for property ''{0}'' does not exist on target ''{0}''.
-PropertyUtils.failedToSetProperty=Failed to set property ''{0}'' on target ''{0}''.
+PropertyUtils.setMethodDoesNotExistOnTarget=Set method for property ''{0}'' does not exist on target ''{1}''.
+PropertyUtils.failedToSetProperty=Failed to set property ''{0}'' on target ''{1}''.
+PropertyUtils.failedToSetPropertyWithReason=Failed to set property ''{0}'' on target ''{1}''. {2}
 
 # Read Write Splitting Plugin
 ReadWriteSplittingPlugin.errorSwitchingToReader=An error occurred while trying to switch to a reader connection.

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -51,13 +51,19 @@ dependencies {
     testImplementation("org.testcontainers:toxiproxy:1.17.+")
     testImplementation("org.apache.poi:poi-ooxml:5.2.2")
     testImplementation("org.slf4j:slf4j-simple:1.7.+")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
 }
 
 tasks.withType<Test> {
+
+    testClassesDirs += fileTree("./libs") { include("*.jar") } + project.files("./test")
+    classpath += fileTree("./libs") { include("*.jar") } + project.files("./test")
+    outputs.upToDateWhen { false }
+
     useJUnitPlatform()
 
     testLogging {
-        events(FAILED, SKIPPED)
+        events(PASSED, FAILED, SKIPPED)
         showStandardStreams = true
         exceptionFormat = FULL
         showExceptions = true
@@ -66,50 +72,13 @@ tasks.withType<Test> {
     }
 
     systemProperty("java.util.logging.config.file", "./test/resources/logging-test.properties")
+
+    reports.junitXml.required.set(true)
+    reports.junitXml.outputLocation.set(file("${project.buildDir}/test-results/container-" + System.currentTimeMillis()))
+
+    reports.html.required.set(false)
 }
 
-// Integration tests are run in a specific order.
-// To add more tests, see integration.container.aurora.postgres.AuroraPostgresTestSuite.java
-tasks.register<Test>("in-container-aurora-postgres") {
-    filter.includeTestsMatching("integration.container.aurora.postgres.AuroraPostgresTestSuite")
-}
-
-tasks.register<Test>("in-container-aurora-postgres-performance") {
-    filter.includeTestsMatching("integration.container.aurora.postgres.AuroraPostgresPerformanceTest")
-    filter.includeTestsMatching("integration.container.aurora.postgres.AuroraAdvancedPerformanceTest")
-    filter.includeTestsMatching("integration.container.aurora.postgres.AuroraPostgresReadWriteSplittingPerformanceTest")
-
-}
-
-// Integration tests are run in a specific order.
-// To add more tests, see integration.container.standard.postgres.StandardPostgresTestSuite.java
-tasks.register<Test>("in-container-standard-postgres") {
-    filter.includeTestsMatching("integration.container.standard.postgres.StandardPostgresTestSuite")
-}
-
-// Integration tests are run in a specific order.
-// To add more tests, see integration.container.aurora.mysql.mysqldriver.AuroraMysqlTestSuite.java
-// and integration.container.aurora.mysql.mariadbdriver.MariadbAuroraMysqlTestSuite.java
-tasks.register<Test>("in-container-aurora-mysql") {
-    filter.includeTestsMatching("integration.container.aurora.mysql.mysqldriver.MysqlAuroraMysqlTestSuite")
-    filter.includeTestsMatching("integration.container.aurora.mysql.mariadbdriver.MariadbAuroraMysqlTestSuite")
-}
-
-// Integration tests are run in a specific order.
-// To add more tests, see integration.container.standard.mysql.mysqldriver.StandardMysqlTestSuite.java
-// and integration.container.standard.mysql.mariadbdriver.MariadbStandardMysqlTestSuite.java
-tasks.register<Test>("in-container-standard-mysql") {
-    filter.includeTestsMatching("integration.container.standard.mysql.mysqldriver.MysqlStandardMysqlTestSuite")
-    filter.includeTestsMatching("integration.container.standard.mysql.mariadbdriver.MariadbStandardMysqlTestSuite")
-}
-
-tasks.register<Test>("in-container-standard-mariadb") {
-    filter.includeTestsMatching("integration.container.standard.mariadb.StandardMariadbTestSuite")
-}
-
-tasks.withType<Test> {
-    testClassesDirs += fileTree("./libs") { include("*.jar") } + project.files("./test")
-    classpath += fileTree("./libs") { include("*.jar") } + project.files("./test")
-    outputs.upToDateWhen { false }
-    useJUnitPlatform()
+tasks.register<Test>("in-container") {
+    filter.includeTestsMatching("integration.refactored.container.tests.*")
 }

--- a/wrapper/src/test/java/integration/refactored/DatabaseEngine.java
+++ b/wrapper/src/test/java/integration/refactored/DatabaseEngine.java
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
-
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+public enum DatabaseEngine {
+  MYSQL,
+  PG,
+  MARIADB
+}

--- a/wrapper/src/test/java/integration/refactored/DatabaseEngineDeployment.java
+++ b/wrapper/src/test/java/integration/refactored/DatabaseEngineDeployment.java
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
-
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+public enum DatabaseEngineDeployment {
+  DOCKER,
+  RDS,
+  AURORA
+}

--- a/wrapper/src/test/java/integration/refactored/DatabaseInstances.java
+++ b/wrapper/src/test/java/integration/refactored/DatabaseInstances.java
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
-
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+public enum DatabaseInstances {
+  SINGLE_INSTANCE,
+  MULTI_INSTANCE
+}

--- a/wrapper/src/test/java/integration/refactored/DriverHelper.java
+++ b/wrapper/src/test/java/integration/refactored/DriverHelper.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored;
+
+import com.mysql.cj.conf.PropertyKey;
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestEnvironment;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.postgresql.PGProperty;
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+
+public class DriverHelper {
+
+  private static final Logger LOGGER = Logger.getLogger(DriverHelper.class.getName());
+
+  public static String getDriverProtocol() {
+    return getDriverProtocol(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+        TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static String getDriverProtocol(DatabaseEngine databaseEngine) {
+    switch (databaseEngine) {
+      case MYSQL:
+        return "jdbc:mysql://";
+      case PG:
+        return "jdbc:postgresql://";
+      case MARIADB:
+        return "jdbc:mariadb://";
+      default:
+        throw new NotImplementedException(databaseEngine.toString());
+    }
+  }
+
+  public static String getDriverProtocol(DatabaseEngine databaseEngine, TestDriver testDriver) {
+    switch (testDriver) {
+      case MYSQL:
+        return "jdbc:mysql://";
+      case PG:
+        return "jdbc:postgresql://";
+      case MARIADB:
+        if (databaseEngine == DatabaseEngine.MARIADB) {
+          return "jdbc:mariadb://";
+        } else if (databaseEngine == DatabaseEngine.MYSQL) {
+          return "jdbc:mysql://";
+        }
+        throw new UnsupportedOperationException(testDriver.toString());
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static String getWrapperDriverProtocol() {
+    return getWrapperDriverProtocol(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+        TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static String getWrapperDriverProtocol(TestDriver testDriver) {
+    return getWrapperDriverProtocol(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver);
+  }
+
+  public static String getWrapperDriverProtocol(
+      DatabaseEngine databaseEngine, TestDriver testDriver) {
+    switch (testDriver) {
+      case MYSQL:
+        return "jdbc:aws-wrapper:mysql://";
+      case PG:
+        return "jdbc:aws-wrapper:postgresql://";
+      case MARIADB:
+        if (databaseEngine == DatabaseEngine.MARIADB) {
+          return "jdbc:aws-wrapper:mariadb://";
+        } else if (databaseEngine == DatabaseEngine.MYSQL) {
+          return "jdbc:aws-wrapper:mysql://";
+        }
+        throw new UnsupportedOperationException(testDriver.toString());
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static String getDriverClassname(DatabaseEngine databaseEngine) {
+    switch (databaseEngine) {
+      case MYSQL:
+        return getDriverClassname(TestDriver.MYSQL);
+      case PG:
+        return getDriverClassname(TestDriver.PG);
+      case MARIADB:
+        return getDriverClassname(TestDriver.MARIADB);
+      default:
+        throw new NotImplementedException(databaseEngine.toString());
+    }
+  }
+
+  public static String getDriverClassname() {
+    return getDriverClassname(TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static String getDriverClassname(TestDriver testDriver) {
+    switch (testDriver) {
+      case MYSQL:
+        return "com.mysql.cj.jdbc.Driver";
+      case PG:
+        return "org.postgresql.Driver";
+      case MARIADB:
+        return "org.mariadb.jdbc.Driver";
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static String getDataSourceClassname() {
+    return getDataSourceClassname(TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static String getDataSourceClassname(TestDriver testDriver) {
+    switch (testDriver) {
+      case MYSQL:
+        return "com.mysql.cj.jdbc.MysqlDataSource";
+      case PG:
+        return "org.postgresql.ds.PGSimpleDataSource";
+      case MARIADB:
+        return "org.mariadb.jdbc.MariaDbDataSource";
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static Class<?> getConnectionClass() {
+    return getConnectionClass(TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static Class<?> getConnectionClass(TestDriver testDriver) {
+    switch (testDriver) {
+      case MYSQL:
+        return com.mysql.cj.jdbc.ConnectionImpl.class;
+      case PG:
+        return org.postgresql.PGConnection.class;
+      case MARIADB:
+        return org.mariadb.jdbc.Connection.class;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static String getDriverRequiredParameters() {
+    return getDriverRequiredParameters(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+        TestEnvironment.getCurrent().getCurrentDriver());
+  }
+
+  public static String getDriverRequiredParameters(TestDriver testDriver) {
+    return getDriverRequiredParameters(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver);
+  }
+
+  public static String getDriverRequiredParameters(
+      DatabaseEngine databaseEngine, TestDriver testDriver) {
+    if (testDriver == TestDriver.MARIADB && databaseEngine == DatabaseEngine.MYSQL) {
+      return "?permitMysqlScheme";
+    }
+    return "";
+  }
+
+  public static String getHostnameSql() {
+    return getHostnameSql(TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine());
+  }
+
+  public static String getHostnameSql(DatabaseEngine databaseEngine) {
+    switch (databaseEngine) {
+      case MYSQL:
+        return "SELECT @@hostname";
+      case PG:
+        return "SELECT inet_server_addr()";
+      case MARIADB:
+        return "SELECT @@hostname"; // TODO: verify
+      default:
+        throw new NotImplementedException(databaseEngine.toString());
+    }
+  }
+
+  public static void setConnectTimeout(Properties props, long timeout, TimeUnit timeUnit) {
+    setConnectTimeout(TestEnvironment.getCurrent().getCurrentDriver(), props, timeout, timeUnit);
+  }
+
+  public static void setConnectTimeout(
+      TestDriver testDriver, Properties props, long timeout, TimeUnit timeUnit) {
+    switch (testDriver) {
+      case MYSQL:
+        props.setProperty(
+            PropertyKey.connectTimeout.getKeyName(), String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      case PG:
+        props.setProperty(
+            PGProperty.CONNECT_TIMEOUT.getName(), String.valueOf(timeUnit.toSeconds(timeout)));
+        break;
+      case MARIADB:
+        props.setProperty("connectTimeout", String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static void setSocketTimeout(Properties props, long timeout, TimeUnit timeUnit) {
+    setSocketTimeout(TestEnvironment.getCurrent().getCurrentDriver(), props, timeout, timeUnit);
+  }
+
+  public static void setSocketTimeout(
+      TestDriver testDriver, Properties props, long timeout, TimeUnit timeUnit) {
+    switch (testDriver) {
+      case MYSQL:
+        props.setProperty(
+            PropertyKey.socketTimeout.getKeyName(), String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      case PG:
+        props.setProperty(
+            PGProperty.SOCKET_TIMEOUT.getName(), String.valueOf(timeUnit.toSeconds(timeout)));
+        break;
+      case MARIADB:
+        props.setProperty("socketTimeout", String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static void setTcpKeepAlive(Properties props, boolean enabled) {
+    setTcpKeepAlive(TestEnvironment.getCurrent().getCurrentDriver(), props, enabled);
+  }
+
+  public static void setTcpKeepAlive(TestDriver testDriver, Properties props, boolean enabled) {
+    switch (testDriver) {
+      case MYSQL:
+        props.setProperty(PropertyKey.tcpKeepAlive.getKeyName(), String.valueOf(enabled));
+        break;
+      case PG:
+        props.setProperty(PGProperty.TCP_KEEP_ALIVE.getName(), String.valueOf(enabled));
+        break;
+      case MARIADB:
+        props.setProperty("tcpKeepAlive", String.valueOf(enabled));
+        break;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static void setMonitoringConnectTimeout(
+      Properties props, long timeout, TimeUnit timeUnit) {
+    setMonitoringConnectTimeout(
+        TestEnvironment.getCurrent().getCurrentDriver(), props, timeout, timeUnit);
+  }
+
+  public static void setMonitoringConnectTimeout(
+      TestDriver testDriver, Properties props, long timeout, TimeUnit timeUnit) {
+    switch (testDriver) {
+      case MYSQL:
+        props.setProperty(
+            "monitoring-" + PropertyKey.connectTimeout.getKeyName(),
+            String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      case PG:
+        props.setProperty(
+            "monitoring-" + PGProperty.CONNECT_TIMEOUT.getName(),
+            String.valueOf(timeUnit.toSeconds(timeout)));
+        break;
+      case MARIADB:
+        props.setProperty("monitoring-connectTimeout", String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static void setMonitoringSocketTimeout(Properties props, long timeout, TimeUnit timeUnit) {
+    setMonitoringSocketTimeout(
+        TestEnvironment.getCurrent().getCurrentDriver(), props, timeout, timeUnit);
+  }
+
+  public static void setMonitoringSocketTimeout(
+      TestDriver testDriver, Properties props, long timeout, TimeUnit timeUnit) {
+    switch (testDriver) {
+      case MYSQL:
+        props.setProperty(
+            "monitoring-" + PropertyKey.socketTimeout.getKeyName(),
+            String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      case PG:
+        props.setProperty(
+            "monitoring-" + PGProperty.SOCKET_TIMEOUT.getName(),
+            String.valueOf(timeUnit.toSeconds(timeout)));
+        break;
+      case MARIADB:
+        props.setProperty("monitoring-socketTimeout", String.valueOf(timeUnit.toMillis(timeout)));
+        break;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+  }
+
+  public static void unregisterAllDrivers() throws SQLException {
+    if (software.amazon.jdbc.Driver.isRegistered()) {
+      software.amazon.jdbc.Driver.deregister();
+    }
+
+    List<Driver> registeredDrivers = Collections.list(DriverManager.getDrivers());
+    for (Driver d : registeredDrivers) {
+      try {
+        DriverManager.deregisterDriver(d);
+      } catch (SQLException ex) {
+        LOGGER.log(Level.FINEST, "Can't deregister driver " + d.getClass().getName(), ex);
+        throw ex;
+      }
+    }
+  }
+
+  public static void registerDriver(TestDriver testDriver) throws SQLException {
+    try {
+      Driver d = (Driver) Class.forName(getDriverClassname(testDriver)).newInstance();
+      DriverManager.registerDriver(d);
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException("Can't register driver.", e);
+    }
+
+    if (!software.amazon.jdbc.Driver.isRegistered()) {
+      software.amazon.jdbc.Driver.register();
+    }
+
+    LOGGER.finest(
+        () -> {
+          List<Driver> registeredDrivers = Collections.list(DriverManager.getDrivers());
+          StringBuilder sb = new StringBuilder("Available drivers: ");
+          boolean isFirst = true;
+          for (Driver d : registeredDrivers) {
+            if (!isFirst) {
+              sb.append(", ");
+            }
+            sb.append(d.getClass().getName());
+            isFirst = false;
+          }
+          return sb.toString();
+        });
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/GenericTypedParameterResolver.java
+++ b/wrapper/src/test/java/integration/refactored/GenericTypedParameterResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class GenericTypedParameterResolver<T> implements ParameterResolver {
+  T data;
+
+  public GenericTypedParameterResolver(T data) {
+    this.data = data;
+  }
+
+  @Override
+  public boolean supportsParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return parameterContext.getParameter().getType().isInstance(data);
+  }
+
+  @Override
+  public Object resolveParameter(
+      ParameterContext parameterContext, ExtensionContext extensionContext)
+      throws ParameterResolutionException {
+    return data;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/TargetJvm.java
+++ b/wrapper/src/test/java/integration/refactored/TargetJvm.java
@@ -14,22 +14,9 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
-
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+public enum TargetJvm {
+  OPENJDK,
+  GRAALVM
+}

--- a/wrapper/src/test/java/integration/refactored/TestDatabaseInfo.java
+++ b/wrapper/src/test/java/integration/refactored/TestDatabaseInfo.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored;
+
+import java.util.ArrayList;
+
+public class TestDatabaseInfo {
+
+  private String username;
+  private String password;
+  private String defaultDbName;
+
+  private String clusterEndpoint; // "ABC.cluster-XYZ.us-west-2.rds.amazonaws.com"
+  private int clusterEndpointPort;
+
+  private String clusterReadOnlyEndpoint; // "ABC.cluster-ro-XYZ.us-west-2.rds.amazonaws.com"
+  private int clusterReadOnlyEndpointPort;
+
+  private String instanceEndpointPrefix; // "XYZ.us-west-2.rds.amazonaws.com"
+  private int instanceEndpointPrefixPort;
+
+  private final ArrayList<TestInstanceInfo> instances = new ArrayList<>();
+
+  public TestDatabaseInfo() {}
+
+  public ArrayList<TestInstanceInfo> getInstances() {
+    return this.instances;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public void setDefaultDbName(String defaultDbName) {
+    this.defaultDbName = defaultDbName;
+  }
+
+  public String getUsername() {
+    return this.username;
+  }
+
+  public String getPassword() {
+    return this.password;
+  }
+
+  public String getDefaultDbName() {
+    return this.defaultDbName;
+  }
+
+  public String getClusterEndpoint() {
+    return this.clusterEndpoint;
+  }
+
+  public int getClusterEndpointPort() {
+    return this.clusterEndpointPort;
+  }
+
+  public String getClusterReadOnlyEndpoint() {
+    return this.clusterReadOnlyEndpoint;
+  }
+
+  public int getClusterReadOnlyEndpointPort() {
+    return this.clusterReadOnlyEndpointPort;
+  }
+
+  public void setClusterEndpoint(String clusterEndpoint, int clusterEndpointPort) {
+    this.clusterEndpoint = clusterEndpoint;
+    this.clusterEndpointPort = clusterEndpointPort;
+  }
+
+  public void setClusterReadOnlyEndpoint(
+      String clusterReadOnlyEndpoint, int clusterReadOnlyEndpointPort) {
+    this.clusterReadOnlyEndpoint = clusterReadOnlyEndpoint;
+    this.clusterReadOnlyEndpointPort = clusterReadOnlyEndpointPort;
+  }
+
+  public void setInstanceEndpointPrefix(
+      String instanceEndpointPrefix, int instanceEndpointPrefixPort) {
+    this.instanceEndpointPrefix = instanceEndpointPrefix;
+    this.instanceEndpointPrefixPort = instanceEndpointPrefixPort;
+  }
+
+  public String getInstanceEndpointPrefix() {
+    return this.instanceEndpointPrefix;
+  }
+
+  public int getInstanceEndpointPrefixPort() {
+    return this.instanceEndpointPrefixPort;
+  }
+
+  public TestInstanceInfo getInstance(String instanceName) {
+    for (TestInstanceInfo instance : this.instances) {
+      if (instanceName != null && instanceName.equals(instance.getInstanceName())) {
+        return instance;
+      }
+    }
+    throw new RuntimeException("Instance " + instanceName + " not found.");
+  }
+
+  public void moveInstanceFirst(String instanceName) {
+    for (int i = 0; i < this.instances.size(); i++) {
+      TestInstanceInfo currentInstance = this.instances.get(i);
+      if (instanceName != null && instanceName.equals(currentInstance.getInstanceName())) {
+        // move this instance to position 0
+        this.instances.remove(i);
+        this.instances.add(0, currentInstance);
+        return;
+      }
+    }
+    throw new RuntimeException("Instance " + instanceName + " not found.");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/TestDatabaseInfo.java
+++ b/wrapper/src/test/java/integration/refactored/TestDatabaseInfo.java
@@ -30,8 +30,8 @@ public class TestDatabaseInfo {
   private String clusterReadOnlyEndpoint; // "ABC.cluster-ro-XYZ.us-west-2.rds.amazonaws.com"
   private int clusterReadOnlyEndpointPort;
 
-  private String instanceEndpointPrefix; // "XYZ.us-west-2.rds.amazonaws.com"
-  private int instanceEndpointPrefixPort;
+  private String instanceEndpointSuffix; // "XYZ.us-west-2.rds.amazonaws.com"
+  private int instanceEndpointSuffixPort;
 
   private final ArrayList<TestInstanceInfo> instances = new ArrayList<>();
 
@@ -94,16 +94,16 @@ public class TestDatabaseInfo {
 
   public void setInstanceEndpointPrefix(
       String instanceEndpointPrefix, int instanceEndpointPrefixPort) {
-    this.instanceEndpointPrefix = instanceEndpointPrefix;
-    this.instanceEndpointPrefixPort = instanceEndpointPrefixPort;
+    this.instanceEndpointSuffix = instanceEndpointPrefix;
+    this.instanceEndpointSuffixPort = instanceEndpointPrefixPort;
   }
 
-  public String getInstanceEndpointPrefix() {
-    return this.instanceEndpointPrefix;
+  public String getInstanceEndpointSuffix() {
+    return this.instanceEndpointSuffix;
   }
 
-  public int getInstanceEndpointPrefixPort() {
-    return this.instanceEndpointPrefixPort;
+  public int getInstanceEndpointSuffixPort() {
+    return this.instanceEndpointSuffixPort;
   }
 
   public TestInstanceInfo getInstance(String instanceName) {

--- a/wrapper/src/test/java/integration/refactored/TestEnvironmentFeatures.java
+++ b/wrapper/src/test/java/integration/refactored/TestEnvironmentFeatures.java
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
-
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+public enum TestEnvironmentFeatures {
+  IAM,
+  SECRETS_MANAGER,
+  FAILOVER_SUPPORTED,
+  NETWORK_OUTAGES_ENABLED,
+  AWS_CREDENTIALS_ENABLED,
+  PERFORMANCE,
+  HIKARI,
+  SKIP_MYSQL_DRIVER_TESTS,
+  SKIP_PG_DRIVER_TESTS,
+  SKIP_MARIADB_DRIVER_TESTS
+}

--- a/wrapper/src/test/java/integration/refactored/TestEnvironmentInfo.java
+++ b/wrapper/src/test/java/integration/refactored/TestEnvironmentInfo.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored;
+
+public class TestEnvironmentInfo {
+
+  private TestEnvironmentRequest request;
+
+  private String awsAccessKeyId;
+  private String awsSecretAccessKey;
+  private String awsSessionToken;
+
+  private String auroraRegion;
+  private String auroraClusterName;
+  private String iamUsername;
+
+  private TestDatabaseInfo databaseInfo;
+  private TestProxyDatabaseInfo proxyDatabaseInfo;
+
+  public TestDatabaseInfo getDatabaseInfo() {
+    return this.databaseInfo;
+  }
+
+  public TestProxyDatabaseInfo getProxyDatabaseInfo() {
+    return this.proxyDatabaseInfo;
+  }
+
+  public TestEnvironmentRequest getRequest() {
+    return this.request;
+  }
+
+  public String getAwsAccessKeyId() {
+    return this.awsAccessKeyId;
+  }
+
+  public String getAwsSecretAccessKey() {
+    return this.awsSecretAccessKey;
+  }
+
+  public String getAwsSessionToken() {
+    return this.awsSessionToken;
+  }
+
+  public String getAuroraRegion() {
+    return this.auroraRegion;
+  }
+
+  public String getAuroraClusterName() {
+    return this.auroraClusterName;
+  }
+
+  public String getIamUsername() {
+    return this.iamUsername;
+  }
+
+  public void setRequest(TestEnvironmentRequest request) {
+    this.request = request;
+  }
+
+  public void setAuroraRegion(String auroraRegion) {
+    this.auroraRegion = auroraRegion;
+  }
+
+  public void setAuroraClusterName(String auroraClusterName) {
+    this.auroraClusterName = auroraClusterName;
+  }
+
+  public void setDatabaseInfo(TestDatabaseInfo databaseInfo) {
+    this.databaseInfo = databaseInfo;
+  }
+
+  public void setProxyDatabaseInfo(TestProxyDatabaseInfo proxyDatabaseInfo) {
+    this.proxyDatabaseInfo = proxyDatabaseInfo;
+  }
+
+  public void setAwsAccessKeyId(String awsAccessKeyId) {
+    this.awsAccessKeyId = awsAccessKeyId;
+  }
+
+  public void setAwsSecretAccessKey(String awsSecretAccessKey) {
+    this.awsSecretAccessKey = awsSecretAccessKey;
+  }
+
+  public void setAwsSessionToken(String awsSessionToken) {
+    this.awsSessionToken = awsSessionToken;
+  }
+
+  public void setIamUsername(String iamUsername) {
+    this.iamUsername = iamUsername;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/TestEnvironmentRequest.java
+++ b/wrapper/src/test/java/integration/refactored/TestEnvironmentRequest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TestEnvironmentRequest {
+
+  @JsonProperty("engine")
+  private DatabaseEngine engine;
+
+  @JsonProperty("instances")
+  private DatabaseInstances instances;
+
+  @JsonProperty("deployment")
+  private DatabaseEngineDeployment deployment;
+
+  @JsonProperty("targetJvm")
+  private TargetJvm targetJvm;
+
+  @JsonProperty("features")
+  private final Set<TestEnvironmentFeatures> features = new HashSet<>();
+
+  @JsonProperty("numOfInstances")
+  private int numOfInstances = 1;
+
+  // This constructor should NOT be used in the code. It's required for serialization.
+  public TestEnvironmentRequest() {}
+
+  public TestEnvironmentRequest(
+      DatabaseEngine engine,
+      DatabaseInstances instances,
+      int numOfInstances,
+      DatabaseEngineDeployment deployment,
+      TargetJvm targetJvm,
+      TestEnvironmentFeatures... features) {
+
+    this.engine = engine;
+    this.instances = instances;
+    this.deployment = deployment;
+    this.targetJvm = targetJvm;
+    this.numOfInstances = numOfInstances;
+
+    if (features != null) {
+      for (TestEnvironmentFeatures feature : features) {
+        if (feature != null) {
+          this.features.add(feature);
+        }
+      }
+    }
+  }
+
+  @JsonIgnore
+  public DatabaseEngine getDatabaseEngine() {
+    return this.engine;
+  }
+
+  @JsonIgnore
+  public DatabaseInstances getDatabaseInstances() {
+    return this.instances;
+  }
+
+  @JsonIgnore
+  public DatabaseEngineDeployment getDatabaseEngineDeployment() {
+    return this.deployment;
+  }
+
+  @JsonIgnore
+  public TargetJvm getTargetJvm() {
+    return this.targetJvm;
+  }
+
+  @JsonIgnore
+  public Set<TestEnvironmentFeatures> getFeatures() {
+    return this.features;
+  }
+
+  @JsonIgnore
+  public int getNumOfInstances() {
+    return this.numOfInstances;
+  }
+
+  @JsonIgnore
+  public String getDisplayName() {
+    return String.format(
+        "Test environment [%s, %s, %s, %s, %d, %s]",
+        deployment, engine, targetJvm, instances, numOfInstances, features);
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/TestInstanceInfo.java
+++ b/wrapper/src/test/java/integration/refactored/TestInstanceInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored;
+
+public class TestInstanceInfo {
+
+  private String instanceName; // "instance-1"
+  private String endpoint; // "instance-1.ABC.cluster-XYZ.us-west-2.rds.amazonaws.com"
+  private int endpointPort;
+
+  // This constructor should NOT be used in the code. It's required for serialization.
+  public TestInstanceInfo() {}
+
+  public TestInstanceInfo(String instanceName, String endpoint, int endpointPort) {
+    this.instanceName = instanceName;
+    this.endpoint = endpoint;
+    this.endpointPort = endpointPort;
+  }
+
+  public String getInstanceName() {
+    return this.instanceName;
+  }
+
+  public String getEndpoint() {
+    return this.endpoint;
+  }
+
+  public int getEndpointPort() {
+    return this.endpointPort;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/TestProxyDatabaseInfo.java
+++ b/wrapper/src/test/java/integration/refactored/TestProxyDatabaseInfo.java
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+public class TestProxyDatabaseInfo extends TestDatabaseInfo {
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+  private int controlPort;
+
+  public void setControlPort(int controlPort) {
+    this.controlPort = controlPort;
+  }
+
+  public int getControlPort() {
+    return this.controlPort;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container;
+
+import integration.refactored.DriverHelper;
+import java.util.Properties;
+import software.amazon.jdbc.PropertyDefinition;
+
+public class ConnectionStringHelper {
+
+  public static String getUrl() {
+    return getUrl(
+        TestEnvironment.getCurrent().getCurrentDriver(),
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint(),
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpointPort(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+  }
+
+  public static String getUrl(String host, int port, String databaseName) {
+    return getUrl(TestEnvironment.getCurrent().getCurrentDriver(), host, port, databaseName);
+  }
+
+  public static String getUrl(TestDriver testDriver, String host, int port, String databaseName) {
+    return DriverHelper.getDriverProtocol(
+            TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver)
+        + host
+        + ":"
+        + port
+        + "/"
+        + databaseName
+        + DriverHelper.getDriverRequiredParameters(
+            TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver);
+  }
+
+  public static String getWrapperUrl() {
+    return getWrapperUrl(
+        TestEnvironment.getCurrent().getCurrentDriver(),
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint(),
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpointPort(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+  }
+
+  public static String getWrapperUrl(String host, int port, String databaseName) {
+    return getWrapperUrl(TestEnvironment.getCurrent().getCurrentDriver(), host, port, databaseName);
+  }
+
+  public static String getWrapperUrl(
+      TestDriver testDriver, String host, int port, String databaseName) {
+    return DriverHelper.getWrapperDriverProtocol(
+            TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver)
+        + host
+        + ":"
+        + port
+        + "/"
+        + databaseName
+        + DriverHelper.getDriverRequiredParameters(
+            TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver);
+  }
+
+  public static String getProxyWrapperUrl() {
+    return getWrapperUrl(
+        TestEnvironment.getCurrent().getCurrentDriver(),
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getProxyDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint(),
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getProxyDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpointPort(),
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getDefaultDbName());
+  }
+
+  public static Properties getDefaultProperties() {
+    final Properties props = new Properties();
+    props.setProperty(
+        PropertyDefinition.USER.name,
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    props.setProperty(
+        PropertyDefinition.PASSWORD.name,
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    DriverHelper.setTcpKeepAlive(TestEnvironment.getCurrent().getCurrentDriver(), props, false);
+    return props;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/MakeSureFirstInstanceWriterExtension.java
+++ b/wrapper/src/test/java/integration/refactored/container/MakeSureFirstInstanceWriterExtension.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.util.AuroraTestUtility;
+import java.util.List;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class MakeSureFirstInstanceWriterExtension implements BeforeAllCallback {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(MakeSureFirstInstanceWriterExtension.class.getName());
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+
+    if (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment()
+        == DatabaseEngineDeployment.AURORA) {
+      // Database instances should be rearranged to have a writer node at position 0.
+      // Many tests expect a writer node to be specified at the first position in the host list.
+
+      if (!TestEnvironment.getCurrent()
+          .getInfo()
+          .getRequest()
+          .getFeatures()
+          .contains(TestEnvironmentFeatures.AWS_CREDENTIALS_ENABLED)) {
+        throw new RuntimeException("AWS_CREDENTIALS_ENABLED feature is required for this test.");
+      }
+
+      AuroraTestUtility auroraUtil =
+          new AuroraTestUtility(TestEnvironment.getCurrent().getInfo().getAuroraRegion());
+      auroraUtil.waitUntilClusterHasRightState(
+          TestEnvironment.getCurrent().getInfo().getAuroraClusterName());
+
+      List<String> latestTopology = auroraUtil.getAuroraInstanceIds();
+
+      assertTrue(
+          auroraUtil.isDBInstanceWriter(
+              TestEnvironment.getCurrent().getInfo().getAuroraClusterName(),
+              latestTopology.get(0)));
+      String currentWriter = latestTopology.get(0);
+      LOGGER.finest("Current writer: " + currentWriter);
+
+      // Adjust database info to reflect a current writer and to move corresponding instance to
+      // position 0.
+      TestEnvironment.getCurrent().getInfo().getDatabaseInfo().moveInstanceFirst(currentWriter);
+      TestEnvironment.getCurrent()
+          .getInfo()
+          .getProxyDatabaseInfo()
+          .moveInstanceFirst(currentWriter);
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/ProxyHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ProxyHelper.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container;
+
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.model.ToxicDirection;
+import integration.refactored.TestInstanceInfo;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class ProxyHelper {
+
+  private static final Logger LOGGER = Logger.getLogger(ProxyHelper.class.getName());
+
+  /** Stops all traffic to and from server. */
+  public static void disableAllConnectivity() {
+    for (Proxy proxy : TestEnvironment.getCurrent().getProxies()) {
+      disableConnectivity(proxy);
+    }
+  }
+
+  /** Stops all traffic to and from server. */
+  public static void disableConnectivity(List<TestInstanceInfo> instances) {
+    for (TestInstanceInfo instanceInfo : instances) {
+      disableConnectivity(instanceInfo.getInstanceName());
+    }
+  }
+
+  /** Stops all traffic to and from server. */
+  public static void disableConnectivity(String instanceName) {
+    Proxy proxy = TestEnvironment.getCurrent().getProxy(instanceName);
+    if (proxy == null) {
+      throw new RuntimeException("Proxy for instance " + instanceName + " not found.");
+    }
+    disableConnectivity(proxy);
+  }
+
+  /** Stops all traffic to and from server. */
+  private static void disableConnectivity(Proxy proxy) {
+    try {
+      proxy
+          .toxics()
+          .bandwidth(
+              "DOWN-STREAM", ToxicDirection.DOWNSTREAM, 0); // from database server towards driver
+    } catch (IOException e) {
+      // ignore
+    }
+
+    try {
+      proxy
+          .toxics()
+          .bandwidth(
+              "UP-STREAM", ToxicDirection.UPSTREAM, 0); // from driver towards database server
+    } catch (IOException e) {
+      // ignore
+    }
+    LOGGER.finest("Disabled connectivity to " + proxy.getName());
+  }
+
+  /** Allow traffic to and from server. */
+  public static void enableAllConnectivity() {
+    for (Proxy proxy : TestEnvironment.getCurrent().getProxies()) {
+      enableConnectivity(proxy);
+    }
+  }
+
+  /** Allow traffic to and from server. */
+  public static void enableConnectivity(List<TestInstanceInfo> instances) {
+    for (TestInstanceInfo instanceInfo : instances) {
+      enableConnectivity(instanceInfo.getInstanceName());
+    }
+  }
+
+  /** Allow traffic to and from server. */
+  public static void enableConnectivity(String instanceName) {
+    Proxy proxy = TestEnvironment.getCurrent().getProxy(instanceName);
+    if (proxy == null) {
+      throw new RuntimeException("Proxy for instance " + instanceName + " not found.");
+    }
+    enableConnectivity(proxy);
+  }
+
+  /** Allow traffic to and from server. */
+  private static void enableConnectivity(Proxy proxy) {
+    try {
+      proxy.toxics().get("DOWN-STREAM").remove();
+    } catch (IOException ex) {
+      // ignore
+    }
+
+    try {
+      proxy.toxics().get("UP-STREAM").remove();
+    } catch (IOException ex) {
+      // ignore
+    }
+    LOGGER.finest("Enabled connectivity to " + proxy.getName());
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/TestDriver.java
+++ b/wrapper/src/test/java/integration/refactored/container/TestDriver.java
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
-
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+public enum TestDriver {
+  PG,
+  MYSQL,
+  MARIADB
+}

--- a/wrapper/src/test/java/integration/refactored/container/TestDriverProvider.java
+++ b/wrapper/src/test/java/integration/refactored/container/TestDriverProvider.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container;
+
+import static java.util.Arrays.asList;
+
+import integration.refactored.DriverHelper;
+import integration.refactored.GenericTypedParameterResolver;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.condition.EnableBasedOnEnvironmentFeatureExtension;
+import integration.refactored.container.condition.EnableBasedOnTestDriverExtension;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+public class TestDriverProvider implements TestTemplateInvocationContextProvider {
+
+  private static final Logger LOGGER = Logger.getLogger(TestDriverProvider.class.getName());
+
+  @Override
+  public boolean supportsTestTemplate(ExtensionContext context) {
+    return true;
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      ExtensionContext context) {
+
+    ArrayList<TestTemplateInvocationContext> resultContextList = new ArrayList<>();
+    for (TestDriver testDriver : TestEnvironment.getCurrent().getAllowedTestDrivers()) {
+      TestTemplateInvocationContext testTemplateInvocationContext =
+          getEnvironment(context, testDriver);
+      if (testTemplateInvocationContext != null) {
+        resultContextList.add(testTemplateInvocationContext);
+      }
+    }
+    return Arrays.stream(resultContextList.toArray(new TestTemplateInvocationContext[0]));
+  }
+
+  private TestTemplateInvocationContext getEnvironment(
+      ExtensionContext context, final TestDriver testDriver) {
+    return new TestTemplateInvocationContext() {
+      @Override
+      public String getDisplayName(int invocationIndex) {
+        return String.format(
+            "[%d] - [Driver: %-7s] - [%s]",
+            invocationIndex,
+            testDriver,
+            TestEnvironment.getCurrent().getInfo().getRequest().getDisplayName());
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return asList(
+            new GenericTypedParameterResolver(testDriver),
+            new EnableBasedOnTestDriverExtension(testDriver),
+            new EnableBasedOnEnvironmentFeatureExtension(testDriver),
+            new BeforeEachCallback() {
+              @Override
+              public void beforeEach(ExtensionContext context) throws Exception {
+                DriverHelper.unregisterAllDrivers();
+                DriverHelper.registerDriver(testDriver);
+                TestEnvironment.getCurrent().setCurrentDriver(testDriver);
+                LOGGER.finest("Registered " + testDriver + " driver.");
+
+                if (TestEnvironment.getCurrent()
+                    .getInfo()
+                    .getRequest()
+                    .getFeatures()
+                    .contains(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)) {
+                  // Enable all proxies
+                  ProxyHelper.enableAllConnectivity();
+                }
+              }
+            });
+      }
+    };
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/refactored/container/TestEnvironment.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import integration.refactored.DatabaseEngine;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.TestEnvironmentInfo;
+import integration.refactored.TestInstanceInfo;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+import software.amazon.jdbc.util.StringUtils;
+
+public class TestEnvironment {
+
+  private static TestEnvironment env;
+
+  private TestEnvironmentInfo info;
+  private HashMap<String, Proxy> proxies;
+  private TestDriver currentDriver;
+
+  private TestEnvironment() {}
+
+  public static synchronized TestEnvironment getCurrent() {
+    if (env == null) {
+      env = create();
+    }
+    return env;
+  }
+
+  private static TestEnvironment create() {
+    TestEnvironment environment = new TestEnvironment();
+
+    String infoJson = System.getenv("TEST_ENV_INFO_JSON");
+
+    if (StringUtils.isNullOrEmpty(infoJson)) {
+      throw new RuntimeException("Environment variable TEST_ENV_INFO_JSON is required.");
+    }
+
+    try {
+      final ObjectMapper mapper = new ObjectMapper();
+      environment.info = mapper.readValue(infoJson, TestEnvironmentInfo.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Invalid value in TEST_ENV_INFO_JSON.", e);
+    }
+
+    if (environment
+        .info
+        .getRequest()
+        .getFeatures()
+        .contains(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)) {
+      initProxies(environment);
+    }
+
+    return environment;
+  }
+
+  private static void initProxies(TestEnvironment environment) {
+    environment.proxies = new HashMap<>();
+
+    int proxyControlPort = environment.info.getProxyDatabaseInfo().getControlPort();
+    for (TestInstanceInfo instance : environment.info.getProxyDatabaseInfo().getInstances()) {
+      ToxiproxyClient client = new ToxiproxyClient(instance.getEndpoint(), proxyControlPort);
+      List<Proxy> proxies;
+      try {
+        proxies = client.getProxies();
+      } catch (IOException e) {
+        throw new RuntimeException("Error getting proxies for " + instance.getInstanceName(), e);
+      }
+      if (proxies == null || proxies.isEmpty()) {
+        throw new RuntimeException("Proxy for " + instance.getInstanceName() + " is not found.");
+      }
+      environment.proxies.put(instance.getInstanceName(), proxies.get(0));
+    }
+
+    if (!StringUtils.isNullOrEmpty(environment.info.getProxyDatabaseInfo().getClusterEndpoint())) {
+      ToxiproxyClient client =
+          new ToxiproxyClient(
+              environment.info.getProxyDatabaseInfo().getClusterEndpoint(), proxyControlPort);
+      Proxy proxy =
+          environment.getProxy(
+              client,
+              environment.info.getDatabaseInfo().getClusterEndpoint(),
+              environment.info.getDatabaseInfo().getClusterEndpointPort());
+      environment.proxies.put(environment.info.getProxyDatabaseInfo().getClusterEndpoint(), proxy);
+    }
+
+    if (!StringUtils.isNullOrEmpty(
+        environment.info.getProxyDatabaseInfo().getClusterReadOnlyEndpoint())) {
+      ToxiproxyClient client =
+          new ToxiproxyClient(
+              environment.info.getProxyDatabaseInfo().getClusterReadOnlyEndpoint(),
+              proxyControlPort);
+      Proxy proxy =
+          environment.getProxy(
+              client,
+              environment.info.getDatabaseInfo().getClusterReadOnlyEndpoint(),
+              environment.info.getDatabaseInfo().getClusterReadOnlyEndpointPort());
+      environment.proxies.put(
+          environment.info.getProxyDatabaseInfo().getClusterReadOnlyEndpoint(), proxy);
+    }
+  }
+
+  private Proxy getProxy(ToxiproxyClient proxyClient, String host, int port) {
+    final String upstream = host + ":" + port;
+    try {
+      return proxyClient.getProxy(upstream);
+    } catch (IOException e) {
+      throw new RuntimeException("Error getting proxy for " + upstream, e);
+    }
+  }
+
+  public Proxy getProxy(String instanceName) {
+    Proxy proxy = this.proxies.get(instanceName);
+    if (proxy == null) {
+      throw new RuntimeException("Proxy for " + instanceName + " not found.");
+    }
+    return proxy;
+  }
+
+  public java.util.Collection<Proxy> getProxies() {
+    return Collections.unmodifiableCollection(this.proxies.values());
+  }
+
+  public TestEnvironmentInfo getInfo() {
+    return this.info;
+  }
+
+  public void setCurrentDriver(TestDriver testDriver) {
+    this.currentDriver = testDriver;
+  }
+
+  public TestDriver getCurrentDriver() {
+    return this.currentDriver;
+  }
+
+  public List<TestDriver> getAllowedTestDrivers() {
+    ArrayList<TestDriver> allowedTestDrivers = new ArrayList<>();
+    for (TestDriver testDriver : TestDriver.values()) {
+      if (isTestDriverAllowed(testDriver)) {
+        allowedTestDrivers.add(testDriver);
+      }
+    }
+    return allowedTestDrivers;
+  }
+
+  public boolean isTestDriverAllowed(TestDriver testDriver) {
+
+    boolean disabledByFeature;
+    boolean driverCompatibleToDatabaseEngine;
+
+    final Set<TestEnvironmentFeatures> features = this.info.getRequest().getFeatures();
+    final DatabaseEngine databaseEngine = this.info.getRequest().getDatabaseEngine();
+
+    switch (testDriver) {
+      case MYSQL:
+        driverCompatibleToDatabaseEngine =
+            databaseEngine == DatabaseEngine.MYSQL || databaseEngine == DatabaseEngine.MARIADB;
+        disabledByFeature = features.contains(TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS);
+        break;
+      case PG:
+        driverCompatibleToDatabaseEngine = databaseEngine == DatabaseEngine.PG;
+        disabledByFeature = features.contains(TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS);
+        break;
+      case MARIADB:
+        driverCompatibleToDatabaseEngine =
+            databaseEngine == DatabaseEngine.MYSQL || databaseEngine == DatabaseEngine.MARIADB;
+        disabledByFeature = features.contains(TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS);
+        break;
+      default:
+        throw new NotImplementedException(testDriver.toString());
+    }
+
+    if (disabledByFeature || !driverCompatibleToDatabaseEngine) {
+      // this driver is disabled
+      return false;
+    }
+    return true;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/DisableOnTestDriver.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/DisableOnTestDriver.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import integration.refactored.container.TestDriver;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DisableOnTestDriver {
+  TestDriver[] value() default {};
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/DisableOnTestFeature.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/DisableOnTestFeature.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import integration.refactored.TestEnvironmentFeatures;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(DisableOnTestFeatureCondition.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DisableOnTestFeature {
+  TestEnvironmentFeatures[] value() default {};
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/DisableOnTestFeatureCondition.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/DisableOnTestFeatureCondition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.TestEnvironment;
+import java.util.Arrays;
+import java.util.Set;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+class DisableOnTestFeatureCondition implements ExecutionCondition {
+
+  public DisableOnTestFeatureCondition() {}
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    Set<TestEnvironmentFeatures> features =
+        TestEnvironment.getCurrent().getInfo().getRequest().getFeatures();
+
+    boolean disabled =
+        findAnnotation(context.getElement(), DisableOnTestFeature.class)
+            .map(
+                annotation -> {
+                  if (annotation == null || annotation.value() == null) {
+                    return true;
+                  }
+                  return Arrays.stream(annotation.value()).anyMatch(features::contains);
+                }) //
+            .orElse(false);
+
+    if (disabled) {
+      return ConditionEvaluationResult.disabled("Disabled by @DisableOnTestFeature");
+    }
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableBasedOnEnvironmentFeatureExtension.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableBasedOnEnvironmentFeatureExtension.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestEnvironment;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class EnableBasedOnEnvironmentFeatureExtension implements ExecutionCondition {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(EnableBasedOnEnvironmentFeatureExtension.class.getName());
+
+  private final TestDriver testDriver;
+
+  public EnableBasedOnEnvironmentFeatureExtension(TestDriver testDriver) {
+    this.testDriver = testDriver;
+  }
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (!TestEnvironment.getCurrent().isTestDriverAllowed(this.testDriver)) {
+      return ConditionEvaluationResult.disabled("Disabled by test environment features.");
+    }
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableBasedOnTestDriverExtension.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableBasedOnTestDriverExtension.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import integration.refactored.container.TestDriver;
+import java.util.Arrays;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class EnableBasedOnTestDriverExtension implements ExecutionCondition {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(EnableBasedOnTestDriverExtension.class.getName());
+
+  private final TestDriver testDriver;
+
+  public EnableBasedOnTestDriverExtension(TestDriver testDriver) {
+    this.testDriver = testDriver;
+  }
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    if (!context.getElement().isPresent()) {
+      return ConditionEvaluationResult.enabled("Test enabled");
+    }
+
+    boolean enabled =
+        findAnnotation(context.getElement(), EnableOnTestDriver.class)
+            .filter(annotation -> annotation != null && annotation.value() != null)
+            .map(annotation -> Arrays.stream(annotation.value()).anyMatch(v -> v == testDriver))
+            .orElse(true);
+
+    boolean disabled =
+        findAnnotation(context.getElement(), DisableOnTestDriver.class)
+            .filter(annotation -> annotation != null && annotation.value() != null)
+            .map(annotation -> Arrays.stream(annotation.value()).anyMatch(v -> v == testDriver))
+            .orElse(!enabled);
+
+    if (disabled) {
+      LOGGER.finest("Disabled by @EnableOnTestDriver or @DisableOnTestDriver annotation.");
+      return ConditionEvaluationResult.disabled(
+          "Disabled by @EnableOnTestDriver or @DisableOnTestDriver annotation.");
+    }
+
+    LOGGER.finest("Test enabled");
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngine.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngine.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import integration.refactored.DatabaseEngine;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(EnableOnDatabaseEngineCondition.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableOnDatabaseEngine {
+  DatabaseEngine[] value() default {};
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngineCondition.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngineCondition.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import integration.refactored.DatabaseEngine;
+import integration.refactored.container.TestEnvironment;
+import java.util.Arrays;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class EnableOnDatabaseEngineCondition implements ExecutionCondition {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(EnableOnDatabaseEngineCondition.class.getName());
+
+  public EnableOnDatabaseEngineCondition() {}
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    final DatabaseEngine databaseEngine =
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine();
+
+    boolean enabled =
+        findAnnotation(context.getElement(), EnableOnDatabaseEngine.class)
+            .map(
+                annotation -> {
+                  if (annotation == null || annotation.value() == null) {
+                    return true;
+                  }
+                  return Arrays.stream(annotation.value()).anyMatch(v -> databaseEngine.equals(v));
+                }) //
+            .orElse(true);
+
+    if (!enabled) {
+      return ConditionEvaluationResult.disabled("Disabled by @EnableOnTestDatabaseEngine");
+    }
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngineDeployment.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngineDeployment.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import integration.refactored.DatabaseEngineDeployment;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(EnableOnDatabaseEngineDeploymentCondition.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableOnDatabaseEngineDeployment {
+  DatabaseEngineDeployment[] value() default {};
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngineDeploymentCondition.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnDatabaseEngineDeploymentCondition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.container.TestEnvironment;
+import java.util.Arrays;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class EnableOnDatabaseEngineDeploymentCondition implements ExecutionCondition {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(EnableOnDatabaseEngineDeploymentCondition.class.getName());
+
+  public EnableOnDatabaseEngineDeploymentCondition() {}
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    final DatabaseEngineDeployment databaseEngineDeployment =
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment();
+
+    boolean enabled =
+        findAnnotation(context.getElement(), EnableOnDatabaseEngineDeployment.class)
+            .map(
+                annotation -> {
+                  if (annotation == null || annotation.value() == null) {
+                    return true;
+                  }
+                  return Arrays.stream(annotation.value())
+                      .anyMatch(v -> databaseEngineDeployment.equals(v));
+                }) //
+            .orElse(true);
+
+    if (!enabled) {
+      return ConditionEvaluationResult.disabled("Disabled by @EnableOnDatabaseEngineDeployment");
+    }
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnNumOfInstances.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnNumOfInstances.java
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(EnableOnNumOfInstancesCondition.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableOnNumOfInstances {
+  int min() default 0;
+
+  int max() default 0;
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnNumOfInstancesCondition.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnNumOfInstancesCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import integration.refactored.container.TestEnvironment;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+class EnableOnNumOfInstancesCondition implements ExecutionCondition {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(EnableOnTestFeatureCondition.class.getName());
+
+  public EnableOnNumOfInstancesCondition() {}
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    final int actualNumOfInstances =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstances().size();
+
+    boolean enabled =
+        findAnnotation(context.getElement(), EnableOnNumOfInstances.class)
+            .map(
+                annotation -> {
+                  if (annotation == null) {
+                    return true;
+                  }
+                  if (annotation.min() > 0 && actualNumOfInstances < annotation.min()) {
+                    return false;
+                  }
+                  if (annotation.max() > 0 && actualNumOfInstances > annotation.max()) {
+                    return false;
+                  }
+                  return true;
+                }) //
+            .orElse(true);
+
+    if (!enabled) {
+      return ConditionEvaluationResult.disabled("Disabled by @EnableOnNumOfInstances");
+    }
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnTestDriver.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnTestDriver.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import integration.refactored.container.TestDriver;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface EnableOnTestDriver {
+  TestDriver[] value() default {};
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnTestFeature.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnTestFeature.java
@@ -14,22 +14,18 @@
  * limitations under the License.
  */
 
-package integration.container.standard.mariadb;
+package integration.refactored.container.condition;
 
-import org.junit.platform.suite.api.SelectClasses;
-import org.junit.platform.suite.api.Suite;
-import org.junit.platform.suite.api.SuiteDisplayName;
+import integration.refactored.TestEnvironmentFeatures;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-// Tests will run in order of top to bottom.
-// To add additional tests, append it inside SelectClasses, comma-separated
-@Suite
-@SelectClasses({
-  StandardMariadbIntegrationTest.class,
-  DataCachePluginTests.class,
-  DataSourceTests.class,
-  HikariTests.class,
-  LogQueryPluginTests.class,
-  SpringTests.class,
-  StandardMariadbReadWriteSplittingTest.class
-})
-public class StandardMariadbTestSuite {}
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ExtendWith(EnableOnTestFeatureCondition.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableOnTestFeature {
+  TestEnvironmentFeatures[] value() default {};
+}

--- a/wrapper/src/test/java/integration/refactored/container/condition/EnableOnTestFeatureCondition.java
+++ b/wrapper/src/test/java/integration/refactored/container/condition/EnableOnTestFeatureCondition.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.condition;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.TestEnvironment;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+class EnableOnTestFeatureCondition implements ExecutionCondition {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(EnableOnTestFeatureCondition.class.getName());
+
+  public EnableOnTestFeatureCondition() {}
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+
+    final Set<TestEnvironmentFeatures> features =
+        TestEnvironment.getCurrent().getInfo().getRequest().getFeatures();
+
+    boolean enabled =
+        findAnnotation(context.getElement(), EnableOnTestFeature.class)
+            .map(
+                annotation -> {
+                  if (annotation == null || annotation.value() == null) {
+                    return true;
+                  }
+                  return Arrays.stream(annotation.value())
+                      .allMatch(
+                          v -> {
+                            // LOGGER.finest("value=" + v + ", features=" + features);
+                            return features.contains(v);
+                          });
+                }) //
+            .orElse(true);
+
+    if (!enabled) {
+      return ConditionEvaluationResult.disabled("Disabled by @EnableOnTestFeature");
+    }
+    return ConditionEvaluationResult.enabled("Test enabled");
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/AdvancedPerformanceTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AdvancedPerformanceTest.java
@@ -1,0 +1,718 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import integration.container.aurora.TestAuroraHostListProvider;
+import integration.container.aurora.TestPluginServiceImpl;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.EnableOnTestFeature;
+import integration.util.AuroraTestUtility;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.Arguments;
+import software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException;
+import software.amazon.jdbc.util.StringUtils;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnTestFeature({
+  TestEnvironmentFeatures.PERFORMANCE,
+  TestEnvironmentFeatures.FAILOVER_SUPPORTED
+})
+public class AdvancedPerformanceTest {
+
+  private static final Logger LOGGER = Logger.getLogger(AdvancedPerformanceTest.class.getName());
+
+  private static final int REPEAT_TIMES =
+      StringUtils.isNullOrEmpty(System.getenv("REPEAT_TIMES"))
+          ? 5
+          : Integer.parseInt(System.getenv("REPEAT_TIMES"));
+
+  private static final int TIMEOUT_SEC = 5;
+  private static final int CONNECT_TIMEOUT_SEC = 5;
+  private static final int FAILOVER_TIMEOUT_MS = 300000;
+  private static final int EFM_FAILURE_DETECTION_TIME_MS = 30000;
+  private static final int EFM_FAILURE_DETECTION_INTERVAL_MS = 5000;
+  private static final int EFM_FAILURE_DETECTION_COUNT = 3;
+  private static final String QUERY = "SELECT pg_sleep(600)"; // 600s -> 10min
+
+  private static final ConcurrentLinkedQueue<PerfStat> perfDataList = new ConcurrentLinkedQueue<>();
+
+  protected static final AuroraTestUtility auroraUtil =
+      new AuroraTestUtility(TestEnvironment.getCurrent().getInfo().getAuroraRegion());
+
+  private static void doWritePerfDataToFile(
+      String fileName, ConcurrentLinkedQueue<PerfStat> dataList) throws IOException {
+
+    if (dataList.isEmpty()) {
+      return;
+    }
+
+    LOGGER.finest(() -> "File name: " + fileName);
+
+    List<PerfStat> sortedData =
+        dataList.stream()
+            .sorted(
+                (d1, d2) ->
+                    d1.paramFailoverDelayMillis == d2.paramFailoverDelayMillis
+                        ? d1.paramDriverName.compareTo(d2.paramDriverName)
+                        : 0)
+            .collect(Collectors.toList());
+
+    try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+
+      final XSSFSheet sheet = workbook.createSheet("PerformanceResults");
+
+      for (int rows = 0; rows < dataList.size(); rows++) {
+        PerfStat perfStat = sortedData.get(rows);
+        Row row;
+
+        if (rows == 0) {
+          // Header
+          row = sheet.createRow(0);
+          perfStat.writeHeader(row);
+        }
+
+        row = sheet.createRow(rows + 1);
+        perfStat.writeData(row);
+      }
+
+      // Write to file
+      final File newExcelFile = new File(fileName);
+      newExcelFile.createNewFile();
+      try (FileOutputStream fileOut = new FileOutputStream(newExcelFile)) {
+        workbook.write(fileOut);
+      }
+    }
+  }
+
+  @TestTemplate
+  public void test_AdvancedPerformance() throws IOException {
+
+    perfDataList.clear();
+
+    try {
+      Stream<Arguments> argsStream = generateParams();
+      argsStream.forEach(
+          a -> {
+            try {
+              ensureClusterHealthy();
+              LOGGER.finest("DB cluster is healthy.");
+              ensureDnsHealthy();
+              LOGGER.finest("DNS is healthy.");
+
+              Object[] args = a.get();
+              int failoverDelayTimeMillis = (int) args[0];
+              int runNumber = (int) args[1];
+
+              LOGGER.finest(
+                  "Iteration "
+                      + runNumber
+                      + "/"
+                      + REPEAT_TIMES
+                      + " for "
+                      + failoverDelayTimeMillis
+                      + "ms delay");
+
+              doMeasurePerformance(failoverDelayTimeMillis);
+
+            } catch (InterruptedException ex) {
+              throw new RuntimeException(ex);
+            } catch (UnknownHostException e) {
+              throw new RuntimeException(e);
+            }
+          });
+
+    } finally {
+      doWritePerfDataToFile(
+          String.format(
+              "./build/reports/tests/DbEngine_%s_Driver_%s_AdvancedPerformanceResults.xlsx",
+              TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+              TestEnvironment.getCurrent().getCurrentDriver()),
+          perfDataList);
+      perfDataList.clear();
+    }
+  }
+
+  private void doMeasurePerformance(int sleepDelayMillis) throws InterruptedException {
+
+    final AtomicLong downtime = new AtomicLong();
+    final CountDownLatch startLatch = new CountDownLatch(5);
+    final CountDownLatch finishLatch = new CountDownLatch(5);
+
+    downtime.set(0);
+
+    final Thread failoverThread =
+        getThread_Failover(sleepDelayMillis, downtime, startLatch, finishLatch);
+    final Thread pgThread =
+        getThread_DirectDriver(sleepDelayMillis, downtime, startLatch, finishLatch);
+    final Thread wrapperEfmThread =
+        getThread_WrapperEfm(sleepDelayMillis, downtime, startLatch, finishLatch);
+    final Thread wrapperEfmFailoverThread =
+        getThread_WrapperEfmFailover(sleepDelayMillis, downtime, startLatch, finishLatch);
+    final Thread dnsThread = getThread_DNS(sleepDelayMillis, downtime, startLatch, finishLatch);
+
+    failoverThread.start();
+    pgThread.start();
+    wrapperEfmThread.start();
+    wrapperEfmFailoverThread.start();
+    dnsThread.start();
+
+    LOGGER.finest("All threads started.");
+
+    finishLatch.await(5, TimeUnit.MINUTES); // wait for all threads to complete
+
+    LOGGER.finest("Test is over.");
+
+    failoverThread.interrupt();
+    pgThread.interrupt();
+    wrapperEfmThread.interrupt();
+    wrapperEfmFailoverThread.interrupt();
+    dnsThread.interrupt();
+  }
+
+  private void ensureDnsHealthy() throws UnknownHostException, InterruptedException {
+    LOGGER.finest(
+        "Writer is "
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getInstanceName());
+    final String writerIpAddress =
+        InetAddress.getByName(
+                TestEnvironment.getCurrent()
+                    .getInfo()
+                    .getDatabaseInfo()
+                    .getInstances()
+                    .get(0)
+                    .getEndpoint())
+            .getHostAddress();
+    LOGGER.finest("Writer resolves to " + writerIpAddress);
+    LOGGER.finest(
+        "Cluster Endpoint is "
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint());
+    String clusterIpAddress =
+        InetAddress.getByName(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint())
+            .getHostAddress();
+    LOGGER.finest("Cluster Endpoint resolves to " + clusterIpAddress);
+
+    long startTimeNano = System.nanoTime();
+    while (!clusterIpAddress.equals(writerIpAddress)
+        && TimeUnit.NANOSECONDS.toMinutes(System.nanoTime() - startTimeNano) < 5) {
+      Thread.sleep(1000);
+      clusterIpAddress =
+          InetAddress.getByName(
+                  TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint())
+              .getHostAddress();
+      LOGGER.finest("Cluster Endpoint resolves to " + clusterIpAddress);
+    }
+
+    if (!clusterIpAddress.equals(writerIpAddress)) {
+      fail("DNS has stale data");
+    }
+  }
+
+  private Thread getThread_Failover(
+      final int sleepDelayMillis,
+      final AtomicLong downtime,
+      final CountDownLatch startLatch,
+      final CountDownLatch finishLatch) {
+
+    return new Thread(
+        () -> {
+          try {
+            Thread.sleep(1000);
+            startLatch.countDown(); // notify that this thread is ready for work
+            startLatch.await(
+                5, TimeUnit.MINUTES); // wait for another threads to be ready to start the test
+
+            LOGGER.finest("Waiting " + sleepDelayMillis + "ms...");
+            Thread.sleep(sleepDelayMillis);
+            LOGGER.finest("Trigger failover...");
+
+            // trigger failover
+            failoverCluster();
+            downtime.set(System.nanoTime());
+            LOGGER.finest("Failover is started.");
+
+          } catch (InterruptedException interruptedException) {
+            // Ignore, stop the thread
+          } catch (Exception exception) {
+            fail("Failover thread exception: " + exception);
+          } finally {
+            finishLatch.countDown();
+            LOGGER.finest("Failover thread is completed.");
+          }
+        });
+  }
+
+  private Thread getThread_DirectDriver(
+      final int sleepDelayMillis,
+      final AtomicLong downtime,
+      final CountDownLatch startLatch,
+      final CountDownLatch finishLatch) {
+
+    return new Thread(
+        () -> {
+          long failureTime = 0;
+          try {
+            // DB_CONN_STR_PREFIX
+            final Properties props = ConnectionStringHelper.getDefaultProperties();
+            final Connection conn =
+                openConnectionWithRetry(
+                    ConnectionStringHelper.getUrl(
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpoint(),
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpointPort(),
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getDefaultDbName()),
+                    props);
+            LOGGER.finest("DirectDriver connection is open.");
+
+            Thread.sleep(1000);
+            startLatch.countDown(); // notify that this thread is ready for work
+            startLatch.await(
+                5, TimeUnit.MINUTES); // wait for another threads to be ready to start the test
+
+            LOGGER.finest("DirectDriver Starting long query...");
+            // Execute long query
+            final Statement statement = conn.createStatement();
+            try (final ResultSet result = statement.executeQuery(QUERY)) {
+              fail("Sleep query finished, should not be possible with network downed.");
+            } catch (SQLException throwable) { // Catching executing query
+              LOGGER.finest("DirectDriver thread exception: " + throwable);
+              // Calculate and add detection time
+              failureTime = (System.nanoTime() - downtime.get());
+            }
+
+          } catch (InterruptedException interruptedException) {
+            // Ignore, stop the thread
+          } catch (Exception exception) {
+            fail("PG thread exception: " + exception);
+          } finally {
+            PerfStat data = new PerfStat();
+            data.paramFailoverDelayMillis = sleepDelayMillis;
+            data.paramDriverName =
+                "DirectDriver - " + TestEnvironment.getCurrent().getCurrentDriver();
+            data.failureDetectionTimeMillis = TimeUnit.NANOSECONDS.toMillis(failureTime);
+            perfDataList.add(data);
+            LOGGER.finest(
+                "DirectDriver Failure detection time is " + data.failureDetectionTimeMillis + "ms");
+
+            finishLatch.countDown();
+            LOGGER.finest("DirectDriver thread is completed.");
+          }
+        });
+  }
+
+  private Thread getThread_WrapperEfm(
+      final int sleepDelayMillis,
+      final AtomicLong downtime,
+      final CountDownLatch startLatch,
+      final CountDownLatch finishLatch) {
+
+    return new Thread(
+        () -> {
+          long failureTime = 0;
+          try {
+            final Properties props = ConnectionStringHelper.getDefaultProperties();
+            DriverHelper.setMonitoringConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
+            DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            props.setProperty(
+                "failureDetectionTime", Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
+            props.setProperty(
+                "failureDetectionInterval", Integer.toString(EFM_FAILURE_DETECTION_INTERVAL_MS));
+            props.setProperty(
+                "failureDetectionCount", Integer.toString(EFM_FAILURE_DETECTION_COUNT));
+            props.setProperty("wrapperPlugins", "efm");
+
+            final Connection conn =
+                openConnectionWithRetry(
+                    ConnectionStringHelper.getWrapperUrl(
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpoint(),
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpointPort(),
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getDefaultDbName()),
+                    props);
+            LOGGER.finest("WrapperEfm connection is open.");
+
+            Thread.sleep(1000);
+            startLatch.countDown(); // notify that this thread is ready for work
+            startLatch.await(
+                5, TimeUnit.MINUTES); // wait for another threads to be ready to start the test
+
+            LOGGER.finest("WrapperEfm Starting long query...");
+            // Execute long query
+            final Statement statement = conn.createStatement();
+            try (final ResultSet result = statement.executeQuery(QUERY)) {
+              fail("Sleep query finished, should not be possible with network downed.");
+            } catch (SQLException throwable) { // Catching executing query
+              LOGGER.finest("WrapperEfm thread exception: " + throwable);
+
+              // Calculate and add detection time
+              failureTime = (System.nanoTime() - downtime.get());
+            }
+
+          } catch (InterruptedException interruptedException) {
+            // Ignore, stop the thread
+          } catch (Exception exception) {
+            fail("WrapperEfm thread exception: " + exception);
+          } finally {
+            PerfStat data = new PerfStat();
+            data.paramFailoverDelayMillis = sleepDelayMillis;
+            data.paramDriverName =
+                String.format(
+                    "AWS Wrapper (%s, EFM)", TestEnvironment.getCurrent().getCurrentDriver());
+            data.failureDetectionTimeMillis = TimeUnit.NANOSECONDS.toMillis(failureTime);
+            perfDataList.add(data);
+            LOGGER.finest(
+                "WrapperEfm Failure detection time is " + data.failureDetectionTimeMillis + "ms");
+
+            finishLatch.countDown();
+            LOGGER.finest("WrapperEfm thread is completed.");
+          }
+        });
+  }
+
+  private Thread getThread_WrapperEfmFailover(
+      final int sleepDelayMillis,
+      final AtomicLong downtime,
+      final CountDownLatch startLatch,
+      final CountDownLatch finishLatch) {
+
+    return new Thread(
+        () -> {
+          long failureTime = 0;
+          try {
+            final Properties props = ConnectionStringHelper.getDefaultProperties();
+            DriverHelper.setMonitoringConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
+            DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            props.setProperty(
+                "failureDetectionTime", Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
+            props.setProperty(
+                "failureDetectionInterval", Integer.toString(EFM_FAILURE_DETECTION_INTERVAL_MS));
+            props.setProperty(
+                "failureDetectionCount", Integer.toString(EFM_FAILURE_DETECTION_COUNT));
+            props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
+            props.setProperty("wrapperPlugins", "failover,efm");
+
+            final Connection conn =
+                openConnectionWithRetry(
+                    ConnectionStringHelper.getWrapperUrl(
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpoint(),
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpointPort(),
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getDefaultDbName()),
+                    props);
+            LOGGER.finest("WrapperEfmFailover connection is open.");
+
+            Thread.sleep(1000);
+            startLatch.countDown(); // notify that this thread is ready for work
+            startLatch.await(
+                5, TimeUnit.MINUTES); // wait for another threads to be ready to start the test
+
+            LOGGER.finest("WrapperEfmFailover Starting long query...");
+            // Execute long query
+            final Statement statement = conn.createStatement();
+            try (final ResultSet result = statement.executeQuery(QUERY)) {
+              fail("Sleep query finished, should not be possible with network downed.");
+            } catch (SQLException throwable) {
+              LOGGER.finest("WrapperEfmFailover thread exception: " + throwable);
+              if (throwable instanceof FailoverSuccessSQLException) {
+                // Calculate and add detection time
+                failureTime = (System.nanoTime() - downtime.get());
+              }
+            }
+
+          } catch (InterruptedException interruptedException) {
+            // Ignore, stop the thread
+          } catch (Exception exception) {
+            fail("WrapperEfmFailover thread exception: " + exception);
+          } finally {
+            PerfStat data = new PerfStat();
+            data.paramFailoverDelayMillis = sleepDelayMillis;
+            data.paramDriverName =
+                String.format(
+                    "AWS Wrapper (%s, EFM, Failover)",
+                    TestEnvironment.getCurrent().getCurrentDriver());
+            data.reconnectTimeMillis = TimeUnit.NANOSECONDS.toMillis(failureTime);
+            perfDataList.add(data);
+            LOGGER.finest(
+                "WrapperEfmFailover Reconnect time is " + data.reconnectTimeMillis + "ms");
+
+            finishLatch.countDown();
+            LOGGER.finest("WrapperEfmFailover thread is completed.");
+          }
+        });
+  }
+
+  private Thread getThread_DNS(
+      final int sleepDelayMillis,
+      final AtomicLong downtime,
+      final CountDownLatch startLatch,
+      final CountDownLatch finishLatch) {
+
+    return new Thread(
+        () -> {
+          long failureTime = 0;
+          String currentClusterIpAddress;
+
+          try {
+            currentClusterIpAddress =
+                InetAddress.getByName(
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpoint())
+                    .getHostAddress();
+            LOGGER.finest("Cluster Endpoint resolves to " + currentClusterIpAddress);
+
+            Thread.sleep(1000);
+            startLatch.countDown(); // notify that this thread is ready for work
+            startLatch.await(
+                5, TimeUnit.MINUTES); // wait for another threads to be ready to start the test
+
+            String clusterIpAddress =
+                InetAddress.getByName(
+                        TestEnvironment.getCurrent()
+                            .getInfo()
+                            .getDatabaseInfo()
+                            .getClusterEndpoint())
+                    .getHostAddress();
+
+            long startTimeNano = System.nanoTime();
+            while (clusterIpAddress.equals(currentClusterIpAddress)
+                && TimeUnit.NANOSECONDS.toMinutes(System.nanoTime() - startTimeNano) < 5) {
+              Thread.sleep(1000);
+              clusterIpAddress =
+                  InetAddress.getByName(
+                          TestEnvironment.getCurrent()
+                              .getInfo()
+                              .getDatabaseInfo()
+                              .getClusterEndpoint())
+                      .getHostAddress();
+              LOGGER.finest("Cluster Endpoint resolves to " + currentClusterIpAddress);
+            }
+
+            // DNS data has changed
+            if (!clusterIpAddress.equals(currentClusterIpAddress)) {
+              failureTime = (System.nanoTime() - downtime.get());
+            }
+
+          } catch (InterruptedException interruptedException) {
+            // Ignore, stop the thread
+          } catch (Exception exception) {
+            fail("Failover thread exception: " + exception);
+          } finally {
+            PerfStat data = new PerfStat();
+            data.paramFailoverDelayMillis = sleepDelayMillis;
+            data.paramDriverName = "DNS";
+            data.dnsUpdateTimeMillis = TimeUnit.NANOSECONDS.toMillis(failureTime);
+            perfDataList.add(data);
+            LOGGER.finest("DNS Update time is " + data.dnsUpdateTimeMillis + "ms");
+
+            finishLatch.countDown();
+            LOGGER.finest("DNS thread is completed.");
+          }
+        });
+  }
+
+  private Connection openConnectionWithRetry(String url, Properties props) {
+    Connection conn = null;
+    int connectCount = 0;
+    while (conn == null && connectCount < 10) {
+      try {
+        conn = DriverManager.getConnection(url, props);
+
+      } catch (SQLException sqlEx) {
+        // ignore, try to connect again
+      }
+      connectCount++;
+    }
+
+    if (conn == null) {
+      fail("Can't connect to " + url);
+    }
+    return conn;
+  }
+
+  private void failoverCluster() throws InterruptedException {
+    auroraUtil.failoverCluster(TestEnvironment.getCurrent().getInfo().getAuroraClusterName());
+  }
+
+  private void ensureClusterHealthy() throws InterruptedException {
+
+    auroraUtil.waitUntilClusterHasRightState(
+        TestEnvironment.getCurrent().getInfo().getAuroraClusterName());
+
+    // Always get the latest topology info with writer as first
+    List<String> latestTopology = new ArrayList<>();
+
+    // Need to ensure that cluster details through API matches topology fetched through SQL
+    // Wait up to 5min
+    long startTimeNano = System.nanoTime();
+    while ((latestTopology.size()
+                != TestEnvironment.getCurrent().getInfo().getRequest().getNumOfInstances()
+            || !auroraUtil.isDBInstanceWriter(latestTopology.get(0)))
+        && TimeUnit.NANOSECONDS.toMinutes(System.nanoTime() - startTimeNano) < 5) {
+
+      Thread.sleep(5000);
+
+      try {
+        latestTopology = auroraUtil.getAuroraInstanceIds();
+      } catch (SQLException ex) {
+        latestTopology = new ArrayList<>();
+      }
+    }
+    assertTrue(
+        auroraUtil.isDBInstanceWriter(
+            TestEnvironment.getCurrent().getInfo().getAuroraClusterName(), latestTopology.get(0)));
+    String currentWriter = latestTopology.get(0);
+
+    // Adjust database info to reflect a current writer and to move corresponding instance to
+    // position 0.
+    TestEnvironment.getCurrent().getInfo().getDatabaseInfo().moveInstanceFirst(currentWriter);
+    TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().moveInstanceFirst(currentWriter);
+
+    auroraUtil.makeSureInstancesUp(latestTopology);
+
+    TestAuroraHostListProvider.clearCache();
+    TestPluginServiceImpl.clearHostAvailabilityCache();
+  }
+
+  private static Stream<Arguments> generateParams() {
+
+    ArrayList<Arguments> args = new ArrayList<>();
+
+    for (int i = 1; i <= REPEAT_TIMES; i++) {
+      args.add(Arguments.of(10000, i));
+    }
+    for (int i = 1; i <= REPEAT_TIMES; i++) {
+      args.add(Arguments.of(20000, i));
+    }
+    for (int i = 1; i <= REPEAT_TIMES; i++) {
+      args.add(Arguments.of(30000, i));
+    }
+    for (int i = 1; i <= REPEAT_TIMES; i++) {
+      args.add(Arguments.of(40000, i));
+    }
+    for (int i = 1; i <= REPEAT_TIMES; i++) {
+      args.add(Arguments.of(50000, i));
+    }
+    for (int i = 1; i <= REPEAT_TIMES; i++) {
+      args.add(Arguments.of(60000, i));
+    }
+
+    return Stream.of(args.toArray(new Arguments[0]));
+  }
+
+  private static class PerfStat {
+
+    public String paramDriverName;
+    public int paramFailoverDelayMillis;
+    public long failureDetectionTimeMillis;
+    public long reconnectTimeMillis;
+    public long dnsUpdateTimeMillis;
+
+    public void writeHeader(Row row) {
+      Cell cell = row.createCell(0);
+      cell.setCellValue("Driver Configuration");
+      cell = row.createCell(1);
+      cell.setCellValue("Failover Delay Millis");
+      cell = row.createCell(2);
+      cell.setCellValue("Failure Detection Time Millis");
+      cell = row.createCell(3);
+      cell.setCellValue("Reconnect Time Millis");
+      cell = row.createCell(4);
+      cell.setCellValue("DNS Update Time Millis");
+    }
+
+    public void writeData(Row row) {
+      Cell cell = row.createCell(0);
+      cell.setCellValue(this.paramDriverName);
+      cell = row.createCell(1);
+      cell.setCellValue(this.paramFailoverDelayMillis);
+      cell = row.createCell(2);
+      cell.setCellValue(this.failureDetectionTimeMillis);
+      cell = row.createCell(3);
+      cell.setCellValue(this.reconnectTimeMillis);
+      cell = row.createCell(4);
+      cell.setCellValue(this.dnsUpdateTimeMillis);
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/AuroraFailoverTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AuroraFailoverTest.java
@@ -594,7 +594,7 @@ public class AuroraFailoverTest {
             + TestEnvironment.getCurrent()
                 .getInfo()
                 .getProxyDatabaseInfo()
-                .getInstanceEndpointPrefix());
+                .getInstanceEndpointSuffix());
     return props;
   }
 

--- a/wrapper/src/test/java/integration/refactored/container/tests/AuroraFailoverTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AuroraFailoverTest.java
@@ -1,0 +1,667 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mysql.cj.conf.PropertyKey;
+import integration.container.aurora.TestAuroraHostListProvider;
+import integration.container.aurora.TestPluginServiceImpl;
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.TestInstanceInfo;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.ProxyHelper;
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import integration.refactored.container.condition.EnableOnNumOfInstances;
+import integration.refactored.container.condition.EnableOnTestDriver;
+import integration.refactored.container.condition.EnableOnTestFeature;
+import integration.util.AuroraTestUtility;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.ds.AwsWrapperDataSource;
+import software.amazon.jdbc.hostlistprovider.AuroraHostListProvider;
+import software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin;
+import software.amazon.jdbc.util.SqlState;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnTestFeature(TestEnvironmentFeatures.FAILOVER_SUPPORTED)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+@EnableOnNumOfInstances(min = 2)
+public class AuroraFailoverTest {
+
+  private static final Logger LOGGER = Logger.getLogger(AuroraFailoverTest.class.getName());
+
+  protected static final AuroraTestUtility auroraUtil =
+      new AuroraTestUtility(TestEnvironment.getCurrent().getInfo().getAuroraRegion());
+  protected static final int IS_VALID_TIMEOUT = 5;
+
+  protected String currentWriter;
+
+  @BeforeEach
+  public void setUpEach() throws InterruptedException {
+
+    auroraUtil.waitUntilClusterHasRightState(
+        TestEnvironment.getCurrent().getInfo().getAuroraClusterName());
+
+    // Always get the latest topology info with writer as first
+    List<String> latestTopology = new ArrayList<>();
+
+    // Need to ensure that cluster details through API matches topology fetched through SQL
+    // Wait up to 5min
+    long startTimeNano = System.nanoTime();
+    while ((latestTopology.size()
+                != TestEnvironment.getCurrent().getInfo().getRequest().getNumOfInstances()
+            || !auroraUtil.isDBInstanceWriter(latestTopology.get(0)))
+        && TimeUnit.NANOSECONDS.toMinutes(System.nanoTime() - startTimeNano) < 5) {
+
+      Thread.sleep(5000);
+
+      try {
+        latestTopology = auroraUtil.getAuroraInstanceIds();
+      } catch (SQLException ex) {
+        latestTopology = new ArrayList<>();
+      }
+    }
+    assertTrue(
+        auroraUtil.isDBInstanceWriter(
+            TestEnvironment.getCurrent().getInfo().getAuroraClusterName(), latestTopology.get(0)));
+    currentWriter = latestTopology.get(0);
+
+    // Adjust database info to reflect a current writer and to move corresponding instance to
+    // position 0.
+    TestEnvironment.getCurrent().getInfo().getDatabaseInfo().moveInstanceFirst(currentWriter);
+    TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().moveInstanceFirst(currentWriter);
+
+    auroraUtil.makeSureInstancesUp(latestTopology);
+
+    TestAuroraHostListProvider.clearCache();
+    TestPluginServiceImpl.clearHostAvailabilityCache();
+  }
+
+  /**
+   * Current writer dies, a reader instance is nominated to be a new writer, failover to the new
+   * writer. Driver failover occurs when executing a method against the connection
+   */
+  @TestTemplate
+  public void test_failFromWriterToNewWriter_failOnConnectionInvocation()
+      throws SQLException, InterruptedException {
+
+    final String initialWriterId = this.currentWriter;
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(initialWriterId);
+
+    final Properties props = initDefaultProps();
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                initialWriterInstanceInfo.getEndpoint(),
+                initialWriterInstanceInfo.getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      // Crash Instance1 and nominate a new writer
+      auroraUtil.failoverClusterAndWaitUntilWriterChanged(initialWriterId);
+
+      // Failure occurs on Connection invocation
+      assertFirstQueryThrows(conn, SqlState.COMMUNICATION_LINK_CHANGED.getState());
+
+      // Assert that we are connected to the new writer after failover happens.
+      final String currentConnectionId = auroraUtil.queryInstanceId(conn);
+      assertTrue(auroraUtil.isDBInstanceWriter(currentConnectionId));
+      assertNotEquals(currentConnectionId, initialWriterId);
+    }
+  }
+
+  /**
+   * Current writer dies, a reader instance is nominated to be a new writer, failover to the new
+   * writer. Driver failover occurs when executing a method against an object bound to the
+   * connection (eg a Statement object created by the connection).
+   */
+  @TestTemplate
+  public void test_failFromWriterToNewWriter_failOnConnectionBoundObjectInvocation()
+      throws SQLException, InterruptedException {
+
+    final String initialWriterId = this.currentWriter;
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(initialWriterId);
+
+    final Properties props = initDefaultProps();
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                initialWriterInstanceInfo.getEndpoint(),
+                initialWriterInstanceInfo.getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      final Statement stmt = conn.createStatement();
+
+      // Crash Instance1 and nominate a new writer
+      auroraUtil.failoverClusterAndWaitUntilWriterChanged(initialWriterId);
+
+      // Failure occurs on Statement invocation
+      assertFirstQueryThrows(stmt, SqlState.COMMUNICATION_LINK_CHANGED.getState());
+
+      // Assert that the driver is connected to the new writer after failover happens.
+      final String currentConnectionId = auroraUtil.queryInstanceId(conn);
+      assertTrue(auroraUtil.isDBInstanceWriter(currentConnectionId));
+
+      assertNotEquals(initialWriterId, currentConnectionId);
+    }
+  }
+
+  /**
+   * Current reader dies, no other reader instance, failover to writer, then writer dies, failover
+   * to another available reader instance.
+   */
+  @TestTemplate
+  @EnableOnNumOfInstances(min = 3)
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_failFromReaderToWriterToAnyAvailableInstance()
+      throws SQLException, InterruptedException {
+
+    // Crashing all readers except the first one
+    for (int i = 2;
+        i < TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().size();
+        i++) {
+      ProxyHelper.disableConnectivity(
+          TestEnvironment.getCurrent()
+              .getInfo()
+              .getProxyDatabaseInfo()
+              .getInstances()
+              .get(i)
+              .getInstanceName());
+    }
+
+    // Connect to Instance2 which is the only reader that is up.
+    final TestInstanceInfo instanceInfo =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(1);
+    final String instanceId = instanceInfo.getInstanceName();
+
+    final Properties props = initDefaultProxiedProps();
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                instanceInfo.getEndpoint(),
+                instanceInfo.getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      // Crash Instance2
+      ProxyHelper.disableConnectivity(instanceId);
+
+      assertFirstQueryThrows(conn, SqlState.COMMUNICATION_LINK_CHANGED.getState());
+
+      // Assert that we are currently connected to the writer Instance1.
+      final String writerId = this.currentWriter;
+      String currentConnectionId = auroraUtil.queryInstanceId(conn);
+      assertEquals(writerId, currentConnectionId);
+      assertTrue(auroraUtil.isDBInstanceWriter(currentConnectionId));
+
+      // Stop crashing reader Instance2 and Instance3
+      final String readerAId =
+          TestEnvironment.getCurrent()
+              .getInfo()
+              .getProxyDatabaseInfo()
+              .getInstances()
+              .get(1)
+              .getInstanceName();
+      ProxyHelper.enableConnectivity(readerAId);
+
+      final String readerBId =
+          TestEnvironment.getCurrent()
+              .getInfo()
+              .getProxyDatabaseInfo()
+              .getInstances()
+              .get(2)
+              .getInstanceName();
+      ProxyHelper.enableConnectivity(readerBId);
+
+      // Crash writer Instance1.
+      auroraUtil.failoverClusterToATargetAndWaitUntilWriterChanged(writerId, readerBId);
+
+      assertFirstQueryThrows(conn, SqlState.COMMUNICATION_LINK_CHANGED.getState());
+
+      // Assert that we are connected to one of the available instances.
+      currentConnectionId = auroraUtil.queryInstanceId(conn);
+      assertTrue(readerAId.equals(currentConnectionId) || readerBId.equals(currentConnectionId));
+    }
+  }
+
+  /* Failure when within a transaction tests. */
+
+  /** Writer fails within a transaction. Open transaction with setAutoCommit(false) */
+  @TestTemplate
+  public void test_writerFailWithinTransaction_setAutoCommitFalse()
+      throws SQLException, InterruptedException {
+
+    final String initialWriterId = this.currentWriter;
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(initialWriterId);
+
+    final Properties props = initDefaultProps();
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                initialWriterInstanceInfo.getEndpoint(),
+                initialWriterInstanceInfo.getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      final Statement testStmt1 = conn.createStatement();
+      testStmt1.executeUpdate("DROP TABLE IF EXISTS test3_2");
+      testStmt1.executeUpdate(
+          "CREATE TABLE test3_2 (id int not null primary key, test3_2_field varchar(255) not null)");
+      conn.setAutoCommit(false); // open a new transaction
+
+      final Statement testStmt2 = conn.createStatement();
+      testStmt2.executeUpdate("INSERT INTO test3_2 VALUES (1, 'test field string 1')");
+
+      auroraUtil.failoverClusterAndWaitUntilWriterChanged(initialWriterId);
+
+      // If there is an active transaction, roll it back and return an error with SQLState 08007.
+      final SQLException exception =
+          assertThrows(
+              SQLException.class,
+              () ->
+                  testStmt2.executeUpdate("INSERT INTO test3_2 VALUES (2, 'test field string 2')"));
+      assertEquals(
+          SqlState.CONNECTION_FAILURE_DURING_TRANSACTION.getState(), exception.getSQLState());
+
+      // Attempt to query the instance id.
+      final String currentConnectionId = auroraUtil.queryInstanceId(conn);
+      // Assert that we are connected to the new writer after failover happens.
+      assertTrue(auroraUtil.isDBInstanceWriter(currentConnectionId));
+      final String nextClusterWriterId = auroraUtil.getDBClusterWriterInstanceId();
+      assertEquals(currentConnectionId, nextClusterWriterId);
+      assertNotEquals(initialWriterId, nextClusterWriterId);
+
+      // testStmt2 can NOT be used anymore since it's invalid
+
+      final Statement testStmt3 = conn.createStatement();
+      final ResultSet rs = testStmt3.executeQuery("SELECT count(*) from test3_2");
+      rs.next();
+      // Assert that NO row has been inserted to the table;
+      assertEquals(0, rs.getInt(1));
+
+      testStmt3.executeUpdate("DROP TABLE IF EXISTS test3_2");
+    }
+  }
+
+  /** Writer fails within a transaction. Open transaction with "START TRANSACTION". */
+  @TestTemplate
+  public void test_writerFailWithinTransaction_startTransaction()
+      throws SQLException, InterruptedException {
+
+    final String initialWriterId = this.currentWriter;
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(initialWriterId);
+
+    final Properties props = initDefaultProps();
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                initialWriterInstanceInfo.getEndpoint(),
+                initialWriterInstanceInfo.getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      final Statement testStmt1 = conn.createStatement();
+      testStmt1.executeUpdate("DROP TABLE IF EXISTS test3_3");
+      testStmt1.executeUpdate(
+          "CREATE TABLE test3_3 (id int not null primary key, test3_3_field varchar(255) not null)");
+      testStmt1.executeUpdate("START TRANSACTION"); // open a new transaction
+
+      final Statement testStmt2 = conn.createStatement();
+      testStmt2.executeUpdate("INSERT INTO test3_3 VALUES (1, 'test field string 1')");
+
+      auroraUtil.failoverClusterAndWaitUntilWriterChanged(initialWriterId);
+
+      // If there is an active transaction, roll it back and return an error with SQLState 08007.
+      final SQLException exception =
+          assertThrows(
+              SQLException.class,
+              () ->
+                  testStmt2.executeUpdate("INSERT INTO test3_3 VALUES (2, 'test field string 2')"));
+      assertEquals(
+          SqlState.CONNECTION_FAILURE_DURING_TRANSACTION.getState(), exception.getSQLState());
+
+      // Attempt to query the instance id.
+      final String currentConnectionId = auroraUtil.queryInstanceId(conn);
+      // Assert that we are connected to the new writer after failover happens.
+      assertTrue(auroraUtil.isDBInstanceWriter(currentConnectionId));
+      final String nextClusterWriterId = auroraUtil.getDBClusterWriterInstanceId();
+      assertEquals(currentConnectionId, nextClusterWriterId);
+      assertNotEquals(initialWriterId, nextClusterWriterId);
+
+      // testStmt2 can NOT be used anymore since it's invalid
+
+      final Statement testStmt3 = conn.createStatement();
+      final ResultSet rs = testStmt3.executeQuery("SELECT count(*) from test3_3");
+      rs.next();
+      // Assert that NO row has been inserted to the table;
+      assertEquals(0, rs.getInt(1));
+
+      testStmt3.executeUpdate("DROP TABLE IF EXISTS test3_3");
+    }
+  }
+
+  /** Writer fails within NO transaction. */
+  @TestTemplate
+  public void test_writerFailWithNoTransaction() throws SQLException, InterruptedException {
+
+    final String initialWriterId = this.currentWriter;
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(initialWriterId);
+
+    final Properties props = initDefaultProps();
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                initialWriterInstanceInfo.getEndpoint(),
+                initialWriterInstanceInfo.getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      final Statement testStmt1 = conn.createStatement();
+      testStmt1.executeUpdate("DROP TABLE IF EXISTS test3_4");
+      testStmt1.executeUpdate(
+          "CREATE TABLE test3_4 (id int not null primary key, test3_4_field varchar(255) not null)");
+
+      final Statement testStmt2 = conn.createStatement();
+      testStmt2.executeUpdate("INSERT INTO test3_4 VALUES (1, 'test field string 1')");
+
+      auroraUtil.failoverClusterAndWaitUntilWriterChanged(initialWriterId);
+
+      final SQLException exception =
+          assertThrows(
+              SQLException.class,
+              () ->
+                  testStmt2.executeUpdate("INSERT INTO test3_4 VALUES (2, 'test field string 2')"));
+      assertEquals(SqlState.COMMUNICATION_LINK_CHANGED.getState(), exception.getSQLState());
+
+      // Attempt to query the instance id.
+      final String currentConnectionId = auroraUtil.queryInstanceId(conn);
+      // Assert that we are connected to the new writer after failover happens.
+      assertTrue(auroraUtil.isDBInstanceWriter(currentConnectionId));
+      final String nextClusterWriterId = auroraUtil.getDBClusterWriterInstanceId();
+      assertEquals(currentConnectionId, nextClusterWriterId);
+      assertNotEquals(initialWriterId, nextClusterWriterId);
+
+      // testStmt2 can NOT be used anymore since it's invalid
+      final Statement testStmt3 = conn.createStatement();
+      final ResultSet rs = testStmt3.executeQuery("SELECT count(*) from test3_4 WHERE id = 1");
+      rs.next();
+      // Assert that row with id=1 has been inserted to the table;
+      assertEquals(1, rs.getInt(1));
+
+      final ResultSet rs1 = testStmt3.executeQuery("SELECT count(*) from test3_4 WHERE id = 2");
+      rs1.next();
+      // Assert that row with id=2 has NOT been inserted to the table;
+      assertEquals(0, rs1.getInt(1));
+
+      testStmt3.executeUpdate("DROP TABLE IF EXISTS test3_4");
+    }
+  }
+
+  @TestTemplate
+  public void test_DataSourceWriterConnection_BasicFailover()
+      throws SQLException, InterruptedException {
+
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstances().get(0);
+    TestInstanceInfo nominatedWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstances().get(1);
+    final String nominatedWriterId = nominatedWriterInstanceInfo.getInstanceName();
+
+    try (final Connection conn =
+        createDataSourceConnectionWithFailoverUsingInstanceId(
+            initialWriterInstanceInfo.getEndpoint())) {
+
+      // Crash writer Instance1 and nominate Instance2 as the new writer
+      auroraUtil.failoverClusterToATargetAndWaitUntilWriterChanged(
+          initialWriterInstanceInfo.getInstanceName(), nominatedWriterId);
+
+      assertFirstQueryThrows(conn, SqlState.COMMUNICATION_LINK_CHANGED.getState());
+
+      // Execute Query again to get the current connection id;
+      final String currentConnectionId = auroraUtil.queryInstanceId(conn);
+
+      // Assert that we are connected to the new writer after failover happens.
+      final String nextWriterId = auroraUtil.getDBClusterWriterInstanceId();
+      assertEquals(nextWriterId, currentConnectionId);
+      assertEquals(nominatedWriterId, currentConnectionId);
+
+      assertTrue(conn.isValid(IS_VALID_TIMEOUT));
+    }
+  }
+
+  @TestTemplate
+  @EnableOnTestDriver(TestDriver.MYSQL)
+  public void test_takeOverConnectionProperties() throws SQLException, InterruptedException {
+    final String initialWriterId = this.currentWriter;
+
+    final Properties props = initDefaultProps();
+    props.setProperty(PropertyKey.allowMultiQueries.getKeyName(), "false");
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    // Establish the topology cache so that we can later assert that testConnection does not inherit
+    // properties from
+    // establishCacheConnection either before or after failover
+    final Connection establishCacheConnection =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props);
+    establishCacheConnection.close();
+
+    props.setProperty(PropertyKey.allowMultiQueries.getKeyName(), "true");
+
+    try (final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props)) {
+
+      // Verify that connection accepts multi-statement sql
+      final Statement testStmt1 = conn.createStatement();
+      testStmt1.executeQuery("select 1; select 2; select 3;");
+
+      // Crash Instance1 and nominate a new writer
+      auroraUtil.failoverClusterAndWaitUntilWriterChanged(initialWriterId);
+
+      assertFirstQueryThrows(conn, SqlState.COMMUNICATION_LINK_CHANGED.getState());
+
+      // Assert that the connection property is maintained.
+      final Statement testStmt2 = conn.createStatement();
+      testStmt2.executeQuery("select 1; select 2; select 3;");
+    }
+  }
+
+  @TestTemplate
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_failoverTimeoutMs() throws SQLException {
+    final int maxTimeout = 10000; // 10 seconds
+
+    final String initialWriterId = this.currentWriter;
+    TestInstanceInfo initialWriterInstanceInfo =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstance(initialWriterId);
+
+    final Properties props = initDefaultProxiedProps();
+    FailoverConnectionPlugin.FAILOVER_TIMEOUT_MS.set(props, String.valueOf(maxTimeout));
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+
+    try (final Connection conn =
+            DriverManager.getConnection(
+                ConnectionStringHelper.getWrapperUrl(
+                    initialWriterInstanceInfo.getEndpoint(),
+                    initialWriterInstanceInfo.getEndpointPort(),
+                    TestEnvironment.getCurrent()
+                        .getInfo()
+                        .getProxyDatabaseInfo()
+                        .getDefaultDbName()),
+                props);
+        Statement stmt = conn.createStatement()) {
+
+      ProxyHelper.disableConnectivity(initialWriterId);
+
+      final long invokeStartTimeMs = System.currentTimeMillis();
+      final SQLException e = assertThrows(SQLException.class, () -> stmt.executeQuery("SELECT 1"));
+      final long invokeEndTimeMs = System.currentTimeMillis();
+
+      assertEquals(SqlState.CONNECTION_UNABLE_TO_CONNECT.getState(), e.getSQLState());
+
+      final long duration = invokeEndTimeMs - invokeStartTimeMs;
+      assertTrue(duration < 15000); // Add in 5 seconds to account for time to detect the failure
+    }
+  }
+
+  // Helper methods below
+
+  protected Properties initDefaultProps() {
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "failover");
+    return props;
+  }
+
+  protected Properties initDefaultProxiedProps() {
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "failover");
+    AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(
+        props,
+        "?."
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getProxyDatabaseInfo()
+                .getInstanceEndpointPrefix());
+    return props;
+  }
+
+  // Attempt to run a query after the instance is down.
+  // This should initiate the driver failover, first query after a failover
+  // should always throw with the expected error message.
+  protected void assertFirstQueryThrows(Connection connection, String expectedSQLErrorCode) {
+    final SQLException exception =
+        assertThrows(
+            SQLException.class,
+            () ->
+                auroraUtil.queryInstanceId(
+                    TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+                    connection));
+    assertEquals(expectedSQLErrorCode, exception.getSQLState());
+  }
+
+  protected void assertFirstQueryThrows(Statement stmt, String expectedSQLErrorCode) {
+    final SQLException exception =
+        assertThrows(
+            SQLException.class,
+            () ->
+                auroraUtil.executeInstanceIdQuery(
+                    TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), stmt));
+    assertEquals(
+        expectedSQLErrorCode,
+        exception.getSQLState(),
+        "Unexpected SQL Exception: " + exception.getMessage());
+  }
+
+  protected Connection createDataSourceConnectionWithFailoverUsingInstanceId(
+      String instanceEndpoint) throws SQLException {
+
+    AwsWrapperDataSource ds = new AwsWrapperDataSource();
+
+    // Configure the property names for the underlying driver-specific data source:
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setDatabasePropertyName("databaseName");
+    ds.setServerPropertyName("serverName");
+    ds.setPortPropertyName("port");
+    ds.setUrlPropertyName("url");
+
+    // Specify the driver-specific data source:
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    // Configure the driver-specific data source:
+    Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty("serverName", instanceEndpoint);
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty("wrapperPlugins", "failover");
+
+    if (TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MARIADB
+        && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
+            == DatabaseEngine.MYSQL) {
+      // Connecting to Mysql database with MariaDb driver requires a configuration parameter
+      // "permitMysqlScheme"
+      targetDataSourceProps.setProperty("permitMysqlScheme", "1");
+    }
+
+    DriverHelper.setConnectTimeout(targetDataSourceProps, 3, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(targetDataSourceProps, 3, TimeUnit.SECONDS);
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    return ds.getConnection(
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/AwsIamIntegrationTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AwsIamIntegrationTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestDriver;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import integration.refactored.container.condition.EnableOnTestFeature;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.ds.AwsWrapperDataSource;
+import software.amazon.jdbc.plugin.IamAuthConnectionPlugin;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnTestFeature(TestEnvironmentFeatures.IAM)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+// MariaDb driver has no configuration parameters to force using 'mysql_clear_password'
+// authentication that is essential for IAM. A proper user name and IAM token are passed to MariaDb
+// driver however 'mysql_native_password' authentication is chosen by default.
+// 'mysql_native_password' authentication sends a password (IAM token in this case) hash,
+// rather than a clear password, to a DB server and that leads to 'Access denied' error.
+// So taking that into account, all IAM tests are disabled for MariaDb driver.
+public class AwsIamIntegrationTest {
+
+  private static final Logger LOGGER = Logger.getLogger(AwsIamIntegrationTest.class.getName());
+
+  @BeforeEach
+  public void beforeEach() {
+    IamAuthConnectionPlugin.clearCache();
+  }
+
+  /** Attempt to connect using the wrong database username. */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_AwsIam_WrongDatabaseUsername() {
+    final Properties props =
+        initAwsIamProps(
+            "WRONG_"
+                + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername()
+                + "_USER",
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    Assertions.assertThrows(
+        SQLException.class,
+        () -> DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props));
+  }
+
+  /** Attempt to connect without specifying a database username. */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_AwsIam_NoDatabaseUsername() {
+    final Properties props =
+        initAwsIamProps("", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    Assertions.assertThrows(
+        SQLException.class,
+        () -> DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props));
+  }
+
+  /** Attempt to connect using IP address instead of a hostname. */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_AwsIam_UsingIPAddress() throws UnknownHostException, SQLException {
+    final Properties props =
+        initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "<anything>");
+
+    final String hostIp =
+        hostToIP(
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint());
+    props.setProperty(
+        "iamHost",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+
+    final Connection conn =
+        DriverManager.getConnection(
+            ConnectionStringHelper.getWrapperUrl(
+                hostIp,
+                TestEnvironment.getCurrent()
+                    .getInfo()
+                    .getDatabaseInfo()
+                    .getInstances()
+                    .get(0)
+                    .getEndpointPort(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()),
+            props);
+    Assertions.assertDoesNotThrow(conn::close);
+  }
+
+  /** Attempt to connect using valid database username/password & valid Amazon RDS hostname. */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_AwsIam_ValidConnectionProperties() throws SQLException {
+    final Properties props =
+        initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "<anything>");
+
+    final Connection conn =
+        DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+    conn.close();
+  }
+
+  /**
+   * Attempt to connect using valid database username, valid Amazon RDS hostname, but no password.
+   */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void test_AwsIam_ValidConnectionPropertiesNoPassword() throws SQLException {
+    final Properties props =
+        initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "");
+    final Connection conn =
+        DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+    conn.close();
+  }
+
+  /**
+   * Attempts a valid connection followed by invalid connection without the AWS protocol in
+   * Connection URL.
+   */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  void test_AwsIam_NoAwsProtocolConnection() throws SQLException {
+    final String dbConn = ConnectionStringHelper.getWrapperUrl();
+    final Properties validProp =
+        initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "<anything>");
+
+    final Connection conn = DriverManager.getConnection(dbConn, validProp);
+    conn.close();
+
+    final Properties invalidProp =
+        initAwsIamProps(
+            "WRONG_" + TestEnvironment.getCurrent().getInfo().getIamUsername() + "_USER",
+            "<anything>");
+
+    Assertions.assertThrows(
+        SQLException.class, () -> DriverManager.getConnection(dbConn, invalidProp));
+  }
+
+  /**
+   * Attempts a valid connection followed by an invalid connection with Username in Connection URL.
+   */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  void test_AwsIam_UserInConnStr() throws SQLException {
+    final String dbConn = ConnectionStringHelper.getWrapperUrl();
+    final Properties awsIamProp =
+        initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "<anything>");
+    awsIamProp.remove(PropertyDefinition.USER.name);
+
+    final Connection validConn =
+        DriverManager.getConnection(
+            dbConn
+                + (dbConn.contains("?") ? "&" : "?")
+                + PropertyDefinition.USER.name
+                + "="
+                + TestEnvironment.getCurrent().getInfo().getIamUsername(),
+            awsIamProp);
+    Assertions.assertNotNull(validConn);
+    Assertions.assertThrows(
+        SQLException.class,
+        () ->
+            DriverManager.getConnection(
+                dbConn
+                    + (dbConn.contains("?") ? "&" : "?")
+                    + PropertyDefinition.USER.name
+                    + "="
+                    + "WRONG_"
+                    + TestEnvironment.getCurrent().getInfo().getIamUsername(),
+                awsIamProp));
+  }
+
+  /**
+   * Attempts a valid connection with a datasource and makes sure that the user and password
+   * properties persist.
+   */
+  @TestTemplate
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  void test_AwsIam_UserAndPasswordPropertiesArePreserved() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties props =
+        initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "<anything>");
+    props.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint());
+    props.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(props);
+
+    try (final Connection conn = ds.getConnection()) {
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  protected Properties initAwsIamProps(String user, String password) {
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "iam");
+    props.setProperty(PropertyDefinition.USER.name, user);
+    props.setProperty(PropertyDefinition.PASSWORD.name, password);
+    DriverHelper.setTcpKeepAlive(TestEnvironment.getCurrent().getCurrentDriver(), props, false);
+    return props;
+  }
+
+  protected String hostToIP(String hostname) throws UnknownHostException {
+    final InetAddress inet = InetAddress.getByName(hostname);
+    return inet.getHostAddress();
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.TestInstanceInfo;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.ProxyHelper;
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import integration.refactored.container.condition.EnableOnTestFeature;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.util.StringUtils;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class BasicConnectivityTests {
+
+  private static final Logger LOGGER = Logger.getLogger(BasicConnectivityTests.class.getName());
+
+  @TestTemplate
+  @ExtendWith(TestDriverProvider.class)
+  public void test_DirectConnection(TestDriver testDriver) throws SQLException {
+    LOGGER.info(testDriver.toString());
+
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+
+    String url =
+        ConnectionStringHelper.getUrl(
+            testDriver,
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint(),
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    LOGGER.finest("Connecting to " + url);
+
+    final Connection conn = DriverManager.getConnection(url, props);
+    assertTrue(conn.isValid(5));
+
+    Statement stmt = conn.createStatement();
+    stmt.executeQuery("SELECT 1");
+    ResultSet rs = stmt.getResultSet();
+    rs.next();
+    assertEquals(1, rs.getInt(1));
+
+    conn.close();
+  }
+
+  @TestTemplate
+  @ExtendWith(TestDriverProvider.class)
+  public void test_WrapperConnection(TestDriver testDriver) throws SQLException {
+    LOGGER.info(testDriver.toString());
+
+    final Properties props = new Properties();
+    props.setProperty(
+        PropertyDefinition.USER.name,
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    props.setProperty(
+        PropertyDefinition.PASSWORD.name,
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+
+    String url =
+        ConnectionStringHelper.getWrapperUrl(
+            testDriver,
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint(),
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    LOGGER.finest("Connecting to " + url);
+
+    final Connection conn = DriverManager.getConnection(url, props);
+    assertTrue(conn.isValid(5));
+
+    Statement stmt = conn.createStatement();
+    stmt.executeQuery("SELECT 1");
+    ResultSet rs = stmt.getResultSet();
+    rs.next();
+    assertEquals(1, rs.getInt(1));
+
+    conn.close();
+  }
+
+  @TestTemplate
+  @ExtendWith(TestDriverProvider.class)
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_ProxiedDirectConnection(TestDriver testDriver) throws SQLException {
+    LOGGER.info(testDriver.toString());
+
+    final Properties props = new Properties();
+    props.setProperty(
+        PropertyDefinition.USER.name,
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getUsername());
+    props.setProperty(
+        PropertyDefinition.PASSWORD.name,
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getPassword());
+    DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+
+    TestInstanceInfo instanceInfo =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(0);
+
+    String url =
+        ConnectionStringHelper.getUrl(
+            testDriver,
+            instanceInfo.getEndpoint(),
+            instanceInfo.getEndpointPort(),
+            TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getDefaultDbName());
+    LOGGER.finest("Connecting to " + url);
+
+    final Connection conn = DriverManager.getConnection(url, props);
+    assertTrue(conn.isValid(5));
+
+    Statement stmt = conn.createStatement();
+    stmt.executeQuery("SELECT 1");
+    ResultSet rs = stmt.getResultSet();
+    rs.next();
+    assertEquals(1, rs.getInt(1));
+
+    ProxyHelper.disableConnectivity(instanceInfo.getInstanceName());
+
+    assertFalse(conn.isValid(5));
+
+    ProxyHelper.enableConnectivity(instanceInfo.getInstanceName());
+
+    conn.close();
+  }
+
+  @TestTemplate
+  @ExtendWith(TestDriverProvider.class)
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_ProxiedWrapperConnection() throws SQLException {
+    LOGGER.info(TestEnvironment.getCurrent().getCurrentDriver().toString());
+
+    final Properties props = new Properties();
+    props.setProperty(
+        PropertyDefinition.USER.name,
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getUsername());
+    props.setProperty(
+        PropertyDefinition.PASSWORD.name,
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getPassword());
+    DriverHelper.setConnectTimeout(props, 10, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 10, TimeUnit.SECONDS);
+
+    TestInstanceInfo instanceInfo =
+        TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(0);
+
+    String url =
+        ConnectionStringHelper.getWrapperUrl(
+            instanceInfo.getEndpoint(),
+            instanceInfo.getEndpointPort(),
+            TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getDefaultDbName());
+    LOGGER.finest("Connecting to " + url);
+
+    final Connection conn = DriverManager.getConnection(url, props);
+    assertTrue(conn.isValid(5));
+
+    Statement stmt = conn.createStatement();
+    stmt.executeQuery("SELECT 1");
+    ResultSet rs = stmt.getResultSet();
+    rs.next();
+    assertEquals(1, rs.getInt(1));
+
+    ProxyHelper.disableConnectivity(instanceInfo.getInstanceName());
+
+    assertFalse(conn.isValid(5));
+
+    ProxyHelper.enableConnectivity(instanceInfo.getInstanceName());
+
+    conn.close();
+  }
+
+  @TestTemplate
+  @ExtendWith(TestDriverProvider.class)
+  public void testSuccessOpenConnectionNoPort() throws SQLException {
+    String url =
+        DriverHelper.getWrapperDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + DriverHelper.getDriverRequiredParameters();
+
+    LOGGER.finest("Connecting to " + url);
+
+    try (Connection conn =
+        DriverManager.getConnection(url, ConnectionStringHelper.getDefaultProperties())) {
+
+      assertTrue(conn instanceof ConnectionWrapper);
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("testConnectionParameters")
+  public void testFailedConnection(TestDriver testDriver, String url) throws SQLException {
+    DriverHelper.unregisterAllDrivers();
+    DriverHelper.registerDriver(testDriver);
+    TestEnvironment.getCurrent().setCurrentDriver(testDriver);
+
+    LOGGER.finest("Connecting to " + url);
+
+    assertThrows(
+        SQLException.class,
+        () -> {
+          Connection conn =
+              DriverManager.getConnection(url, ConnectionStringHelper.getDefaultProperties());
+          conn.close();
+        });
+  }
+
+  @ParameterizedTest
+  @MethodSource("testPropertiesParameters")
+  public void testFailedProperties(
+      TestDriver testDriver, String url, String username, String password) throws SQLException {
+    DriverHelper.unregisterAllDrivers();
+    DriverHelper.registerDriver(testDriver);
+    TestEnvironment.getCurrent().setCurrentDriver(testDriver);
+
+    if (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
+            == DatabaseEngine.MARIADB
+        && TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MARIADB
+        && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment()
+            == DatabaseEngineDeployment.DOCKER
+        && StringUtils.isNullOrEmpty(username)) {
+      // MariaDb driver uses "root" username if no username is provided. Since MariaDb database in
+      // docker container
+      // has "root" user by default (the password is the same), the test always passes and makes no
+      // sense.
+      // Skip this test.
+      return;
+    }
+
+    final Properties props = new Properties();
+    props.setProperty(PropertyDefinition.USER.name, username);
+    props.setProperty(PropertyDefinition.PASSWORD.name, password);
+
+    LOGGER.finest("Connecting to " + url);
+
+    assertThrows(
+        SQLException.class,
+        () -> {
+          Connection conn = DriverManager.getConnection(url, props);
+          conn.close();
+        });
+  }
+
+  protected static String buildConnectionString(
+      String connStringPrefix,
+      String host,
+      String port,
+      String databaseName,
+      String requiredParameters) {
+    return connStringPrefix + host + ":" + port + "/" + databaseName + requiredParameters;
+  }
+
+  private static Stream<Arguments> testConnectionParameters() {
+    ArrayList<Arguments> results = new ArrayList<>();
+    for (TestDriver testDriver : TestEnvironment.getCurrent().getAllowedTestDrivers()) {
+
+      // missing connection prefix
+      results.add(
+          Arguments.of(
+              testDriver,
+              buildConnectionString(
+                  "",
+                  TestEnvironment.getCurrent()
+                      .getInfo()
+                      .getDatabaseInfo()
+                      .getInstances()
+                      .get(0)
+                      .getEndpoint(),
+                  String.valueOf(
+                      TestEnvironment.getCurrent()
+                          .getInfo()
+                          .getDatabaseInfo()
+                          .getInstances()
+                          .get(0)
+                          .getEndpointPort()),
+                  TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName(),
+                  DriverHelper.getDriverRequiredParameters(testDriver))));
+
+      // incorrect database name
+      results.add(
+          Arguments.of(
+              testDriver,
+              buildConnectionString(
+                  DriverHelper.getWrapperDriverProtocol(testDriver),
+                  TestEnvironment.getCurrent()
+                      .getInfo()
+                      .getDatabaseInfo()
+                      .getInstances()
+                      .get(0)
+                      .getEndpoint(),
+                  String.valueOf(
+                      TestEnvironment.getCurrent()
+                          .getInfo()
+                          .getDatabaseInfo()
+                          .getInstances()
+                          .get(0)
+                          .getEndpointPort()),
+                  "failedDatabaseNameTest",
+                  DriverHelper.getDriverRequiredParameters(testDriver))));
+    }
+    return results.stream();
+  }
+
+  private static Stream<Arguments> testPropertiesParameters() {
+    ArrayList<Arguments> results = new ArrayList<>();
+    for (TestDriver testDriver : TestEnvironment.getCurrent().getAllowedTestDrivers()) {
+
+      // missing username
+      results.add(
+          Arguments.of(
+              testDriver,
+              buildConnectionString(
+                  DriverHelper.getWrapperDriverProtocol(testDriver),
+                  TestEnvironment.getCurrent()
+                      .getInfo()
+                      .getDatabaseInfo()
+                      .getInstances()
+                      .get(0)
+                      .getEndpoint(),
+                  String.valueOf(
+                      TestEnvironment.getCurrent()
+                          .getInfo()
+                          .getDatabaseInfo()
+                          .getInstances()
+                          .get(0)
+                          .getEndpointPort()),
+                  TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName(),
+                  DriverHelper.getDriverRequiredParameters(testDriver)),
+              "",
+              TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+
+      // missing password
+      results.add(
+          Arguments.of(
+              testDriver,
+              buildConnectionString(
+                  DriverHelper.getWrapperDriverProtocol(testDriver),
+                  TestEnvironment.getCurrent()
+                      .getInfo()
+                      .getDatabaseInfo()
+                      .getInstances()
+                      .get(0)
+                      .getEndpoint(),
+                  String.valueOf(
+                      TestEnvironment.getCurrent()
+                          .getInfo()
+                          .getDatabaseInfo()
+                          .getInstances()
+                          .get(0)
+                          .getEndpointPort()),
+                  TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName(),
+                  DriverHelper.getDriverRequiredParameters(testDriver)),
+              TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+              ""));
+    }
+    return results.stream();
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/DataCachePluginTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/DataCachePluginTests.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.MakeSureFirstInstanceWriterExtension;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.DataCacheConnectionPlugin;
+import software.amazon.jdbc.plugin.DataCacheConnectionPlugin.CachedResultSet;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@ExtendWith(MakeSureFirstInstanceWriterExtension.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class DataCachePluginTests {
+
+  private static final Logger LOGGER = Logger.getLogger(DataCachePluginTests.class.getName());
+
+  @BeforeEach
+  public void beforeEach() {
+    DataCacheConnectionPlugin.clearCache();
+  }
+
+  @TestTemplate
+  public void testQueryCacheable() throws SQLException {
+
+    DataCacheConnectionPlugin.clearCache();
+
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    DriverHelper.setConnectTimeout(props, 30, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 30, TimeUnit.SECONDS);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "dataCache");
+    props.setProperty(DataCacheConnectionPlugin.DATA_CACHE_TRIGGER_CONDITION.name, ".*testTable.*");
+
+    Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+
+    conn.createStatement().execute("drop table if exists testTable");
+    conn.createStatement().execute("create table testTable (id int not null, name varchar(100))");
+    conn.createStatement().execute("insert into testTable (id, name) values (1, 'name1')");
+    conn.createStatement().execute("insert into testTable (id, name) values (2, 'name2')");
+    conn.createStatement().execute("insert into testTable (id, name) values (3, 'name3')");
+
+    printTable();
+
+    Statement statement = conn.createStatement();
+    ResultSet resultSet = statement.executeQuery("select id, name from testTable");
+    assertTrue(resultSet.next());
+    assertEquals(1, resultSet.getObject(1));
+    assertEquals("name1", resultSet.getObject(2));
+    assertTrue(resultSet.next());
+    assertEquals(2, resultSet.getObject(1));
+    assertEquals("name2", resultSet.getObject(2));
+    assertTrue(resultSet.next());
+    assertEquals(3, resultSet.getObject(1));
+    assertEquals("name3", resultSet.getObject(2));
+
+    assertFalse(resultSet.next()); // no more data
+
+    conn.createStatement().execute("update testTable set id=id*10");
+    conn.createStatement().execute("update testTable set name=concat('name', id)");
+
+    // Actual data in the database table
+    // 10, "name10"
+    // 20, "name20"
+    // 30, "name30"
+
+    printTable();
+
+    Statement testStatement = conn.createStatement();
+    ResultSet testResultSet = testStatement.executeQuery("select id, name from testTable");
+    assertTrue(testResultSet.isWrapperFor(CachedResultSet.class));
+
+    // It's expected to get cached data
+    assertTrue(resultSet.next());
+    assertEquals(1, resultSet.getObject(1));
+    assertEquals("name1", resultSet.getObject(2));
+    assertTrue(resultSet.next());
+    assertEquals(2, resultSet.getObject(1));
+    assertEquals("name2", resultSet.getObject(2));
+    assertTrue(resultSet.next());
+    assertEquals(3, resultSet.getObject(1));
+    assertEquals("name3", resultSet.getObject(2));
+
+    printTable();
+
+    // The following SQL statement isn't in the cache so data is fetched from DB
+    Statement statementFromDb = conn.createStatement();
+    ResultSet resultSetFromDb =
+        statementFromDb.executeQuery("select id, name from testTable where id > 0");
+    assertTrue(resultSetFromDb.next());
+    assertEquals(10, resultSetFromDb.getObject(1));
+    assertEquals("name10", resultSetFromDb.getObject(2));
+    assertTrue(resultSetFromDb.next());
+    assertEquals(20, resultSetFromDb.getObject(1));
+    assertEquals("name20", resultSetFromDb.getObject(2));
+    assertTrue(resultSetFromDb.next());
+    assertEquals(30, resultSetFromDb.getObject(1));
+    assertEquals("name30", resultSetFromDb.getObject(2));
+
+    conn.close();
+  }
+
+  private void printTable() {
+    LOGGER.finest(
+        () -> {
+          try {
+            final Properties props = ConnectionStringHelper.getDefaultProperties();
+            Connection conn = DriverManager.getConnection(ConnectionStringHelper.getUrl(), props);
+            Statement statementFromDb = conn.createStatement();
+            ResultSet resultSetFromDb =
+                statementFromDb.executeQuery("select id, name from testTable where id > 0");
+            StringBuilder sb = new StringBuilder("Table content:");
+            boolean hasData = false;
+            while (resultSetFromDb.next()) {
+              hasData = true;
+              sb.append("\n\t")
+                  .append(resultSetFromDb.getObject(1))
+                  .append(", ")
+                  .append(resultSetFromDb.getObject(2));
+            }
+            if (!hasData) {
+              sb.append("\n\t<No data>");
+            }
+            conn.close();
+            return sb.toString();
+
+          } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+          }
+        });
+  }
+
+  @TestTemplate
+  public void testQueryNotCacheable() throws SQLException {
+
+    DataCacheConnectionPlugin.clearCache();
+
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    DriverHelper.setConnectTimeout(props, 30, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 30, TimeUnit.SECONDS);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "dataCache");
+    props.setProperty(
+        DataCacheConnectionPlugin.DATA_CACHE_TRIGGER_CONDITION.name, ".*WRONG_EXPRESSION.*");
+
+    Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+
+    conn.createStatement().execute("drop table if exists testTable");
+    conn.createStatement().execute("create table testTable (id int not null, name varchar(100))");
+    conn.createStatement().execute("insert into testTable (id, name) values (1, 'name1')");
+    conn.createStatement().execute("insert into testTable (id, name) values (2, 'name2')");
+    conn.createStatement().execute("insert into testTable (id, name) values (3, 'name3')");
+
+    printTable();
+
+    Statement statement = conn.createStatement();
+    ResultSet resultSet = statement.executeQuery("select id, name from testTable");
+    assertTrue(resultSet.next());
+    assertEquals(1, resultSet.getObject(1));
+    assertEquals("name1", resultSet.getObject(2));
+    assertTrue(resultSet.next());
+    assertEquals(2, resultSet.getObject(1));
+    assertEquals("name2", resultSet.getObject(2));
+    assertTrue(resultSet.next());
+    assertEquals(3, resultSet.getObject(1));
+    assertEquals("name3", resultSet.getObject(2));
+
+    assertFalse(resultSet.next()); // no more data
+
+    conn.createStatement().execute("update testTable set id=id*10");
+    conn.createStatement().execute("update testTable set name=concat('name', id)");
+
+    // Actual data in the database table
+    // 10, "name10"
+    // 20, "name20"
+    // 30, "name30"
+
+    printTable();
+
+    Statement testStatement = conn.createStatement();
+    ResultSet testResultSet = testStatement.executeQuery("select id, name from testTable");
+    assertFalse(testResultSet.isWrapperFor(CachedResultSet.class));
+
+    // It's expected to get cached data
+    assertTrue(testResultSet.next());
+    assertEquals(10, testResultSet.getObject(1));
+    assertEquals("name10", testResultSet.getObject(2));
+    assertTrue(testResultSet.next());
+    assertEquals(20, testResultSet.getObject(1));
+    assertEquals("name20", testResultSet.getObject(2));
+    assertTrue(testResultSet.next());
+    assertEquals(30, testResultSet.getObject(1));
+    assertEquals("name30", testResultSet.getObject(2));
+
+    conn.close();
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
@@ -1,0 +1,874 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestDriver;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import integration.refactored.container.condition.EnableOnTestDriver;
+import integration.util.SimpleJndiContextFactory;
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Hashtable;
+import java.util.Properties;
+import java.util.logging.Logger;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.ds.AwsWrapperDataSource;
+import software.amazon.jdbc.util.StringUtils;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class DataSourceTests {
+
+  private static final Logger LOGGER = Logger.getLogger(DataSourceTests.class.getName());
+
+  @TestTemplate
+  public void testConnectionWithDataSourceClassNameAndUrl() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setUrlPropertyName("url");
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    try (final Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn instanceof ConnectionWrapper);
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  public void testConnectionWithUrl() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcUrl(ConnectionStringHelper.getUrl());
+
+    try (final Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn instanceof ConnectionWrapper);
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameAndServerName() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    try (final Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameAndCredentialProperties() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(
+        "user", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    targetDataSourceProps.setProperty(
+        "password", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    try (final Connection conn = ds.getConnection()) {
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  // @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameMissingProtocol() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  public void testConnectionWithDataSourceClassNameMissingServer() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  // Database is optional for Mysql database.
+  // See next test: testConnectionWithDataSourceClassNameMissingDatabase_MysqlDriver
+  @DisableOnTestDriver({TestDriver.MARIADB, TestDriver.MYSQL})
+  public void testConnectionWithDataSourceClassNameMissingDatabase() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  @EnableOnTestDriver(TestDriver.MYSQL)
+  public void testConnectionWithDataSourceClassNameMissingDatabase_MysqlDriver()
+      throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    conn.close();
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameMissingUser() {
+
+    if (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment()
+            == DatabaseEngineDeployment.DOCKER
+        && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
+            == DatabaseEngine.MYSQL
+        && TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MYSQL) {
+      // Mysql database in docker container uses "root" user (with the same password)
+      // if not user provided and the test always passes. The test makes no sense.
+      return;
+    }
+
+    if (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment()
+            == DatabaseEngineDeployment.DOCKER
+        && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
+            == DatabaseEngine.MARIADB
+        && TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MYSQL) {
+      // MariaDb database in docker container uses "root" user (with the same password)
+      // if not user provided and the test always passes. The test makes no sense.
+      return;
+    }
+
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                "", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameMissingPassword() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(), ""));
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  // @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameMissingPropertyNames() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameUsingUrl() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + DriverHelper.getDriverRequiredParameters());
+
+    try (final Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  public void testConnectionWithDataSourceClassNameUsingUrlWithCredentials() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final String driverRequiredParameters = DriverHelper.getDriverRequiredParameters();
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + ":"
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + driverRequiredParameters
+            + (StringUtils.isNullOrEmpty(driverRequiredParameters) ? "?" : "&")
+            + "user="
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername()
+            + "&password="
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    try (final Connection conn = ds.getConnection()) {
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  public void testConnectionWithDataSourceClassNameUsingUrlWithPort() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + ":"
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + DriverHelper.getDriverRequiredParameters());
+
+    try (final Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  public void testConnectionWithDataSourceClassNameUsingUrlMissingPropertyNames() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + DriverHelper.getDriverRequiredParameters());
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  @DisableOnTestDriver({
+    TestDriver.MYSQL,
+    TestDriver.MARIADB
+  }) // Database is optional for Mysql and MariaDb databases
+  public void testConnectionWithDataSourceClassNameUsingUrlMissingDatabase() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + "/"
+            + DriverHelper.getDriverRequiredParameters());
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  public void testConnectionWithUrlWithCredentials() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    final String driverRequiredParameters = DriverHelper.getDriverRequiredParameters();
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + ":"
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + driverRequiredParameters
+            + (StringUtils.isNullOrEmpty(driverRequiredParameters) ? "?" : "&")
+            + "user="
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername()
+            + "&password="
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    try (final Connection conn = ds.getConnection()) {
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  public void testConnectionWithUrlMissingPort() throws SQLException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + "/"
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+            + DriverHelper.getDriverRequiredParameters());
+
+    try (final Connection conn =
+        ds.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  @DisableOnTestDriver({
+    TestDriver.MYSQL,
+    TestDriver.MARIADB
+  }) // Database is optional for Mysql and MariaDb databases
+  public void testConnectionWithUrlMissingDatabase() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + ":"
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort()
+            + "/"
+            + DriverHelper.getDriverRequiredParameters());
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  public void testConnectionWithUrlMissingUser() {
+
+    if (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment()
+            == DatabaseEngineDeployment.DOCKER
+        && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
+            == DatabaseEngine.MYSQL) {
+      // Mysql database in docker container uses "root" user (with the same password)
+      // if not user provided and the test always passes. The test makes no sense.
+      return;
+    }
+
+    if (TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngineDeployment()
+            == DatabaseEngineDeployment.DOCKER
+        && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
+            == DatabaseEngine.MARIADB) {
+      // MariaDb database in docker container uses "root" user (with the same password)
+      // if not user provided and the test always passes. The test makes no sense.
+      return;
+    }
+
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + ":"
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort()
+            + "/");
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                "", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()));
+  }
+
+  @TestTemplate
+  public void testConnectionWithUrlMissingPassword() {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setUrlPropertyName("url");
+
+    ds.setJdbcUrl(
+        DriverHelper.getDriverProtocol()
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpoint()
+            + ":"
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getEndpointPort()
+            + "/"
+            + DriverHelper.getDriverRequiredParameters());
+
+    assertThrows(
+        SQLException.class,
+        () ->
+            ds.getConnection(
+                TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(), ""));
+  }
+
+  @TestTemplate
+  // MariaDb driver datasource class doesn't support serverName so the test doesn't make sense.
+  @DisableOnTestDriver(TestDriver.MARIADB)
+  public void testConnectionWithDataSourceClassNameAndServerNameFromJndiLookup()
+      throws SQLException, NamingException, IllegalAccessException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setServerPropertyName("serverName");
+    ds.setDatabasePropertyName("databaseName");
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    final Hashtable<String, Object> env = new Hashtable<>();
+    env.put(Context.INITIAL_CONTEXT_FACTORY, SimpleJndiContextFactory.class.getName());
+    final InitialContext context = new InitialContext(env);
+    context.bind("wrapperDataSource", ds);
+    final AwsWrapperDataSource dsFromJndiLookup =
+        (AwsWrapperDataSource) context.lookup("wrapperDataSource");
+    assertNotNull(dsFromJndiLookup);
+
+    assertNotSame(ds, dsFromJndiLookup);
+    final Properties jndiDsProperties = dsFromJndiLookup.getTargetDataSourceProperties();
+    assertEquals(targetDataSourceProps, jndiDsProperties);
+
+    for (Field f : ds.getClass().getFields()) {
+      assertEquals(f.get(ds), f.get(dsFromJndiLookup));
+    }
+
+    try (final Connection conn =
+        dsFromJndiLookup.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+
+  @TestTemplate
+  public void testConnectionWithDataSourceClassNameAndUrlFromJndiLookup()
+      throws SQLException, NamingException, IllegalAccessException {
+    final AwsWrapperDataSource ds = new AwsWrapperDataSource();
+
+    ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
+    ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
+    ds.setUrlPropertyName("url");
+
+    final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
+    ds.setTargetDataSourceProperties(targetDataSourceProps);
+
+    final Hashtable<String, Object> env = new Hashtable<>();
+    env.put(Context.INITIAL_CONTEXT_FACTORY, SimpleJndiContextFactory.class.getName());
+    final InitialContext context = new InitialContext(env);
+    context.bind("wrapperDataSource", ds);
+    final AwsWrapperDataSource dsFromJndiLookup =
+        (AwsWrapperDataSource) context.lookup("wrapperDataSource");
+    assertNotNull(dsFromJndiLookup);
+
+    assertNotSame(ds, dsFromJndiLookup);
+    final Properties jndiDsProperties = dsFromJndiLookup.getTargetDataSourceProperties();
+    assertEquals(targetDataSourceProps, jndiDsProperties);
+
+    for (Field f : ds.getClass().getFields()) {
+      assertEquals(f.get(ds), f.get(dsFromJndiLookup));
+    }
+
+    try (final Connection conn =
+        dsFromJndiLookup.getConnection(
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+            TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword())) {
+
+      assertTrue(conn instanceof ConnectionWrapper);
+      assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+      assertEquals(
+          conn.getCatalog(),
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+
+      assertTrue(conn.isValid(10));
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/DriverConfigurationProfileTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/DriverConfigurationProfileTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Random;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.ExecutionTimeConnectionPluginFactory;
+import software.amazon.jdbc.profile.DriverConfigurationProfiles;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+import software.amazon.jdbc.wrapper.ResultSetWrapper;
+import software.amazon.jdbc.wrapper.StatementWrapper;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class DriverConfigurationProfileTests {
+
+  @TestTemplate
+  public void testOpenConnectionWithUnknownProfile() {
+
+    Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PROFILE_NAME.name, "unknownProfile");
+
+    SQLException actualException =
+        assertThrows(
+            SQLException.class,
+            () -> DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props));
+
+    assertTrue(actualException.getMessage().contains("unknownProfile"));
+  }
+
+  @TestTemplate
+  public void testOpenConnectionWithProfile() throws SQLException {
+
+    Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PROFILE_NAME.name, "testProfile");
+
+    DriverConfigurationProfiles.clear();
+    DriverConfigurationProfiles.addOrReplaceProfile(
+        "testProfile", Collections.singletonList(ExecutionTimeConnectionPluginFactory.class));
+
+    Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+
+    assertTrue(conn instanceof ConnectionWrapper);
+    assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+
+    assertTrue(conn.isValid(10));
+
+    Statement statement = conn.createStatement();
+    assertNotNull(statement);
+    assertTrue(statement instanceof StatementWrapper);
+
+    int rnd = new Random().nextInt(100);
+    ResultSet resultSet = statement.executeQuery("SELECT " + rnd);
+    assertNotNull(resultSet);
+    assertTrue(resultSet instanceof ResultSetWrapper);
+
+    resultSet.next();
+    int result = resultSet.getInt(1);
+    assertEquals(rnd, result);
+
+    conn.close();
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/ExecutionTimeTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/ExecutionTimeTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+import software.amazon.jdbc.wrapper.ResultSetWrapper;
+import software.amazon.jdbc.wrapper.StatementWrapper;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class ExecutionTimeTests {
+
+  private static final Logger LOGGER = Logger.getLogger(ExecutionTimeTests.class.getName());
+
+  @TestTemplate
+  public void testExecutionTime() throws SQLException, UnsupportedEncodingException {
+
+    Logger logger = Logger.getLogger(""); // get root logger
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    StreamHandler handler = new StreamHandler(os, new SimpleFormatter());
+    handler.setLevel(Level.ALL);
+    logger.addHandler(handler);
+
+    Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "executionTime");
+
+    Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+
+    assertTrue(conn instanceof ConnectionWrapper);
+    assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
+
+    assertTrue(conn.isValid(10));
+
+    Statement statement = conn.createStatement();
+    assertNotNull(statement);
+    assertTrue(statement instanceof StatementWrapper);
+
+    int rnd = new Random().nextInt(100);
+    ResultSet resultSet = statement.executeQuery("SELECT " + rnd);
+    assertNotNull(resultSet);
+    assertTrue(resultSet instanceof ResultSetWrapper);
+
+    resultSet.next();
+    int result = resultSet.getInt(1);
+    assertEquals(rnd, result);
+
+    conn.close();
+
+    handler.flush();
+    String logMessages = new String(os.toByteArray(), "UTF-8");
+    LOGGER.finest("logMessages=" + logMessages);
+
+    assertTrue(logMessages.contains("Executed Statement.executeQuery in"));
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/HikariTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/HikariTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariProxyConnection;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.ds.AwsWrapperDataSource;
+import software.amazon.jdbc.wrapper.ConnectionWrapper;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class HikariTests {
+
+  @TestTemplate
+  public void testOpenConnectionWithUrl() throws SQLException {
+
+    HikariDataSource ds = new HikariDataSource();
+    ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+    ds.setUsername(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    ds.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    Connection conn = ds.getConnection();
+
+    assertTrue(conn instanceof HikariProxyConnection);
+    HikariProxyConnection hikariConn = (HikariProxyConnection) conn;
+
+    assertTrue(hikariConn.isWrapperFor(ConnectionWrapper.class));
+    ConnectionWrapper connWrapper = (ConnectionWrapper) hikariConn.unwrap(Connection.class);
+    assertTrue(connWrapper.isWrapperFor(DriverHelper.getConnectionClass()));
+
+    assertTrue(conn.isValid(10));
+    conn.close();
+  }
+
+  @TestTemplate
+  public void testOpenConnectionWithDataSourceClassName() throws SQLException {
+
+    HikariDataSource ds = new HikariDataSource();
+    ds.setDataSourceClassName(AwsWrapperDataSource.class.getName());
+
+    // Configure the connection pool:
+    ds.setUsername(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    ds.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    // Configure AwsWrapperDataSource:
+    ds.addDataSourceProperty(
+        "jdbcProtocol", DriverHelper.getDriverProtocol());
+    ds.addDataSourceProperty("databasePropertyName", "databaseName");
+    ds.addDataSourceProperty("portPropertyName", "port");
+    ds.addDataSourceProperty("serverPropertyName", "serverName");
+
+    // Specify the driver-specific data source for AwsWrapperDataSource:
+    ds.addDataSourceProperty("targetDataSourceClassName", DriverHelper.getDataSourceClassname());
+
+    // Configuring MariadbDataSource:
+    Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(
+        "serverName",
+        TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint());
+    targetDataSourceProps.setProperty(
+        "databaseName",
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
+    ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
+
+    Connection conn = ds.getConnection();
+
+    assertTrue(conn instanceof HikariProxyConnection);
+    HikariProxyConnection hikariConn = (HikariProxyConnection) conn;
+
+    assertTrue(hikariConn.isWrapperFor(ConnectionWrapper.class));
+    ConnectionWrapper connWrapper = (ConnectionWrapper) hikariConn.unwrap(Connection.class);
+    assertTrue(connWrapper.isWrapperFor(DriverHelper.getConnectionClass()));
+
+    assertTrue(conn.isValid(10));
+    conn.close();
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/LogQueryPluginTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/LogQueryPluginTests.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.plugin.LogQueryConnectionPlugin;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class LogQueryPluginTests {
+
+  private static final Logger LOGGER = Logger.getLogger(LogQueryPluginTests.class.getName());
+
+  @TestTemplate
+  public void testStatementExecuteQueryWithArg() throws SQLException, UnsupportedEncodingException {
+
+    Logger logger = Logger.getLogger(""); // get root logger
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    StreamHandler handler = new StreamHandler(os, new SimpleFormatter());
+    handler.setLevel(Level.ALL);
+    logger.addHandler(handler);
+
+    Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "logQuery");
+    props.setProperty(LogQueryConnectionPlugin.ENHANCED_LOG_QUERY_ENABLED.name, "true");
+
+    Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+
+    Statement statement = conn.createStatement();
+
+    ResultSet resultSet = statement.executeQuery("SELECT 100");
+    resultSet.next();
+    resultSet.getInt(1);
+
+    conn.close();
+
+    handler.flush();
+    String logMessages = new String(os.toByteArray(), "UTF-8");
+    assertTrue(logMessages.contains("[Statement.executeQuery] Executing query: SELECT 100"));
+  }
+
+  @TestTemplate
+  public void testPreparedStatementExecuteQuery()
+      throws SQLException, UnsupportedEncodingException {
+
+    Logger logger = Logger.getLogger(""); // get root logger
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    StreamHandler handler = new StreamHandler(os, new SimpleFormatter());
+    handler.setLevel(Level.ALL);
+    logger.addHandler(handler);
+
+    Properties props = ConnectionStringHelper.getDefaultProperties();
+    props.setProperty(PropertyDefinition.PLUGINS.name, "logQuery");
+    props.setProperty(LogQueryConnectionPlugin.ENHANCED_LOG_QUERY_ENABLED.name, "true");
+
+    Connection conn = DriverManager.getConnection(ConnectionStringHelper.getWrapperUrl(), props);
+
+    PreparedStatement statement = conn.prepareStatement("SELECT 12345 * ?");
+    statement.setInt(1, 10);
+    ResultSet resultSet = statement.executeQuery();
+    resultSet.next();
+    resultSet.getInt(1);
+
+    conn.close();
+
+    handler.flush();
+    String logMessages = new String(os.toByteArray(), "UTF-8");
+    assertTrue(
+        logMessages.contains("[PreparedStatement.executeQuery] Executing query: SELECT 12345 * ?"));
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/PerformanceTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/PerformanceTest.java
@@ -218,7 +218,7 @@ public class PerformanceTest {
             + TestEnvironment.getCurrent()
                 .getInfo()
                 .getProxyDatabaseInfo()
-                .getInstanceEndpointPrefix());
+                .getInstanceEndpointSuffix());
 
     final PerfStatMonitoring data = new PerfStatMonitoring();
     doMeasurePerformance(sleepDelayMillis, REPEAT_TIMES, props, true, data);
@@ -272,7 +272,7 @@ public class PerformanceTest {
             + TestEnvironment.getCurrent()
                 .getInfo()
                 .getProxyDatabaseInfo()
-                .getInstanceEndpointPrefix());
+                .getInstanceEndpointSuffix());
     props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
 
     final PerfStatSocketTimeout data = new PerfStatSocketTimeout();

--- a/wrapper/src/test/java/integration/refactored/container/tests/PerformanceTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/PerformanceTest.java
@@ -1,0 +1,513 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.ProxyHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.EnableOnTestFeature;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.Arguments;
+import software.amazon.jdbc.util.StringUtils;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnTestFeature({
+  TestEnvironmentFeatures.PERFORMANCE,
+  TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+  TestEnvironmentFeatures.FAILOVER_SUPPORTED
+})
+public class PerformanceTest {
+
+  private static final Logger LOGGER = Logger.getLogger(PerformanceTest.class.getName());
+
+  private static final int REPEAT_TIMES =
+      StringUtils.isNullOrEmpty(System.getenv("REPEAT_TIMES"))
+          ? 5
+          : Integer.parseInt(System.getenv("REPEAT_TIMES"));
+
+  private static final int TIMEOUT_SEC = 1;
+  private static final int CONNECT_TIMEOUT_SEC = 3;
+  private static final int FAILOVER_TIMEOUT_MS = 120000;
+
+  private static final List<PerfStatMonitoring> enhancedFailureMonitoringPerfDataList =
+      new ArrayList<>();
+  private static final List<PerfStatMonitoring> failoverWithEfmPerfDataList = new ArrayList<>();
+  private static final List<PerfStatSocketTimeout> failoverWithSocketTimeoutPerfDataList =
+      new ArrayList<>();
+
+  private void doWritePerfDataToFile(String fileName, List<? extends PerfStatBase> dataList)
+      throws IOException {
+
+    if (dataList.isEmpty()) {
+      return;
+    }
+
+    LOGGER.finest(() -> "File name: " + fileName);
+
+    try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+
+      final XSSFSheet sheet = workbook.createSheet("PerformanceResults");
+
+      for (int rows = 0; rows < dataList.size(); rows++) {
+        PerfStatBase perfStat = dataList.get(rows);
+        Row row;
+
+        if (rows == 0) {
+          // Header
+          row = sheet.createRow(0);
+          perfStat.writeHeader(row);
+        }
+
+        row = sheet.createRow(rows + 1);
+        perfStat.writeData(row);
+      }
+
+      // Write to file
+      final File newExcelFile = new File(fileName);
+      newExcelFile.createNewFile();
+      try (FileOutputStream fileOut = new FileOutputStream(newExcelFile)) {
+        workbook.write(fileOut);
+      }
+    }
+  }
+
+  @TestTemplate
+  public void test_FailureDetectionTime_EnhancedMonitoringEnabled() throws IOException {
+
+    enhancedFailureMonitoringPerfDataList.clear();
+
+    try {
+      Stream<Arguments> argsStream = generateFailureDetectionTimeParams();
+      argsStream.forEach(
+          a -> {
+            try {
+              Object[] args = a.get();
+              execute_FailureDetectionTime_EnhancedMonitoringEnabled(
+                  (int) args[0], (int) args[1], (int) args[2], (int) args[3]);
+            } catch (SQLException ex) {
+              throw new RuntimeException(ex);
+            }
+          });
+
+    } finally {
+      doWritePerfDataToFile(
+          String.format(
+              "./build/reports/tests/"
+                + "DbEngine_%s_Driver_%s_"
+                + "FailureDetectionPerformanceResults_EnhancedMonitoringEnabled.xlsx",
+              TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+              TestEnvironment.getCurrent().getCurrentDriver()),
+          enhancedFailureMonitoringPerfDataList);
+      enhancedFailureMonitoringPerfDataList.clear();
+    }
+  }
+
+  private void execute_FailureDetectionTime_EnhancedMonitoringEnabled(
+      int detectionTime, int detectionInterval, int detectionCount, int sleepDelayMillis)
+      throws SQLException {
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    DriverHelper.setMonitoringConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+    DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
+    DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+    // this performance test measures efm failure detection time after disconnecting the network
+    props.setProperty("failureDetectionTime", Integer.toString(detectionTime));
+    props.setProperty("failureDetectionInterval", Integer.toString(detectionInterval));
+    props.setProperty("failureDetectionCount", Integer.toString(detectionCount));
+    props.setProperty("wrapperPlugins", "efm");
+
+    final PerfStatMonitoring data = new PerfStatMonitoring();
+    doMeasurePerformance(sleepDelayMillis, REPEAT_TIMES, props, false, data);
+    data.paramDetectionTime = detectionTime;
+    data.paramDetectionInterval = detectionInterval;
+    data.paramDetectionCount = detectionCount;
+    enhancedFailureMonitoringPerfDataList.add(data);
+  }
+
+  @TestTemplate
+  public void test_FailureDetectionTime_FailoverAndEnhancedMonitoringEnabled() throws IOException {
+
+    failoverWithEfmPerfDataList.clear();
+
+    try {
+      Stream<Arguments> argsStream = generateFailureDetectionTimeParams();
+      argsStream.forEach(
+          a -> {
+            try {
+              Object[] args = a.get();
+              execute_FailureDetectionTime_FailoverAndEnhancedMonitoringEnabled(
+                  (int) args[0], (int) args[1], (int) args[2], (int) args[3]);
+            } catch (SQLException ex) {
+              throw new RuntimeException(ex);
+            }
+          });
+
+    } finally {
+      doWritePerfDataToFile(
+          String.format(
+              "./build/reports/tests/"
+              + "DbEngine_%s_Driver_%s_"
+              + "FailureDetectionPerformanceResults_FailoverAndEnhancedMonitoringEnabled.xlsx",
+              TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+              TestEnvironment.getCurrent().getCurrentDriver()),
+          failoverWithEfmPerfDataList);
+      failoverWithEfmPerfDataList.clear();
+    }
+  }
+
+  private void execute_FailureDetectionTime_FailoverAndEnhancedMonitoringEnabled(
+      int detectionTime, int detectionInterval, int detectionCount, int sleepDelayMillis)
+      throws SQLException {
+
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    DriverHelper.setMonitoringConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+    DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
+    DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+
+    // this performance test measures failover and efm failure detection time after disconnecting
+    // the network
+    props.setProperty("failureDetectionTime", Integer.toString(detectionTime));
+    props.setProperty("failureDetectionInterval", Integer.toString(detectionInterval));
+    props.setProperty("failureDetectionCount", Integer.toString(detectionCount));
+    props.setProperty("wrapperPlugins", "failover,efm");
+    props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
+    props.setProperty(
+        "clusterInstanceHostPattern",
+        "?."
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getProxyDatabaseInfo()
+                .getInstanceEndpointPrefix());
+
+    final PerfStatMonitoring data = new PerfStatMonitoring();
+    doMeasurePerformance(sleepDelayMillis, REPEAT_TIMES, props, true, data);
+    data.paramDetectionTime = detectionTime;
+    data.paramDetectionInterval = detectionInterval;
+    data.paramDetectionCount = detectionCount;
+    failoverWithEfmPerfDataList.add(data);
+  }
+
+  @TestTemplate
+  public void test_FailoverTime_SocketTimeout() throws IOException {
+
+    failoverWithSocketTimeoutPerfDataList.clear();
+
+    try {
+      Stream<Arguments> argsStream = generateFailoverSocketTimeoutTimeParams();
+      argsStream.forEach(
+          a -> {
+            try {
+              Object[] args = a.get();
+              execute_FailoverTime_SocketTimeout((int) args[0], (int) args[1]);
+            } catch (SQLException ex) {
+              throw new RuntimeException(ex);
+            }
+          });
+
+    } finally {
+      doWritePerfDataToFile(
+          String.format(
+              "./build/reports/tests/DbEngine_%s_Driver_%s_FailoverPerformanceResults_SocketTimeout.xlsx",
+              TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+              TestEnvironment.getCurrent().getCurrentDriver()),
+          failoverWithSocketTimeoutPerfDataList);
+      failoverWithSocketTimeoutPerfDataList.clear();
+    }
+  }
+
+  private void execute_FailoverTime_SocketTimeout(int socketTimeout, int sleepDelayMillis)
+      throws SQLException {
+
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    // this performance test measures how socket timeout changes the overall failover time
+    DriverHelper.setSocketTimeout(props, socketTimeout, TimeUnit.SECONDS);
+    DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
+
+    // Loads just failover plugin; don't load Enhanced Failure Monitoring plugin
+    props.setProperty("wrapperPlugins", "failover");
+    props.setProperty(
+        "clusterInstanceHostPattern",
+        "?."
+            + TestEnvironment.getCurrent()
+                .getInfo()
+                .getProxyDatabaseInfo()
+                .getInstanceEndpointPrefix());
+    props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
+
+    final PerfStatSocketTimeout data = new PerfStatSocketTimeout();
+    doMeasurePerformance(sleepDelayMillis, REPEAT_TIMES, props, true, data);
+    data.paramSocketTimeout = socketTimeout;
+    failoverWithSocketTimeoutPerfDataList.add(data);
+  }
+
+  private void doMeasurePerformance(
+      int sleepDelayMillis,
+      int repeatTimes,
+      Properties props,
+      boolean openReadOnlyConnection,
+      PerfStatBase data)
+      throws SQLException {
+
+    final String QUERY = "SELECT pg_sleep(600)"; // 600s -> 10min
+    final AtomicLong downtime = new AtomicLong();
+    final List<Long> elapsedTimes = new ArrayList<>(repeatTimes);
+
+    for (int i = 0; i < repeatTimes; i++) {
+      downtime.set(0);
+
+      // Thread to stop network
+      final Thread thread =
+          new Thread(
+              () -> {
+                try {
+                  Thread.sleep(sleepDelayMillis);
+                  // Kill network
+                  ProxyHelper.disableConnectivity(
+                      TestEnvironment.getCurrent()
+                          .getInfo()
+                          .getProxyDatabaseInfo()
+                          .getInstances()
+                          .get(0)
+                          .getInstanceName());
+                  downtime.set(System.nanoTime());
+                } catch (InterruptedException interruptedException) {
+                  // Ignore, stop the thread
+                }
+              });
+
+      try (final Connection conn = openConnectionWithRetry(props);
+          final Statement statement = conn.createStatement()) {
+
+        conn.setReadOnly(openReadOnlyConnection);
+        thread.start();
+
+        // Execute long query
+        try (final ResultSet result = statement.executeQuery(QUERY)) {
+          fail("Sleep query finished, should not be possible with network downed.");
+        } catch (SQLException ex) { // Catching executing query
+          // Calculate and add detection time
+          final long failureTime = (System.nanoTime() - downtime.get());
+          elapsedTimes.add(failureTime);
+        }
+
+      } finally {
+        thread.interrupt(); // Ensure thread has stopped running
+        ProxyHelper.enableConnectivity(
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getProxyDatabaseInfo()
+                .getInstances()
+                .get(0)
+                .getInstanceName());
+      }
+    }
+
+    final long min = elapsedTimes.stream().min(Long::compare).orElse(0L);
+    final long max = elapsedTimes.stream().max(Long::compare).orElse(0L);
+    final long avg =
+        (long) elapsedTimes.stream().mapToLong(a -> a).summaryStatistics().getAverage();
+
+    data.paramNetworkOutageDelayMillis = sleepDelayMillis;
+    data.minFailureDetectionTimeMillis = TimeUnit.NANOSECONDS.toMillis(min);
+    data.maxFailureDetectionTimeMillis = TimeUnit.NANOSECONDS.toMillis(max);
+    data.avgFailureDetectionTimeMillis = TimeUnit.NANOSECONDS.toMillis(avg);
+  }
+
+  private Connection openConnectionWithRetry(Properties props) {
+    Connection conn = null;
+    int connectCount = 0;
+    while (conn == null && connectCount < 10) {
+      try {
+        conn = connectToInstance(props);
+      } catch (SQLException sqlEx) {
+        // ignore, try to connect again
+      }
+      connectCount++;
+    }
+
+    if (conn == null) {
+      fail(
+          "Can't connect to "
+              + TestEnvironment.getCurrent()
+                  .getInfo()
+                  .getProxyDatabaseInfo()
+                  .getInstances()
+                  .get(0)
+                  .getEndpoint());
+    }
+    return conn;
+  }
+
+  private Connection connectToInstance(Properties props) throws SQLException {
+    final String url = ConnectionStringHelper.getProxyWrapperUrl();
+    return DriverManager.getConnection(url, props);
+  }
+
+  private Stream<Arguments> generateFailureDetectionTimeParams() {
+    // detectionTime, detectionInterval, detectionCount, sleepDelayMS
+    return Stream.of(
+        // Defaults
+        Arguments.of(30000, 5000, 3, 5000),
+        Arguments.of(30000, 5000, 3, 10000),
+        Arguments.of(30000, 5000, 3, 15000),
+        Arguments.of(30000, 5000, 3, 20000),
+        Arguments.of(30000, 5000, 3, 25000),
+        Arguments.of(30000, 5000, 3, 30000),
+        Arguments.of(30000, 5000, 3, 35000),
+        Arguments.of(30000, 5000, 3, 40000),
+        Arguments.of(30000, 5000, 3, 50000),
+        Arguments.of(30000, 5000, 3, 60000),
+
+        // Aggressive detection scheme
+        Arguments.of(6000, 1000, 1, 1000),
+        Arguments.of(6000, 1000, 1, 2000),
+        Arguments.of(6000, 1000, 1, 3000),
+        Arguments.of(6000, 1000, 1, 4000),
+        Arguments.of(6000, 1000, 1, 5000),
+        Arguments.of(6000, 1000, 1, 6000),
+        Arguments.of(6000, 1000, 1, 7000),
+        Arguments.of(6000, 1000, 1, 8000),
+        Arguments.of(6000, 1000, 1, 9000),
+        Arguments.of(6000, 1000, 1, 10000));
+  }
+
+  private Stream<Arguments> generateFailoverSocketTimeoutTimeParams() {
+    // socketTimeout (seconds), sleepDelayMS
+    return Stream.of(
+        Arguments.of(30, 5000),
+        Arguments.of(30, 10000),
+        Arguments.of(30, 15000),
+        Arguments.of(30, 20000),
+        Arguments.of(30, 25000),
+        Arguments.of(30, 30000));
+  }
+
+  private abstract static class PerfStatBase {
+
+    public int paramNetworkOutageDelayMillis;
+    public long minFailureDetectionTimeMillis;
+    public long maxFailureDetectionTimeMillis;
+    public long avgFailureDetectionTimeMillis;
+
+    public abstract void writeHeader(Row row);
+
+    public abstract void writeData(Row row);
+  }
+
+  private static class PerfStatMonitoring extends PerfStatBase {
+
+    public int paramDetectionTime;
+    public int paramDetectionInterval;
+    public int paramDetectionCount;
+
+    @Override
+    public void writeHeader(Row row) {
+      Cell cell = row.createCell(0);
+      cell.setCellValue("FailureDetectionGraceTime");
+      cell = row.createCell(1);
+      cell.setCellValue("FailureDetectionInterval");
+      cell = row.createCell(2);
+      cell.setCellValue("FailureDetectionCount");
+      cell = row.createCell(3);
+      cell.setCellValue("NetworkOutageDelayMillis");
+      cell = row.createCell(4);
+      cell.setCellValue("MinFailureDetectionTimeMillis");
+      cell = row.createCell(5);
+      cell.setCellValue("MaxFailureDetectionTimeMillis");
+      cell = row.createCell(6);
+      cell.setCellValue("AvgFailureDetectionTimeMillis");
+    }
+
+    @Override
+    public void writeData(Row row) {
+      Cell cell = row.createCell(0);
+      cell.setCellValue(this.paramDetectionTime);
+      cell = row.createCell(1);
+      cell.setCellValue(this.paramDetectionInterval);
+      cell = row.createCell(2);
+      cell.setCellValue(this.paramDetectionCount);
+      cell = row.createCell(3);
+      cell.setCellValue(this.paramNetworkOutageDelayMillis);
+      cell = row.createCell(4);
+      cell.setCellValue(this.minFailureDetectionTimeMillis);
+      cell = row.createCell(5);
+      cell.setCellValue(this.maxFailureDetectionTimeMillis);
+      cell = row.createCell(6);
+      cell.setCellValue(this.avgFailureDetectionTimeMillis);
+    }
+  }
+
+  private static class PerfStatSocketTimeout extends PerfStatBase {
+
+    public int paramSocketTimeout;
+
+    @Override
+    public void writeHeader(Row row) {
+      Cell cell = row.createCell(0);
+      cell.setCellValue("SocketTimeout");
+      cell = row.createCell(1);
+      cell.setCellValue("NetworkOutageDelayMillis");
+      cell = row.createCell(2);
+      cell.setCellValue("MinFailureDetectionTimeMillis");
+      cell = row.createCell(3);
+      cell.setCellValue("MaxFailureDetectionTimeMillis");
+      cell = row.createCell(4);
+      cell.setCellValue("AvgFailureDetectionTimeMillis");
+    }
+
+    @Override
+    public void writeData(Row row) {
+      Cell cell = row.createCell(0);
+      cell.setCellValue(this.paramSocketTimeout);
+      cell = row.createCell(1);
+      cell.setCellValue(this.paramNetworkOutageDelayMillis);
+      cell = row.createCell(2);
+      cell.setCellValue(this.minFailureDetectionTimeMillis);
+      cell = row.createCell(3);
+      cell.setCellValue(this.maxFailureDetectionTimeMillis);
+      cell = row.createCell(4);
+      cell.setCellValue(this.avgFailureDetectionTimeMillis);
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/ReadWriteSplittingTests.java
@@ -1,0 +1,522 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.MakeSureFirstInstanceWriterExtension;
+import integration.refactored.container.ProxyHelper;
+import integration.refactored.container.TestDriver;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestDriver;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import integration.refactored.container.condition.EnableOnDatabaseEngine;
+import integration.refactored.container.condition.EnableOnDatabaseEngineDeployment;
+import integration.refactored.container.condition.EnableOnNumOfInstances;
+import integration.refactored.container.condition.EnableOnTestFeature;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.hostlistprovider.ConnectionStringHostListProvider;
+import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingPlugin;
+import software.amazon.jdbc.util.SqlState;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@ExtendWith(MakeSureFirstInstanceWriterExtension.class)
+@EnableOnNumOfInstances(min = 2)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class ReadWriteSplittingTests {
+
+  private static final Logger LOGGER = Logger.getLogger(ReadWriteSplittingTests.class.getName());
+
+  private Properties defaultProps;
+  private Properties propsWithLoadBalance;
+
+  /**
+   * Properties indirectly depends on a test driver since some properties are driver dependent (for
+   * example, socket timeout). That's why properties needs to be initialized before each test run.
+   */
+  @BeforeEach
+  public void beforeEach() throws SQLException, InterruptedException {
+    this.defaultProps = getPropertiesWithReadWritePlugin();
+
+    final Properties props = getPropertiesWithReadWritePlugin();
+    ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.set(props, "true");
+    this.propsWithLoadBalance = props;
+  }
+
+  protected static Properties getPropertiesWithReadWritePlugin() {
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    PropertyDefinition.PLUGINS.set(props, "readWriteSplitting");
+    ConnectionStringHostListProvider.SINGLE_WRITER_CONNECTION_STRING.set(props, "true");
+    DriverHelper.setSocketTimeout(props, 3, TimeUnit.SECONDS);
+    DriverHelper.setConnectTimeout(props, 3, TimeUnit.SECONDS);
+    return props;
+  }
+
+  protected String queryInstanceId(Connection conn) throws SQLException {
+    Statement stmt = conn.createStatement();
+    ResultSet rs = stmt.executeQuery(DriverHelper.getHostnameSql());
+    rs.next();
+    return rs.getString(1);
+  }
+
+  protected String getUrl() {
+    return DriverHelper.getWrapperDriverProtocol()
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint()
+        + ":"
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpointPort()
+        + ","
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(1)
+            .getEndpoint()
+        + ":"
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getDatabaseInfo()
+            .getInstances()
+            .get(1)
+            .getEndpointPort()
+        + "/"
+        + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
+        + DriverHelper.getDriverRequiredParameters();
+  }
+
+  protected String getProxiedUrl() {
+    return DriverHelper.getWrapperDriverProtocol()
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getProxyDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpoint()
+        + ":"
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getProxyDatabaseInfo()
+            .getInstances()
+            .get(0)
+            .getEndpointPort()
+        + ","
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getProxyDatabaseInfo()
+            .getInstances()
+            .get(1)
+            .getEndpoint()
+        + ":"
+        + TestEnvironment.getCurrent()
+            .getInfo()
+            .getProxyDatabaseInfo()
+            .getInstances()
+            .get(1)
+            .getEndpointPort()
+        + "/"
+        + TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getDefaultDbName()
+        + DriverHelper.getDriverRequiredParameters();
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_connectToWriter_setReadOnlyTrueTrueFalseFalseTrue() throws SQLException {
+    final String url = getUrl();
+    LOGGER.finest("Connecting to url " + url);
+    try (final Connection conn = DriverManager.getConnection(url, this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+      LOGGER.finest("writerConnectionId: " + writerConnectionId);
+
+      conn.setReadOnly(true);
+      final String readerConnectionId = queryInstanceId(conn);
+      LOGGER.finest("readerConnectionId: " + readerConnectionId);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      conn.setReadOnly(true);
+      String currentConnectionId = queryInstanceId(conn);
+      assertEquals(readerConnectionId, currentConnectionId);
+
+      conn.setReadOnly(false);
+      currentConnectionId = queryInstanceId(conn);
+      assertEquals(writerConnectionId, currentConnectionId);
+
+      conn.setReadOnly(false);
+      currentConnectionId = queryInstanceId(conn);
+      assertEquals(writerConnectionId, currentConnectionId);
+
+      conn.setReadOnly(true);
+      currentConnectionId = queryInstanceId(conn);
+      assertEquals(readerConnectionId, currentConnectionId);
+    }
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_setReadOnlyFalseInReadOnlyTransaction() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getUrl(), this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      final String readerConnectionId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      final Statement stmt = conn.createStatement();
+      stmt.execute("START TRANSACTION READ ONLY");
+      stmt.executeQuery("SELECT 1");
+
+      final SQLException exception =
+          assertThrows(SQLException.class, () -> conn.setReadOnly(false));
+      String currentConnectionId = queryInstanceId(conn);
+      assertEquals(SqlState.ACTIVE_SQL_TRANSACTION.getState(), exception.getSQLState());
+      assertEquals(readerConnectionId, currentConnectionId);
+
+      stmt.execute("COMMIT");
+
+      conn.setReadOnly(false);
+      currentConnectionId = queryInstanceId(conn);
+      assertEquals(writerConnectionId, currentConnectionId);
+    }
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_setReadOnlyFalseInTransaction_setAutocommitFalse() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getUrl(), this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      final String readerConnectionId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      final Statement stmt = conn.createStatement();
+      conn.setAutoCommit(false);
+      stmt.executeQuery(
+          // TODO: can we replace it with something less database specific?
+          "SELECT COUNT(*) FROM information_schema.tables");
+
+      final SQLException exception =
+          assertThrows(SQLException.class, () -> conn.setReadOnly(false));
+      String currentConnectionId = queryInstanceId(conn);
+      assertEquals(SqlState.ACTIVE_SQL_TRANSACTION.getState(), exception.getSQLState());
+      assertEquals(readerConnectionId, currentConnectionId);
+
+      stmt.execute("COMMIT");
+
+      conn.setReadOnly(false);
+      currentConnectionId = queryInstanceId(conn);
+      assertEquals(writerConnectionId, currentConnectionId);
+    }
+  }
+
+  @TestTemplate
+  @EnableOnDatabaseEngine(DatabaseEngine.MYSQL)
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_setReadOnlyFalseInTransaction_setAutocommitZero() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getUrl(), this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      final String readerConnectionId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      final Statement stmt = conn.createStatement();
+      stmt.execute("SET autocommit = 0");
+      stmt.executeQuery(
+          // TODO: can we replace it with something less database specific?
+          "SELECT COUNT(*) FROM information_schema.tables");
+
+      final SQLException exception =
+          assertThrows(SQLException.class, () -> conn.setReadOnly(false));
+      String currentConnectionId = queryInstanceId(conn);
+      assertEquals(SqlState.ACTIVE_SQL_TRANSACTION.getState(), exception.getSQLState());
+      assertEquals(readerConnectionId, currentConnectionId);
+
+      stmt.execute("COMMIT");
+
+      conn.setReadOnly(false);
+      currentConnectionId = queryInstanceId(conn);
+      assertEquals(writerConnectionId, currentConnectionId);
+    }
+  }
+
+  @TestTemplate
+  @EnableOnDatabaseEngine(DatabaseEngine.MYSQL)
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_setReadOnlyTrueInTransaction() throws SQLException {
+    String url = getUrl();
+    LOGGER.info("Connecting to " + url);
+    try (final Connection conn = DriverManager.getConnection(url, this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+      LOGGER.info("writerConnectionId: " + writerConnectionId);
+
+      final Statement stmt1 = conn.createStatement();
+      stmt1.executeUpdate("DROP TABLE IF EXISTS test_readWriteSplitting_readOnlyTrueInTransaction");
+      stmt1.executeUpdate(
+          "CREATE TABLE test_readWriteSplitting_readOnlyTrueInTransaction "
+              + "(id int not null primary key, text_field varchar(255) not null)");
+      stmt1.execute("SET autocommit = 0");
+
+      final Statement stmt2 = conn.createStatement();
+      stmt2.executeUpdate(
+          "INSERT INTO test_readWriteSplitting_readOnlyTrueInTransaction VALUES (1, 'test_field value 1')");
+
+      assertDoesNotThrow(() -> conn.setReadOnly(true));
+      final String currentConnectionId = queryInstanceId(conn);
+      assertEquals(writerConnectionId, currentConnectionId);
+
+      stmt2.execute("COMMIT");
+      final ResultSet rs =
+          stmt2.executeQuery(
+              "SELECT count(*) from test_readWriteSplitting_readOnlyTrueInTransaction");
+      rs.next();
+      assertEquals(1, rs.getInt(1));
+
+      conn.setReadOnly(false);
+      stmt2.execute("SET autocommit = 1");
+      stmt2.executeUpdate("DROP TABLE IF EXISTS test_readWriteSplitting_readOnlyTrueInTransaction");
+    }
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_setReadOnlyTrue_allReadersDown() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getProxiedUrl(), this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      // Kill all reader instances
+      int numOfInstances =
+          TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstances().size();
+      for (int i = 1; i < numOfInstances; i++) {
+        ProxyHelper.disableConnectivity(
+            TestEnvironment.getCurrent()
+                .getInfo()
+                .getDatabaseInfo()
+                .getInstances()
+                .get(i)
+                .getInstanceName());
+      }
+
+      assertDoesNotThrow(() -> conn.setReadOnly(true));
+      String currentConnectionId = assertDoesNotThrow(() -> queryInstanceId(conn));
+      assertEquals(writerConnectionId, currentConnectionId);
+
+      assertDoesNotThrow(() -> conn.setReadOnly(false));
+      currentConnectionId = assertDoesNotThrow(() -> queryInstanceId(conn));
+      assertEquals(writerConnectionId, currentConnectionId);
+    }
+  }
+
+  @TestTemplate
+  @Disabled // TODO: fix me
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_setReadOnlyTrue_allInstancesDown() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getProxiedUrl(), this.defaultProps)) {
+
+      ProxyHelper.disableAllConnectivity();
+
+      final SQLException exception = assertThrows(SQLException.class, () -> conn.setReadOnly(true));
+      // A SQL statement setting the read-only status is sent to server.
+      // Since the server is down, a SQLException is thrown.
+      assertEquals(SqlState.COMMUNICATION_ERROR.getState(), exception.getSQLState());
+    }
+  }
+
+  @TestTemplate
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_setReadOnlyTrue_allInstancesDown_writerClosed() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getProxiedUrl(), this.defaultProps)) {
+
+      conn.close();
+
+      // Kill all instances
+      ProxyHelper.disableAllConnectivity();
+
+      final SQLException exception = assertThrows(SQLException.class, () -> conn.setReadOnly(true));
+      assertEquals(SqlState.CONNECTION_UNABLE_TO_CONNECT.getState(), exception.getSQLState());
+    }
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  public void test_setReadOnlyFalse_allInstancesDown() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getProxiedUrl(), this.defaultProps)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      final String readerConnectionId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      // Kill all instances
+      ProxyHelper.disableAllConnectivity();
+
+      final SQLException exception =
+          assertThrows(SQLException.class, () -> conn.setReadOnly(false));
+      assertEquals(SqlState.CONNECTION_UNABLE_TO_CONNECT.getState(), exception.getSQLState());
+    }
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_readerLoadBalancing_autocommitTrue() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getUrl(), this.propsWithLoadBalance)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      String readerConnectionId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      for (int i = 0; i < 10; i++) {
+        final Statement stmt = conn.createStatement();
+        stmt.executeQuery("SELECT " + i);
+        readerConnectionId = queryInstanceId(conn);
+        assertNotEquals(writerConnectionId, readerConnectionId);
+
+        final ResultSet rs = stmt.getResultSet();
+        rs.next();
+        assertEquals(i, rs.getInt(1));
+      }
+    }
+  }
+
+  @TestTemplate
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_readerLoadBalancing_autocommitFalse() throws SQLException {
+    try (final Connection conn = DriverManager.getConnection(getUrl(), this.propsWithLoadBalance)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      String readerConnectionId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerConnectionId);
+
+      conn.setAutoCommit(false);
+      final Statement stmt = conn.createStatement();
+
+      for (int i = 0; i < 5; i++) {
+        stmt.executeQuery("SELECT " + i);
+        conn.commit();
+        readerConnectionId = queryInstanceId(conn);
+        assertNotEquals(writerConnectionId, readerConnectionId);
+
+        final ResultSet rs = stmt.getResultSet();
+        rs.next();
+        assertEquals(i, rs.getInt(1));
+
+        stmt.executeQuery("SELECT " + i);
+        conn.rollback();
+        readerConnectionId = queryInstanceId(conn);
+        assertNotEquals(writerConnectionId, readerConnectionId);
+      }
+    }
+  }
+
+  @TestTemplate
+  @EnableOnTestFeature(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)
+  @DisableOnTestDriver(TestDriver.MARIADB) // TODO: investigate and fix
+  // Tests use Aurora specific SQL to identify instance name
+  @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+  public void test_transactionResolutionUnknown() throws SQLException {
+    try (final Connection conn =
+        DriverManager.getConnection(getProxiedUrl(), this.propsWithLoadBalance)) {
+
+      final String writerConnectionId = queryInstanceId(conn);
+
+      conn.setReadOnly(true);
+      conn.setAutoCommit(false);
+      final String readerId = queryInstanceId(conn);
+      assertNotEquals(writerConnectionId, readerId);
+
+      final Statement stmt = conn.createStatement();
+      stmt.executeQuery("SELECT 1");
+
+      ProxyHelper.disableConnectivity(
+          TestEnvironment.getCurrent()
+              .getInfo()
+              .getDatabaseInfo()
+              .getInstances()
+              .get(1)
+              .getInstanceName());
+
+      final SQLException e = assertThrows(SQLException.class, conn::rollback);
+      assertTrue(
+          SqlState.CONNECTION_FAILURE_DURING_TRANSACTION.getState().equals(e.getSQLState())
+              || SqlState.CONNECTION_FAILURE.getState().equals(e.getSQLState()));
+
+      try (final Connection newConn =
+          DriverManager.getConnection(getProxiedUrl(), this.propsWithLoadBalance)) {
+        newConn.setReadOnly(true);
+        final Statement newStmt = newConn.createStatement();
+        final ResultSet rs = newStmt.executeQuery("SELECT 1");
+        rs.next();
+        assertEquals(1, rs.getInt(1));
+      }
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/container/tests/SpringTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/SpringTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestDriverProvider;
+import integration.refactored.container.TestEnvironment;
+import integration.refactored.container.condition.DisableOnTestFeature;
+import java.util.Properties;
+import java.util.Random;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import software.amazon.jdbc.PropertyDefinition;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@DisableOnTestFeature(TestEnvironmentFeatures.PERFORMANCE)
+public class SpringTests {
+
+  @TestTemplate
+  public void testOpenConnection() {
+
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSource());
+
+    int rnd = new Random().nextInt(100);
+    Integer result = jdbcTemplate.queryForObject("SELECT " + rnd, Integer.class);
+    assertEquals(rnd, result);
+  }
+
+  private DataSource getDataSource() {
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setDriverClassName("software.amazon.jdbc.Driver");
+    dataSource.setUrl(ConnectionStringHelper.getWrapperUrl());
+    dataSource.setUsername(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    dataSource.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+
+    Properties props = new Properties();
+    props.setProperty(PropertyDefinition.LOGGER_LEVEL.name, "ALL");
+    dataSource.setConnectionProperties(props);
+
+    return dataSource;
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
@@ -502,11 +502,11 @@ public class TestEnvironment implements AutoCloseable {
               proxyPort);
     }
 
-    if (!StringUtils.isNullOrEmpty(env.info.getDatabaseInfo().getInstanceEndpointPrefix())) {
+    if (!StringUtils.isNullOrEmpty(env.info.getDatabaseInfo().getInstanceEndpointSuffix())) {
       env.info
           .getProxyDatabaseInfo()
           .setInstanceEndpointPrefix(
-              env.info.getDatabaseInfo().getInstanceEndpointPrefix() + PROXIED_DOMAIN_NAME_SUFFIX,
+              env.info.getDatabaseInfo().getInstanceEndpointSuffix() + PROXIED_DOMAIN_NAME_SUFFIX,
               proxyPort);
     }
 

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
@@ -374,9 +374,8 @@ public class TestEnvironment implements AutoCloseable {
   private static String getAuroraInstanceClass(TestEnvironmentRequest request) {
     switch (request.getDatabaseEngine()) {
       case MYSQL:
-        return "db.r6g.large";
       case PG:
-        return "db.r5.large";
+        return "db.r6g.large";
       default:
         throw new NotImplementedException(request.getDatabaseEngine().toString());
     }

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
@@ -1,0 +1,670 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.host;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestDatabaseInfo;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.TestEnvironmentInfo;
+import integration.refactored.TestEnvironmentRequest;
+import integration.refactored.TestInstanceInfo;
+import integration.refactored.TestProxyDatabaseInfo;
+import integration.util.AuroraTestUtility;
+import integration.util.ContainerHelper;
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+import software.amazon.jdbc.util.StringUtils;
+
+public class TestEnvironment implements AutoCloseable {
+
+  private static final Logger LOGGER = Logger.getLogger(TestEnvironment.class.getName());
+
+  private static final String DATABASE_CONTAINER_NAME_PREFIX = "database-container-";
+  private static final String TEST_CONTAINER_NAME = "test-container";
+  private static final String PROXIED_DOMAIN_NAME_SUFFIX = ".proxied";
+  protected static final int PROXY_CONTROL_PORT = 8474;
+
+  private final TestEnvironmentInfo info =
+      new TestEnvironmentInfo(); // only this info is passed to test container
+
+  // The following variables are local to host portion od test environment. They are not shared to a
+  // test container.
+
+  private int numOfInstances;
+  private boolean reuseAuroraDbCluster;
+  private String auroraClusterName; // "cluster-mysql"
+  private String auroraClusterDomain; // "XYZ.us-west-2.rds.amazonaws.com"
+
+  private String awsAccessKeyId;
+  private String awsSecretAccessKey;
+  private String awsSessionToken;
+
+  private GenericContainer<?> testContainer;
+  private final ArrayList<GenericContainer<?>> databaseContainers = new ArrayList<>();
+  private ArrayList<ToxiproxyContainer> proxyContainers;
+
+  private String runnerIP;
+
+  private final Network network = Network.newNetwork();
+
+  private AuroraTestUtility auroraUtil;
+
+  private TestEnvironment(TestEnvironmentRequest request) {
+    this.info.setRequest(request);
+  }
+
+  public static TestEnvironment build(TestEnvironmentRequest request) {
+    TestEnvironment env = new TestEnvironment(request);
+
+    switch (request.getDatabaseEngineDeployment()) {
+      case DOCKER:
+        initDatabaseParams(env);
+        createDatabaseContainers(env);
+
+        if (request.getFeatures().contains(TestEnvironmentFeatures.IAM)) {
+          throw new UnsupportedOperationException(TestEnvironmentFeatures.IAM.toString());
+        }
+
+        if (request.getFeatures().contains(TestEnvironmentFeatures.FAILOVER_SUPPORTED)) {
+          throw new UnsupportedOperationException(
+              TestEnvironmentFeatures.FAILOVER_SUPPORTED.toString());
+        }
+
+        break;
+      case AURORA:
+        initDatabaseParams(env);
+        createAuroraDbCluster(env);
+
+        if (request.getFeatures().contains(TestEnvironmentFeatures.IAM)) {
+          configureIamAccess(env);
+        }
+
+        break;
+      default:
+        throw new NotImplementedException(request.getDatabaseEngineDeployment().toString());
+    }
+
+    if (request.getFeatures().contains(TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED)) {
+      createProxyContainers(env);
+    }
+
+    createTestContainer(env);
+
+    return env;
+  }
+
+  private static void createDatabaseContainers(TestEnvironment env) {
+    ContainerHelper containerHelper = new ContainerHelper();
+
+    switch (env.info.getRequest().getDatabaseInstances()) {
+      case SINGLE_INSTANCE:
+        env.numOfInstances = 1;
+        break;
+      case MULTI_INSTANCE:
+        env.numOfInstances = env.info.getRequest().getNumOfInstances();
+        if (env.numOfInstances < 1 || env.numOfInstances > 15) {
+          env.numOfInstances = 5;
+        }
+        break;
+      default:
+        throw new NotImplementedException(env.info.getRequest().getDatabaseInstances().toString());
+    }
+
+    switch (env.info.getRequest().getDatabaseEngine()) {
+      case MYSQL:
+        for (int i = 1; i <= env.numOfInstances; i++) {
+          env.databaseContainers.add(
+              containerHelper.createMysqlContainer(
+                  env.network,
+                  DATABASE_CONTAINER_NAME_PREFIX + i,
+                  env.info.getDatabaseInfo().getDefaultDbName(),
+                  env.info.getDatabaseInfo().getUsername(),
+                  env.info.getDatabaseInfo().getPassword()));
+          env.databaseContainers.get(0).start();
+
+          env.info
+              .getDatabaseInfo()
+              .getInstances()
+              .add(
+                  new TestInstanceInfo(
+                      DATABASE_CONTAINER_NAME_PREFIX + i,
+                      DATABASE_CONTAINER_NAME_PREFIX + i,
+                      3306));
+        }
+        break;
+
+      case PG:
+        for (int i = 1; i <= env.numOfInstances; i++) {
+          env.databaseContainers.add(
+              containerHelper.createPostgresContainer(
+                  env.network,
+                  DATABASE_CONTAINER_NAME_PREFIX + i,
+                  env.info.getDatabaseInfo().getDefaultDbName(),
+                  env.info.getDatabaseInfo().getUsername(),
+                  env.info.getDatabaseInfo().getPassword()));
+          env.databaseContainers.get(0).start();
+
+          env.info
+              .getDatabaseInfo()
+              .getInstances()
+              .add(
+                  new TestInstanceInfo(
+                      DATABASE_CONTAINER_NAME_PREFIX + i,
+                      DATABASE_CONTAINER_NAME_PREFIX + i,
+                      5432));
+        }
+        break;
+
+      case MARIADB:
+        for (int i = 1; i <= env.numOfInstances; i++) {
+          env.databaseContainers.add(
+              containerHelper.createMariadbContainer(
+                  env.network,
+                  DATABASE_CONTAINER_NAME_PREFIX + i,
+                  env.info.getDatabaseInfo().getDefaultDbName(),
+                  env.info.getDatabaseInfo().getUsername(),
+                  env.info.getDatabaseInfo().getPassword()));
+          env.databaseContainers.get(0).start();
+
+          env.info
+              .getDatabaseInfo()
+              .getInstances()
+              .add(
+                  new TestInstanceInfo(
+                      DATABASE_CONTAINER_NAME_PREFIX + i,
+                      DATABASE_CONTAINER_NAME_PREFIX + i,
+                      3306));
+        }
+        break;
+
+      default:
+        throw new NotImplementedException(env.info.getRequest().getDatabaseEngine().toString());
+    }
+  }
+
+  private static void createAuroraDbCluster(TestEnvironment env) {
+
+    switch (env.info.getRequest().getDatabaseInstances()) {
+      case SINGLE_INSTANCE:
+        initAwsCredentials(env);
+        env.numOfInstances = 1;
+        createAuroraDbCluster(env, 1);
+        break;
+      case MULTI_INSTANCE:
+        initAwsCredentials(env);
+
+        env.numOfInstances = env.info.getRequest().getNumOfInstances();
+        if (env.numOfInstances < 1 || env.numOfInstances > 15) {
+          env.numOfInstances = 5;
+        }
+
+        createAuroraDbCluster(env, env.numOfInstances);
+        break;
+      default:
+        throw new NotImplementedException(env.info.getRequest().getDatabaseEngine().toString());
+    }
+  }
+
+  private static void createAuroraDbCluster(TestEnvironment env, int numOfInstances) {
+
+    env.info.setAuroraRegion(
+        !StringUtils.isNullOrEmpty(System.getenv("AURORA_DB_REGION"))
+            ? System.getenv("AURORA_DB_REGION")
+            : "us-east-2");
+
+    env.reuseAuroraDbCluster =
+        !StringUtils.isNullOrEmpty(System.getenv("REUSE_AURORA_CLUSTER"))
+            && Boolean.parseBoolean(System.getenv("REUSE_AURORA_CLUSTER"));
+    env.auroraClusterName = System.getenv("AURORA_CLUSTER_NAME"); // "cluster-mysql"
+    env.auroraClusterDomain =
+        System.getenv("AURORA_CLUSTER_DOMAIN"); // "XYZ.us-west-2.rds.amazonaws.com"
+
+    if (StringUtils.isNullOrEmpty(env.auroraClusterDomain)) {
+      throw new RuntimeException("Environment variable AURORA_CLUSTER_DOMAIN is required.");
+    }
+
+    env.auroraUtil =
+        new AuroraTestUtility(
+            env.info.getAuroraRegion(),
+            env.awsAccessKeyId,
+            env.awsSecretAccessKey,
+            env.awsSessionToken);
+    ArrayList<TestInstanceInfo> instances = new ArrayList<>();
+
+    if (env.reuseAuroraDbCluster) {
+      if (!env.auroraUtil.doesClusterExist(env.auroraClusterName)) {
+        throw new RuntimeException(
+            "It's requested to reuse existing DB cluster but it doesn't exist: "
+                + env.auroraClusterName
+                + "."
+                + env.auroraClusterDomain);
+      }
+      LOGGER.finest(
+          "Reuse existing cluster " + env.auroraClusterName + "." + env.auroraClusterDomain);
+
+      DatabaseEngine existingClusterDatabaseEngine =
+          env.auroraUtil.getClusterDatabaseEngine(env.auroraClusterName);
+      if (existingClusterDatabaseEngine != env.info.getRequest().getDatabaseEngine()) {
+        throw new RuntimeException(
+            "Existing cluster is "
+                + existingClusterDatabaseEngine
+                + " cluster. "
+                + env.info.getRequest().getDatabaseEngine()
+                + " is expected.");
+      }
+
+      instances.addAll(env.auroraUtil.getClusterInstanceIds(env.auroraClusterName));
+
+    } else {
+      if (StringUtils.isNullOrEmpty(env.auroraClusterName)) {
+        env.auroraClusterName = getRandomName(env.info.getRequest());
+        LOGGER.finest("Cluster to create: " + env.auroraClusterName);
+      }
+
+      try {
+        env.auroraClusterDomain =
+            env.auroraUtil.createCluster(
+                env.info.getDatabaseInfo().getUsername(),
+                env.info.getDatabaseInfo().getPassword(),
+                env.info.getDatabaseInfo().getDefaultDbName(),
+                env.auroraClusterName,
+                getAuroraDbEngine(env.info.getRequest()),
+                getAuroraInstanceClass(env.info.getRequest()),
+                getAuroraDbEngineVersion(env.info.getRequest()),
+                numOfInstances,
+                instances);
+        LOGGER.finest(
+            "Created a new cluster " + env.auroraClusterName + "." + env.auroraClusterDomain);
+
+      } catch (Exception e) {
+
+        LOGGER.finest("Error creating a cluster " + env.auroraClusterName + ". " + e.getMessage());
+
+        // remove cluster and instances
+        LOGGER.finest("Deleting cluster " + env.auroraClusterName);
+        env.auroraUtil.deleteCluster(env.auroraClusterName);
+        LOGGER.finest("Deleted cluster " + env.auroraClusterName);
+
+        throw new RuntimeException(e);
+      }
+    }
+
+    env.info.setAuroraClusterName(env.auroraClusterName);
+
+    int port = getPort(env.info.getRequest());
+
+    env.info
+        .getDatabaseInfo()
+        .setClusterEndpoint(env.auroraClusterName + ".cluster-" + env.auroraClusterDomain, port);
+    env.info
+        .getDatabaseInfo()
+        .setClusterReadOnlyEndpoint(
+            env.auroraClusterName + ".cluster-ro-" + env.auroraClusterDomain, port);
+    env.info.getDatabaseInfo().setInstanceEndpointPrefix(env.auroraClusterDomain, port);
+
+    env.info.getDatabaseInfo().getInstances().clear();
+    env.info.getDatabaseInfo().getInstances().addAll(instances);
+
+    try {
+      env.runnerIP = env.auroraUtil.getPublicIPAddress();
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+    env.auroraUtil.ec2AuthorizeIP(env.runnerIP);
+  }
+
+  private static String getRandomName(TestEnvironmentRequest request) {
+    switch (request.getDatabaseEngine()) {
+      case MYSQL:
+        return "test-mysql-" + System.nanoTime();
+      case PG:
+        return "test-pg-" + System.nanoTime();
+      default:
+        return String.valueOf(System.nanoTime());
+    }
+  }
+
+  private static String getAuroraDbEngine(TestEnvironmentRequest request) {
+    switch (request.getDatabaseEngine()) {
+      case MYSQL:
+        return "aurora-mysql";
+      case PG:
+        return "aurora-postgresql";
+      default:
+        throw new NotImplementedException(request.getDatabaseEngine().toString());
+    }
+  }
+
+  private static String getAuroraDbEngineVersion(TestEnvironmentRequest request) {
+    switch (request.getDatabaseEngine()) {
+      case MYSQL:
+        return "8.0.mysql_aurora.3.01.0"; // TODO: verify
+      case PG:
+        return "13.7"; // TODO: verify
+      default:
+        throw new NotImplementedException(request.getDatabaseEngine().toString());
+    }
+  }
+
+  private static String getAuroraInstanceClass(TestEnvironmentRequest request) {
+    switch (request.getDatabaseEngine()) {
+      case MYSQL:
+        return "db.r6g.large"; // TODO: verify
+      case PG:
+        return "db.r5.large"; // TODO: verify
+      default:
+        throw new NotImplementedException(request.getDatabaseEngine().toString());
+    }
+  }
+
+  private static int getPort(TestEnvironmentRequest request) {
+    switch (request.getDatabaseEngine()) {
+      case MYSQL:
+      case MARIADB:
+        return 3306;
+      case PG:
+        return 5432;
+      default:
+        throw new NotImplementedException(request.getDatabaseEngine().toString());
+    }
+  }
+
+  private static void initDatabaseParams(TestEnvironment env) {
+    final String dbName =
+        !StringUtils.isNullOrEmpty(System.getenv("DB_DATABASE_NAME"))
+            ? System.getenv("DB_DATABASE_NAME")
+            : "test_database";
+    final String dbUsername =
+        !StringUtils.isNullOrEmpty(System.getenv("DB_USERNAME"))
+            ? System.getenv("DB_USERNAME")
+            : "test_user";
+    final String dbPassword =
+        !StringUtils.isNullOrEmpty(System.getenv("DB_PASSWORD"))
+            ? System.getenv("DB_PASSWORD")
+            : "secret_password";
+
+    env.info.setDatabaseInfo(new TestDatabaseInfo());
+    env.info.getDatabaseInfo().setUsername(dbUsername);
+    env.info.getDatabaseInfo().setPassword(dbPassword);
+    env.info.getDatabaseInfo().setDefaultDbName(dbName);
+  }
+
+  private static void initAwsCredentials(TestEnvironment env) {
+    env.awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID");
+    env.awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+    env.awsSessionToken = System.getenv("AWS_SESSION_TOKEN");
+
+    if (StringUtils.isNullOrEmpty(env.awsAccessKeyId)) {
+      throw new RuntimeException("Environment variable AWS_ACCESS_KEY_ID is required.");
+    }
+    if (StringUtils.isNullOrEmpty(env.awsSecretAccessKey)) {
+      throw new RuntimeException("Environment variable AWS_SECRET_ACCESS_KEY is required.");
+    }
+    if (StringUtils.isNullOrEmpty(env.awsSessionToken)) {
+      throw new RuntimeException("Environment variable AWS_SESSION_TOKEN is required.");
+    }
+
+    if (env.info
+        .getRequest()
+        .getFeatures()
+        .contains(TestEnvironmentFeatures.AWS_CREDENTIALS_ENABLED)) {
+      env.info.setAwsAccessKeyId(env.awsAccessKeyId);
+      env.info.setAwsSecretAccessKey(env.awsSecretAccessKey);
+      env.info.setAwsSessionToken(env.awsSessionToken);
+    }
+  }
+
+  private static void createProxyContainers(TestEnvironment env) {
+    ContainerHelper containerHelper = new ContainerHelper();
+
+    int port = getPort(env.info.getRequest());
+
+    env.info.setProxyDatabaseInfo(new TestProxyDatabaseInfo());
+    env.info.getProxyDatabaseInfo().setControlPort(PROXY_CONTROL_PORT);
+    env.info.getProxyDatabaseInfo().setUsername(env.info.getDatabaseInfo().getUsername());
+    env.info.getProxyDatabaseInfo().setPassword(env.info.getDatabaseInfo().getPassword());
+    env.info.getProxyDatabaseInfo().setDefaultDbName(env.info.getDatabaseInfo().getDefaultDbName());
+
+    env.proxyContainers = new ArrayList<>();
+
+    int proxyPort = 0;
+    for (TestInstanceInfo instance : env.info.getDatabaseInfo().getInstances()) {
+      ToxiproxyContainer container =
+          containerHelper.createProxyContainer(env.network, instance, PROXIED_DOMAIN_NAME_SUFFIX);
+
+      container.start();
+      env.proxyContainers.add(container);
+
+      ToxiproxyContainer.ContainerProxy proxy =
+          container.getProxy(instance.getEndpoint(), instance.getEndpointPort());
+
+      if (proxyPort != 0 && proxyPort != proxy.getOriginalProxyPort()) {
+        throw new RuntimeException("DB cluster proxies should be on the same port.");
+      }
+      proxyPort = proxy.getOriginalProxyPort();
+    }
+
+    if (!StringUtils.isNullOrEmpty(env.info.getDatabaseInfo().getClusterEndpoint())) {
+      env.proxyContainers.add(
+          containerHelper.createAndStartProxyContainer(
+              env.network,
+              "proxy-cluster",
+              env.info.getDatabaseInfo().getClusterEndpoint() + PROXIED_DOMAIN_NAME_SUFFIX,
+              env.info.getDatabaseInfo().getClusterEndpoint(),
+              port,
+              proxyPort));
+
+      env.info
+          .getProxyDatabaseInfo()
+          .setClusterEndpoint(
+              env.info.getDatabaseInfo().getClusterEndpoint() + PROXIED_DOMAIN_NAME_SUFFIX,
+              proxyPort);
+    }
+
+    if (!StringUtils.isNullOrEmpty(env.info.getDatabaseInfo().getClusterReadOnlyEndpoint())) {
+      env.proxyContainers.add(
+          containerHelper.createAndStartProxyContainer(
+              env.network,
+              "proxy-ro-cluster",
+              env.info.getDatabaseInfo().getClusterReadOnlyEndpoint() + PROXIED_DOMAIN_NAME_SUFFIX,
+              env.info.getDatabaseInfo().getClusterReadOnlyEndpoint(),
+              port,
+              proxyPort));
+
+      env.info
+          .getProxyDatabaseInfo()
+          .setClusterReadOnlyEndpoint(
+              env.info.getDatabaseInfo().getClusterReadOnlyEndpoint() + PROXIED_DOMAIN_NAME_SUFFIX,
+              proxyPort);
+    }
+
+    if (!StringUtils.isNullOrEmpty(env.info.getDatabaseInfo().getInstanceEndpointPrefix())) {
+      env.info
+          .getProxyDatabaseInfo()
+          .setInstanceEndpointPrefix(
+              env.info.getDatabaseInfo().getInstanceEndpointPrefix() + PROXIED_DOMAIN_NAME_SUFFIX,
+              proxyPort);
+    }
+
+    for (TestInstanceInfo instanceInfo : env.info.getDatabaseInfo().getInstances()) {
+      TestInstanceInfo proxyInstanceInfo =
+          new TestInstanceInfo(
+              instanceInfo.getInstanceName(),
+              instanceInfo.getEndpoint() + PROXIED_DOMAIN_NAME_SUFFIX,
+              proxyPort);
+      env.info.getProxyDatabaseInfo().getInstances().add(proxyInstanceInfo);
+    }
+  }
+
+  private static void createTestContainer(TestEnvironment env) {
+    final ContainerHelper containerHelper = new ContainerHelper();
+    env.testContainer =
+        containerHelper
+            .createTestContainer(
+                "aws/rds-test-container", getContainerBaseImageName(env.info.getRequest()))
+            .withNetworkAliases(TEST_CONTAINER_NAME)
+            .withNetwork(env.network)
+            .withEnv("TEST_ENV_INFO_JSON", getEnvironmentInfoAsString(env))
+            .withEnv("TEST_ENV_DESCRIPTION", env.info.getRequest().getDisplayName());
+
+    if (env.info
+        .getRequest()
+        .getFeatures()
+        .contains(TestEnvironmentFeatures.AWS_CREDENTIALS_ENABLED)) {
+      env.testContainer
+          .withEnv("AWS_ACCESS_KEY_ID", env.awsAccessKeyId)
+          .withEnv("AWS_SECRET_ACCESS_KEY", env.awsSecretAccessKey)
+          .withEnv("AWS_SESSION_TOKEN", env.awsSessionToken);
+    }
+
+    env.testContainer.start();
+  }
+
+  private static String getContainerBaseImageName(TestEnvironmentRequest request) {
+    switch (request.getTargetJvm()) {
+      case OPENJDK:
+        return "openjdk:8-jdk-alpine";
+      case GRAALVM:
+        return "ghcr.io/graalvm/jdk:22.2.0";
+      default:
+        throw new NotImplementedException(request.getTargetJvm().toString());
+    }
+  }
+
+  private static void configureIamAccess(TestEnvironment env) {
+
+    if (env.info.getRequest().getDatabaseEngineDeployment() != DatabaseEngineDeployment.AURORA) {
+      throw new UnsupportedOperationException(
+          env.info.getRequest().getDatabaseEngineDeployment().toString());
+    }
+
+    env.info.setIamUsername(
+        !StringUtils.isNullOrEmpty(System.getenv("IAM_USER"))
+            ? System.getenv("IAM_USER")
+            : "jane_doe");
+
+    if (!env.reuseAuroraDbCluster) {
+      try {
+        Class.forName(DriverHelper.getDriverClassname(env.info.getRequest().getDatabaseEngine()));
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException(
+            "Driver not found: "
+                + DriverHelper.getDriverClassname(env.info.getRequest().getDatabaseEngine()),
+            e);
+      }
+
+      final String url =
+          String.format(
+              "%s%s:%d/%s",
+              DriverHelper.getDriverProtocol(env.info.getRequest().getDatabaseEngine()),
+              env.info.getDatabaseInfo().getClusterEndpoint(),
+              env.info.getDatabaseInfo().getClusterEndpointPort(),
+              env.info.getDatabaseInfo().getDefaultDbName());
+
+      try {
+        env.auroraUtil.addAuroraAwsIamUser(
+            env.info.getRequest().getDatabaseEngine(),
+            url,
+            env.info.getDatabaseInfo().getUsername(),
+            env.info.getDatabaseInfo().getPassword(),
+            env.info.getIamUsername(),
+            env.info.getDatabaseInfo().getDefaultDbName());
+
+      } catch (SQLException e) {
+        throw new RuntimeException("Error configuring IAM access.", e);
+      }
+    }
+  }
+
+  private static String getEnvironmentInfoAsString(TestEnvironment env) {
+    try {
+      final ObjectMapper mapper = new ObjectMapper();
+      return mapper.writeValueAsString(env.info);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Error serializing environment details.", e);
+    }
+  }
+
+  public void runTests(String taskName) throws IOException, InterruptedException {
+    final ContainerHelper containerHelper = new ContainerHelper();
+    containerHelper.runTest(this.testContainer, taskName);
+  }
+
+  public void debugTests(String taskName) throws IOException, InterruptedException {
+    final ContainerHelper containerHelper = new ContainerHelper();
+    containerHelper.debugTest(this.testContainer, taskName);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (this.databaseContainers != null) {
+      for (GenericContainer<?> container : this.databaseContainers) {
+        try {
+          container.stop();
+        } catch (Exception ex) {
+          // ignore
+        }
+      }
+      this.databaseContainers.clear();
+    }
+
+    if (this.testContainer != null) {
+      this.testContainer.stop();
+      this.testContainer = null;
+    }
+
+    if (this.proxyContainers != null) {
+      for (ToxiproxyContainer proxyContainer : this.proxyContainers) {
+        proxyContainer.stop();
+      }
+      this.proxyContainers = null;
+    }
+
+    switch (this.info.getRequest().getDatabaseEngineDeployment()) {
+      case AURORA:
+        deleteAuroraDbCluster();
+        break;
+      case RDS:
+        throw new NotImplementedException(this.info.getRequest().getTargetJvm().toString());
+      default:
+        // do nothing
+    }
+  }
+
+  private void deleteAuroraDbCluster() {
+    if (!StringUtils.isNullOrEmpty(this.runnerIP)) {
+      auroraUtil.ec2DeauthorizesIP(runnerIP);
+    }
+
+    if (!this.reuseAuroraDbCluster) {
+      LOGGER.finest("Deleting cluster " + this.auroraClusterName + "." + this.auroraClusterDomain);
+      auroraUtil.deleteCluster(this.auroraClusterName);
+      LOGGER.finest("Deleted cluster " + this.auroraClusterName + "." + this.auroraClusterDomain);
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
@@ -363,9 +363,9 @@ public class TestEnvironment implements AutoCloseable {
   private static String getAuroraDbEngineVersion(TestEnvironmentRequest request) {
     switch (request.getDatabaseEngine()) {
       case MYSQL:
-        return "8.0.mysql_aurora.3.01.0"; // TODO: verify
+        return "8.0.mysql_aurora.3.02.2";
       case PG:
-        return "13.7"; // TODO: verify
+        return "14.5";
       default:
         throw new NotImplementedException(request.getDatabaseEngine().toString());
     }
@@ -374,9 +374,9 @@ public class TestEnvironment implements AutoCloseable {
   private static String getAuroraInstanceClass(TestEnvironmentRequest request) {
     switch (request.getDatabaseEngine()) {
       case MYSQL:
-        return "db.r6g.large"; // TODO: verify
+        return "db.r6g.large";
       case PG:
-        return "db.r5.large"; // TODO: verify
+        return "db.r5.large";
       default:
         throw new NotImplementedException(request.getDatabaseEngine().toString());
     }

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironmentProvider.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironmentProvider.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.host;
+
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DatabaseEngineDeployment;
+import integration.refactored.DatabaseInstances;
+import integration.refactored.GenericTypedParameterResolver;
+import integration.refactored.TargetJvm;
+import integration.refactored.TestEnvironmentFeatures;
+import integration.refactored.TestEnvironmentRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+public class TestEnvironmentProvider implements TestTemplateInvocationContextProvider {
+
+  private static final Logger LOGGER = Logger.getLogger(TestEnvironmentProvider.class.getName());
+
+  @Override
+  public boolean supportsTestTemplate(ExtensionContext context) {
+    return true;
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      ExtensionContext context) {
+    ArrayList<TestTemplateInvocationContext> resultContextList = new ArrayList<>();
+
+    final boolean noDocker = Boolean.parseBoolean(System.getProperty("test-no-docker", "false"));
+    final boolean noAurora = Boolean.parseBoolean(System.getProperty("test-no-aurora", "false"));
+    final boolean noPerformance =
+        Boolean.parseBoolean(System.getProperty("test-no-performance", "false"));
+    final boolean noMysqlEngine =
+        Boolean.parseBoolean(System.getProperty("test-no-mysql-engine", "false"));
+    final boolean noMysqlDriver =
+        Boolean.parseBoolean(System.getProperty("test-no-mysql-driver", "false"));
+    final boolean noPgEngine =
+        Boolean.parseBoolean(System.getProperty("test-no-pg-engine", "false"));
+    final boolean noPgDriver =
+        Boolean.parseBoolean(System.getProperty("test-no-pg-driver", "false"));
+    final boolean noMariadbEngine =
+        Boolean.parseBoolean(System.getProperty("test-no-mariadb-engine", "false"));
+    final boolean noMariadbDriver =
+        Boolean.parseBoolean(System.getProperty("test-no-mariadb-driver", "false"));
+    final boolean noFailover =
+        Boolean.parseBoolean(System.getProperty("test-no-failover", "false"));
+    final boolean noIam = Boolean.parseBoolean(System.getProperty("test-no-iam", "false"));
+    final boolean noSecretsManager =
+        Boolean.parseBoolean(System.getProperty("test-no-secrets-manager", "false"));
+    final boolean noHikari = Boolean.parseBoolean(System.getProperty("test-no-hikari", "false"));
+    final boolean noGraalVm = Boolean.parseBoolean(System.getProperty("test-no-graalvm", "false"));
+    final boolean noOpenJdk = Boolean.parseBoolean(System.getProperty("test-no-openjdk", "false"));
+
+    if (!noDocker) {
+      if (!noMysqlEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MYSQL,
+                    DatabaseInstances.SINGLE_INSTANCE,
+                    1,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noPgEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.PG,
+                    DatabaseInstances.SINGLE_INSTANCE,
+                    1,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noMariadbEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MARIADB,
+                    DatabaseInstances.SINGLE_INSTANCE,
+                    1,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noMysqlEngine && !noGraalVm) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MYSQL,
+                    DatabaseInstances.SINGLE_INSTANCE,
+                    1,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.GRAALVM,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noPgEngine && !noGraalVm) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.PG,
+                    DatabaseInstances.SINGLE_INSTANCE,
+                    1,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.GRAALVM,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noMariadbEngine && !noGraalVm) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MARIADB,
+                    DatabaseInstances.SINGLE_INSTANCE,
+                    1,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.GRAALVM,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+
+      // multiple instances
+
+      if (!noMysqlEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MYSQL,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    2,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noPgEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.PG,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    2,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noMariadbEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MARIADB,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    2,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noMysqlEngine && !noGraalVm) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MYSQL,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    2,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.GRAALVM,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noPgEngine && !noGraalVm) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.PG,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    2,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.GRAALVM,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noMariadbEngine && !noGraalVm) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MARIADB,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    2,
+                    DatabaseEngineDeployment.DOCKER,
+                    TargetJvm.GRAALVM,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+    }
+
+    if (!noAurora) {
+      if (!noMysqlEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.MYSQL,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    5,
+                    DatabaseEngineDeployment.AURORA,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noFailover ? null : TestEnvironmentFeatures.FAILOVER_SUPPORTED,
+                    TestEnvironmentFeatures.AWS_CREDENTIALS_ENABLED,
+                    noIam ? null : TestEnvironmentFeatures.IAM,
+                    noSecretsManager ? null : TestEnvironmentFeatures.SECRETS_MANAGER,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noPerformance ? null : TestEnvironmentFeatures.PERFORMANCE,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+      if (!noPgEngine && !noOpenJdk) {
+        resultContextList.add(
+            getEnvironment(
+                new TestEnvironmentRequest(
+                    DatabaseEngine.PG,
+                    DatabaseInstances.MULTI_INSTANCE,
+                    5,
+                    DatabaseEngineDeployment.AURORA,
+                    TargetJvm.OPENJDK,
+                    TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
+                    noFailover ? null : TestEnvironmentFeatures.FAILOVER_SUPPORTED,
+                    TestEnvironmentFeatures.AWS_CREDENTIALS_ENABLED,
+                    noIam ? null : TestEnvironmentFeatures.IAM,
+                    noSecretsManager ? null : TestEnvironmentFeatures.SECRETS_MANAGER,
+                    noHikari ? null : TestEnvironmentFeatures.HIKARI,
+                    noPerformance ? null : TestEnvironmentFeatures.PERFORMANCE,
+                    noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
+                    noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+      }
+    }
+
+    int index = 1;
+    for (TestTemplateInvocationContext testTemplateInvocationContext : resultContextList) {
+      LOGGER.finest(
+          "Added to the test queue: " + testTemplateInvocationContext.getDisplayName(index++));
+    }
+
+    return Arrays.stream(resultContextList.toArray(new TestTemplateInvocationContext[0]));
+  }
+
+  private TestTemplateInvocationContext getEnvironment(TestEnvironmentRequest info) {
+    return new TestTemplateInvocationContext() {
+      @Override
+      public String getDisplayName(int invocationIndex) {
+        return String.format("[%d] - %s", invocationIndex, info.getDisplayName());
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return Collections.singletonList(new GenericTypedParameterResolver(info));
+      }
+    };
+  }
+}

--- a/wrapper/src/test/java/integration/refactored/host/TestRunner.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestRunner.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.refactored.host;
+
+import integration.refactored.TestEnvironmentRequest;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TestEnvironmentProvider.class)
+public class TestRunner {
+
+  @TestTemplate
+  public void runTests(TestEnvironmentRequest testEnvironmentRequest) throws Exception {
+
+    try (final TestEnvironment env = TestEnvironment.build(testEnvironmentRequest)) {
+      env.runTests("in-container");
+    }
+  }
+
+  @TestTemplate
+  public void debugTests(TestEnvironmentRequest testEnvironmentRequest) throws Exception {
+
+    try (final TestEnvironment env = TestEnvironment.build(testEnvironmentRequest)) {
+      env.debugTests("in-container");
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -16,13 +16,37 @@
 
 package integration.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.refactored.DatabaseEngine;
+import integration.refactored.DriverHelper;
+import integration.refactored.TestInstanceInfo;
+import integration.refactored.container.ConnectionStringHelper;
+import integration.refactored.container.TestEnvironment;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ec2.Ec2Client;
@@ -31,9 +55,13 @@ import software.amazon.awssdk.services.ec2.model.Ec2Exception;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
+import software.amazon.awssdk.services.rds.model.DBCluster;
+import software.amazon.awssdk.services.rds.model.DBClusterMember;
+import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.Filter;
 import software.amazon.awssdk.services.rds.model.Tag;
@@ -45,6 +73,9 @@ import software.amazon.jdbc.util.StringUtils;
  * environment variables must be defined: - AWS_ACCESS_KEY_ID - AWS_SECRET_ACCESS_KEY
  */
 public class AuroraTestUtility {
+
+  private static final Logger LOGGER = Logger.getLogger(AuroraTestUtility.class.getName());
+
   // Default values
   private String dbUsername = "my_test_username";
   private String dbPassword = "my_test_password";
@@ -56,6 +87,7 @@ public class AuroraTestUtility {
   private final Region dbRegion;
   private final String dbSecGroup = "default";
   private int numOfInstances = 5;
+  private ArrayList<TestInstanceInfo> instances = new ArrayList<>();
 
   private final RdsClient rdsClient;
   private final Ec2Client ec2Client;
@@ -90,19 +122,30 @@ public class AuroraTestUtility {
     this(getRegionInternal(region), DefaultCredentialsProvider.create());
   }
 
+  public AuroraTestUtility(
+      String region, String awsAccessKeyId, String awsSecretAccessKey, String awsSessionToken) {
+
+    this(
+        getRegionInternal(region),
+        StaticCredentialsProvider.create(
+            AwsSessionCredentials.create(awsAccessKeyId, awsSecretAccessKey, awsSessionToken)));
+  }
+
   /**
    * Initializes an AmazonRDS & AmazonEC2 client.
    *
    * @param region define AWS Regions, refer to
    *     https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
-   * @param credentials Specific AWS credential provider
+   * @param credentialsProvider Specific AWS credential provider
    */
-  public AuroraTestUtility(Region region, DefaultCredentialsProvider credentials) {
+  public AuroraTestUtility(Region region, AwsCredentialsProvider credentialsProvider) {
     dbRegion = region;
 
-    rdsClient = RdsClient.builder().region(dbRegion).credentialsProvider(credentials).build();
+    rdsClient =
+        RdsClient.builder().region(dbRegion).credentialsProvider(credentialsProvider).build();
 
-    ec2Client = Ec2Client.builder().region(dbRegion).credentialsProvider(credentials).build();
+    ec2Client =
+        Ec2Client.builder().region(dbRegion).credentialsProvider(credentialsProvider).build();
   }
 
   public Region getRegion(String rdsRegion) {
@@ -119,13 +162,26 @@ public class AuroraTestUtility {
     throw new IllegalArgumentException(String.format("Unknown AWS region '%s'.", rdsRegion));
   }
 
+  public String createCluster(
+      String username,
+      String password,
+      String name,
+      String identifier,
+      String engine,
+      String instanceClass,
+      String version)
+      throws InterruptedException {
+    return createCluster(
+        username, password, name, identifier, engine, instanceClass, version, 5, new ArrayList<>());
+  }
+
   /**
    * Creates RDS Cluster/Instances and waits until they are up, and proper IP whitelisting for
    * databases.
    *
    * @param username Master username for access to database
    * @param password Master password for access to database
-   * @param name Database name
+   * @param dbName Database name
    * @param identifier Database cluster identifier
    * @param engine Database engine to use, refer to
    *     https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html
@@ -138,20 +194,29 @@ public class AuroraTestUtility {
   public String createCluster(
       String username,
       String password,
-      String name,
+      String dbName,
       String identifier,
       String engine,
       String instanceClass,
-      String version)
+      String version,
+      int numOfInstances,
+      ArrayList<TestInstanceInfo> instances)
       throws InterruptedException {
     dbUsername = username;
     dbPassword = password;
-    dbName = name;
+    this.dbName = dbName;
     dbIdentifier = identifier;
     dbEngine = engine;
     dbInstanceClass = instanceClass;
     dbEngineVersion = version;
+    this.numOfInstances = numOfInstances;
+    this.instances = instances;
     return createCluster();
+  }
+
+  public String createCluster(String username, String password, String name, String identifier)
+      throws InterruptedException {
+    return createCluster(username, password, name, identifier, 5);
   }
 
   /**
@@ -165,12 +230,15 @@ public class AuroraTestUtility {
    * @return An endpoint for one of the instances
    * @throws InterruptedException when clusters have not started after 30 minutes
    */
-  public String createCluster(String username, String password, String name, String identifier)
+  public String createCluster(
+      String username, String password, String name, String identifier, int numOfInstances)
       throws InterruptedException {
     dbUsername = username;
     dbPassword = password;
     dbName = name;
     dbIdentifier = identifier;
+    this.numOfInstances = numOfInstances;
+    this.instances = new ArrayList<>();
     return createCluster();
   }
 
@@ -203,10 +271,11 @@ public class AuroraTestUtility {
 
     // Create Instances
     for (int i = 1; i <= numOfInstances; i++) {
+      final String instanceName = dbIdentifier + "-" + i;
       rdsClient.createDBInstance(
           CreateDbInstanceRequest.builder()
               .dbClusterIdentifier(dbIdentifier)
-              .dbInstanceIdentifier(dbIdentifier + "-" + i)
+              .dbInstanceIdentifier(instanceName)
               .dbClusterIdentifier(dbIdentifier)
               .dbInstanceClass(dbInstanceClass)
               .engine(dbEngine)
@@ -237,7 +306,18 @@ public class AuroraTestUtility {
                 builder.filters(
                     Filter.builder().name("db-cluster-id").values(dbIdentifier).build()));
     final String endpoint = dbInstancesResult.dbInstances().get(0).endpoint().address();
-    return endpoint.substring(endpoint.indexOf('.') + 1);
+    final String clusterDomainPrefix = endpoint.substring(endpoint.indexOf('.') + 1);
+
+    for (DBInstance instance : dbInstancesResult.dbInstances()) {
+      String zone = instance.availabilityZone();
+      this.instances.add(
+          new TestInstanceInfo(
+              instance.dbInstanceIdentifier(),
+              instance.endpoint().address(),
+              instance.endpoint().port()));
+    }
+
+    return clusterDomainPrefix;
   }
 
   /**
@@ -285,15 +365,16 @@ public class AuroraTestUtility {
   }
 
   private boolean ipExists(String ipAddress) {
-    final DescribeSecurityGroupsResponse response = ec2Client.describeSecurityGroups(
-        (builder) ->
-            builder
-                .groupNames(dbSecGroup)
-                .filters(software.amazon.awssdk.services.ec2.model.Filter.builder()
-                    .name("ip-permission.cidr")
-                    .values(ipAddress + "/32")
-                    .build())
-    );
+    final DescribeSecurityGroupsResponse response =
+        ec2Client.describeSecurityGroups(
+            (builder) ->
+                builder
+                    .groupNames(dbSecGroup)
+                    .filters(
+                        software.amazon.awssdk.services.ec2.model.Filter.builder()
+                            .name("ip-permission.cidr")
+                            .values(ipAddress + "/32")
+                            .build()));
 
     return response != null && !response.securityGroups().isEmpty();
   }
@@ -331,11 +412,16 @@ public class AuroraTestUtility {
   public void deleteCluster() {
     // Tear down instances
     for (int i = 1; i <= numOfInstances; i++) {
-      rdsClient.deleteDBInstance(
-          DeleteDbInstanceRequest.builder()
-              .dbInstanceIdentifier(dbIdentifier + "-" + i)
-              .skipFinalSnapshot(true)
-              .build());
+      try {
+        rdsClient.deleteDBInstance(
+            DeleteDbInstanceRequest.builder()
+                .dbInstanceIdentifier(dbIdentifier + "-" + i)
+                .skipFinalSnapshot(true)
+                .build());
+      } catch (Exception ex) {
+        LOGGER.finest("Error deleting instance " + dbIdentifier + "-" + i + ". " + ex.getMessage());
+        // Ignore this error and continue with other instances
+      }
     }
 
     // Tear down cluster
@@ -344,14 +430,342 @@ public class AuroraTestUtility {
   }
 
   public boolean doesClusterExist(final String clusterId) {
-    final DescribeDbClustersRequest request = DescribeDbClustersRequest.builder()
-        .dbClusterIdentifier(clusterId)
-        .build();
+    final DescribeDbClustersRequest request =
+        DescribeDbClustersRequest.builder().dbClusterIdentifier(clusterId).build();
     try {
       rdsClient.describeDBClusters(request);
     } catch (DbClusterNotFoundException ex) {
       return false;
     }
     return true;
+  }
+
+  public DatabaseEngine getClusterDatabaseEngine(final String clusterId) {
+    final DescribeDbClustersRequest request =
+        DescribeDbClustersRequest.builder().dbClusterIdentifier(clusterId).build();
+    final DescribeDbClustersResponse response = rdsClient.describeDBClusters(request);
+    if (!response.hasDbClusters()) {
+      throw new RuntimeException("Cluster " + clusterId + " not found.");
+    }
+
+    switch (response.dbClusters().get(0).engine()) {
+      case "aurora-postgresql":
+        return DatabaseEngine.PG;
+      case "aurora-mysql":
+        return DatabaseEngine.MYSQL;
+      default:
+        throw new UnsupportedOperationException(response.dbClusters().get(0).engine());
+    }
+  }
+
+  public List<TestInstanceInfo> getClusterInstanceIds(final String clusterId) {
+    final DescribeDbInstancesResponse dbInstancesResult =
+        rdsClient.describeDBInstances(
+            (builder) ->
+                builder.filters(Filter.builder().name("db-cluster-id").values(clusterId).build()));
+
+    List<TestInstanceInfo> result = new ArrayList<>();
+    for (DBInstance instance : dbInstancesResult.dbInstances()) {
+      result.add(
+          new TestInstanceInfo(
+              instance.dbInstanceIdentifier(),
+              instance.endpoint().address(),
+              instance.endpoint().port()));
+    }
+    return result;
+  }
+
+  public void waitUntilClusterHasRightState(String clusterId) throws InterruptedException {
+    String status = getDBCluster(clusterId).status();
+    while (!"available".equalsIgnoreCase(status)) {
+      TimeUnit.MILLISECONDS.sleep(1000);
+      status = getDBCluster(clusterId).status();
+    }
+  }
+
+  public DBCluster getDBCluster(String clusterId) {
+    final DescribeDbClustersResponse dbClustersResult =
+        rdsClient.describeDBClusters((builder) -> builder.dbClusterIdentifier(clusterId));
+    final List<DBCluster> dbClusterList = dbClustersResult.dbClusters();
+    return dbClusterList.get(0);
+  }
+
+  public List<String> getAuroraInstanceIds() throws SQLException {
+    return getAuroraInstanceIds(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(),
+        ConnectionStringHelper.getUrl(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername(),
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+  }
+
+  public List<String> getAuroraInstanceIds(
+      DatabaseEngine databaseEngine, String connectionUrl, String userName, String password)
+      throws SQLException {
+
+    String retrieveTopologySql;
+    switch (databaseEngine) {
+      case MYSQL:
+        retrieveTopologySql =
+            "SELECT SERVER_ID, SESSION_ID FROM information_schema.replica_host_status "
+                + "ORDER BY IF(SESSION_ID = 'MASTER_SESSION_ID', 0, 1)";
+        break;
+      case PG:
+        retrieveTopologySql =
+            "SELECT SERVER_ID, SESSION_ID FROM aurora_replica_status() "
+                + "ORDER BY CASE WHEN SESSION_ID = 'MASTER_SESSION_ID' THEN 0 ELSE 1 END";
+        break;
+      default:
+        throw new UnsupportedOperationException(databaseEngine.toString());
+    }
+
+    ArrayList<String> auroraInstances = new ArrayList<>();
+
+    try (final Connection conn = DriverManager.getConnection(connectionUrl, userName, password);
+        final Statement stmt = conn.createStatement()) {
+      // Get instances
+      try (final ResultSet resultSet = stmt.executeQuery(retrieveTopologySql)) {
+        while (resultSet.next()) {
+          // Get Instance endpoints
+          final String hostEndpoint = resultSet.getString("SERVER_ID");
+          auroraInstances.add(hostEndpoint);
+        }
+      }
+    }
+    return auroraInstances;
+  }
+
+  public Boolean isDBInstanceWriter(String instanceId) {
+    return isDBInstanceWriter(
+        TestEnvironment.getCurrent().getInfo().getAuroraClusterName(), instanceId);
+  }
+
+  public Boolean isDBInstanceWriter(String clusterId, String instanceId) {
+    return getMatchedDBClusterMember(clusterId, instanceId).isClusterWriter();
+  }
+
+  public Boolean isDBInstanceReader(String clusterId, String instanceId) {
+    return !getMatchedDBClusterMember(clusterId, instanceId).isClusterWriter();
+  }
+
+  public DBClusterMember getMatchedDBClusterMember(String clusterId, String instanceId) {
+    final List<DBClusterMember> matchedMemberList =
+        getDBClusterMemberList(clusterId).stream()
+            .filter(dbClusterMember -> dbClusterMember.dbInstanceIdentifier().equals(instanceId))
+            .collect(Collectors.toList());
+    if (matchedMemberList.isEmpty()) {
+      throw new RuntimeException(
+          "Cannot find cluster member whose db instance identifier is " + instanceId);
+    }
+    return matchedMemberList.get(0);
+  }
+
+  public List<DBClusterMember> getDBClusterMemberList(String clusterId) {
+    final DBCluster dbCluster = getDBCluster(clusterId);
+    return dbCluster.dbClusterMembers();
+  }
+
+  public void makeSureInstancesUp(List<String> instances) throws InterruptedException {
+    makeSureInstancesUp(instances, true);
+  }
+
+  protected void makeSureInstancesUp(List<String> instances, boolean finalCheck)
+      throws InterruptedException {
+    final ExecutorService executorService = Executors.newFixedThreadPool(instances.size());
+    final ConcurrentHashMap<String, Boolean> remainingInstances = new ConcurrentHashMap<>();
+    instances.forEach((k) -> remainingInstances.put(k, true));
+
+    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    DriverHelper.setConnectTimeout(props, 5, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(props, 5, TimeUnit.SECONDS);
+
+    for (final String id : instances) {
+      executorService.submit(
+          () -> {
+            while (true) {
+              TestInstanceInfo instanceInfo =
+                  TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(id);
+              try (final Connection conn =
+                  DriverManager.getConnection(
+                      ConnectionStringHelper.getUrl(
+                          instanceInfo.getEndpoint(),
+                          instanceInfo.getEndpointPort(),
+                          TestEnvironment.getCurrent()
+                              .getInfo()
+                              .getDatabaseInfo()
+                              .getDefaultDbName()),
+                      props)) {
+                remainingInstances.remove(id);
+                break;
+              } catch (final SQLException ex) {
+                ex.printStackTrace();
+                // Continue waiting until instance is up.
+              } catch (final Exception ex) {
+                System.out.println("Exception: " + ex);
+                break;
+              }
+              TimeUnit.MILLISECONDS.sleep(1000);
+            }
+            return null;
+          });
+    }
+    executorService.shutdown();
+    executorService.awaitTermination(5, TimeUnit.MINUTES);
+
+    if (finalCheck) {
+      assertTrue(
+          remainingInstances.isEmpty(),
+          "The following instances are still down: \n"
+              + String.join("\n", remainingInstances.keySet()));
+    }
+  }
+
+  public void failoverClusterAndWaitUntilWriterChanged(String clusterWriterId)
+      throws InterruptedException {
+    failoverClusterAndWaitUntilWriterChanged(
+        TestEnvironment.getCurrent().getInfo().getAuroraClusterName(), clusterWriterId);
+  }
+
+  public void failoverClusterAndWaitUntilWriterChanged(String clusterId, String clusterWriterId)
+      throws InterruptedException {
+    failoverCluster(clusterId);
+    waitUntilWriterInstanceChanged(clusterId, clusterWriterId);
+  }
+
+  public void failoverCluster(String clusterId) throws InterruptedException {
+    waitUntilClusterHasRightState(clusterId);
+    while (true) {
+      try {
+        rdsClient.failoverDBCluster((builder) -> builder.dbClusterIdentifier(clusterId));
+        break;
+      } catch (final Exception e) {
+        TimeUnit.MILLISECONDS.sleep(1000);
+      }
+    }
+  }
+
+  public void waitUntilWriterInstanceChanged(String clusterId, String initialWriterInstanceId)
+      throws InterruptedException {
+    String nextClusterWriterId = getDBClusterWriterInstanceId(clusterId);
+    while (initialWriterInstanceId.equals(nextClusterWriterId)) {
+      TimeUnit.MILLISECONDS.sleep(3000);
+      // Calling the RDS API to get writer Id.
+      nextClusterWriterId = getDBClusterWriterInstanceId(clusterId);
+    }
+  }
+
+  public void failoverClusterToATargetAndWaitUntilWriterChanged(
+      String clusterWriterId, String targetInstanceId) throws InterruptedException {
+
+    failoverClusterToATargetAndWaitUntilWriterChanged(
+        TestEnvironment.getCurrent().getInfo().getAuroraClusterName(),
+        clusterWriterId,
+        targetInstanceId);
+  }
+
+  public void failoverClusterToATargetAndWaitUntilWriterChanged(
+      String clusterId, String clusterWriterId, String targetInstanceId)
+      throws InterruptedException {
+
+    failoverClusterWithATargetInstance(clusterId, targetInstanceId);
+    waitUntilWriterInstanceChanged(clusterId, clusterWriterId);
+  }
+
+  public void failoverClusterWithATargetInstance(String clusterId, String targetInstanceId)
+      throws InterruptedException {
+    waitUntilClusterHasRightState(clusterId);
+
+    while (true) {
+      try {
+        rdsClient.failoverDBCluster(
+            (builder) ->
+                builder
+                    .dbClusterIdentifier(clusterId)
+                    .targetDBInstanceIdentifier(targetInstanceId));
+        break;
+      } catch (final Exception e) {
+        TimeUnit.MILLISECONDS.sleep(1000);
+      }
+    }
+  }
+
+  public String getDBClusterWriterInstanceId() {
+    return getDBClusterWriterInstanceId(
+        TestEnvironment.getCurrent().getInfo().getAuroraClusterName());
+  }
+
+  public String getDBClusterWriterInstanceId(String clusterId) {
+    final List<DBClusterMember> matchedMemberList =
+        getDBClusterMemberList(clusterId).stream()
+            .filter(DBClusterMember::isClusterWriter)
+            .collect(Collectors.toList());
+    if (matchedMemberList.isEmpty()) {
+      throw new RuntimeException(clusterId);
+    }
+    // Should be only one writer at index 0.
+    return matchedMemberList.get(0).dbInstanceIdentifier();
+  }
+
+  protected String getInstanceIdSql(DatabaseEngine databaseEngine) {
+    switch (databaseEngine) {
+      case MYSQL:
+        return "SELECT @@aurora_server_id as id";
+      case PG:
+        return "SELECT aurora_db_instance_identifier()";
+      default:
+        throw new UnsupportedOperationException(databaseEngine.toString());
+    }
+  }
+
+  public String queryInstanceId(Connection connection) throws SQLException {
+    return queryInstanceId(
+        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), connection);
+  }
+
+  public String queryInstanceId(DatabaseEngine databaseEngine, Connection connection)
+      throws SQLException {
+    try (final Statement stmt = connection.createStatement()) {
+      return executeInstanceIdQuery(databaseEngine, stmt);
+    }
+  }
+
+  public String executeInstanceIdQuery(DatabaseEngine databaseEngine, Statement stmt)
+      throws SQLException {
+    try (final ResultSet rs = stmt.executeQuery(getInstanceIdSql(databaseEngine))) {
+      if (rs.next()) {
+        return rs.getString(1);
+      }
+    }
+    return null;
+  }
+
+  public void addAuroraAwsIamUser(
+      DatabaseEngine databaseEngine,
+      String connectionUrl,
+      String userName,
+      String password,
+      String dbUser,
+      String databaseName)
+      throws SQLException {
+
+    try (final Connection conn = DriverManager.getConnection(connectionUrl, userName, password);
+        final Statement stmt = conn.createStatement()) {
+
+      switch (databaseEngine) {
+        case MYSQL:
+          stmt.execute("DROP USER IF EXISTS " + dbUser + ";");
+          stmt.execute(
+              "CREATE USER " + dbUser + " IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';");
+          stmt.execute("GRANT ALL PRIVILEGES ON " + databaseName + ".* TO '" + dbUser + "'@'%';");
+          break;
+        case PG:
+          stmt.execute("DROP USER IF EXISTS " + dbUser + ";");
+          stmt.execute("CREATE USER " + dbUser + ";");
+          stmt.execute("GRANT rds_iam TO " + dbUser + ";");
+          stmt.execute("GRANT ALL PRIVILEGES ON DATABASE " + databaseName + " TO " + dbUser + ";");
+          break;
+        default:
+          throw new UnsupportedOperationException(databaseEngine.toString());
+      }
+    }
   }
 }

--- a/wrapper/src/test/resources/logging-test.properties
+++ b/wrapper/src/test/resources/logging-test.properties
@@ -31,8 +31,10 @@ software.amazon.jdbc.plugin.failover.ClusterAwareReaderFailoverHandler.level=ALL
 software.amazon.jdbc.plugin.IamAuthConnectionPlugin.level=FINEST
 software.amazon.jdbc.plugin.AuroraStaleDnsPlugin.level=FINEST
 software.amazon.jdbc.plugin.AuroraStaleDnsHelper.level=FINEST
+software.amazon.jdbc.plugin.readwritesplitting.level=FINEST
+
 integration.container.level=FINE
 integration.container.aurora.postgres.AuroraPostgresStaleDnsTest.level=FINEST
 integration.container.aurora.postgres.AuroraAdvancedPerformanceTest.level=FINEST
 integration.container.aurora.postgres.AuroraPostgresBaseTest.level=FINEST
-
+integration.refactored.level=FINEST


### PR DESCRIPTION
### Summary

Integration test suite has been refactored to avoid code repetition and to bring more test environments.
RDS-1233: Wrapper - Migrate functional integration tests under new refactored integration suite.

### Description

Refactored integration suite is located at test//java/integration.refactored
All functional tests and performance tests have been migrated under new suite. The only remaining test (not migrated) is AuroraPostgresReadWriteSplittingPerformanceTest.

AuroraPostgresReadWriteSplittingTest.test_setReadOnlyTrue_allInstancesDown() is disabled and will be investigated as a separated PR. 

### Additional Reviewers

@karenc-bq 
@aaron-congo 
@joyc-bq 
@aaronchung-bitquill 
