### PR TITLE
fix: incorrect log message for empty host change lists.

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -250,7 +250,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
         .collect(Collectors.toList());
 
     if (hostsToChange.isEmpty()) {
-      LOGGER.finest(() -> Messages.get("PluginServiceImpl.hostAliasNotFound", new Object[] {hostAliases}));
+      LOGGER.finest(() -> Messages.get("PluginServiceImpl.hostsChangelistEmpty"));
       return;
     }
 

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -162,6 +162,7 @@ PluginServiceImpl.hostListEmpty=Current host list is empty.
 PluginServiceImpl.releaseResources=Releasing resources.
 PluginServiceImpl.hostListException=Exception while getting a host list.
 PluginServiceImpl.hostAliasNotFound=Can't find any host by the following aliases: {0}
+PluginServiceImpl.hostsChangelistEmpty=There are no changes in the hosts' availability.
 
 # Property Utils
 PropertyUtils.setMethodDoesNotExistOnTarget=Set method for property ''{0}'' does not exist on target ''{0}''.


### PR DESCRIPTION
### Summary

Fix an incorrect log message in `PluginServiceImpl#setAvailability` that says host alias not found instead of empty hosts change list.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->