### PR TITLE
fix: report wrapper driver version with git commit id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,11 +55,15 @@ allprojects {
                 ?: throw GradleException("Unable to parse major.minor.patch version parts from project.version '$version'")
             val (major, minor, patch) = matchResult.destructured
 
+            val git = org.ajoberstar.grgit.Grgit.open(mapOf("currentDir" to project.rootDir))
+            val revision = git.head().id
+
             variables.apply {
                 put("version", version)
                 put("version.major", major)
                 put("version.minor", minor)
                 put("version.patch", patch.ifBlank { "0" })
+                put("version.revision", revision.toString())
             }
         }
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/DatabaseMetaDataWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/DatabaseMetaDataWrapper.java
@@ -21,8 +21,10 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
+import java.util.StringJoiner;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.ConnectionPluginManager;
+import software.amazon.jdbc.util.DriverInfo;
 import software.amazon.jdbc.util.WrapperUtils;
 
 public class DatabaseMetaDataWrapper implements DatabaseMetaData {
@@ -159,44 +161,27 @@ public class DatabaseMetaDataWrapper implements DatabaseMetaData {
 
   @Override
   public String getDriverName() throws SQLException {
-    return WrapperUtils.executeWithPlugins(
-        String.class,
-        SQLException.class,
-        this.pluginManager,
-        this.databaseMetaData,
-        "DatabaseMetaData.getDriverName",
-        () -> this.databaseMetaData.getDriverName());
+    return DriverInfo.DRIVER_NAME;
   }
 
   @Override
   public String getDriverVersion() throws SQLException {
-    return WrapperUtils.executeWithPlugins(
-        String.class,
-        SQLException.class,
-        this.pluginManager,
-        this.databaseMetaData,
-        "DatabaseMetaData.getDriverVersion",
-        () -> this.databaseMetaData.getDriverVersion());
+    final StringJoiner joiner = new StringJoiner(" ");
+    joiner
+        .add(DriverInfo.DRIVER_NAME)
+        .add(DriverInfo.DRIVER_VERSION)
+        .add("( Revision:").add(DriverInfo.REVISION_VERSION).add(")");
+    return joiner.toString();
   }
 
   @Override
   public int getDriverMajorVersion() {
-    return WrapperUtils.executeWithPlugins(
-        int.class,
-        this.pluginManager,
-        this.databaseMetaData,
-        "DatabaseMetaData.getDriverMajorVersion",
-        () -> this.databaseMetaData.getDriverMajorVersion());
+    return DriverInfo.MAJOR_VERSION;
   }
 
   @Override
   public int getDriverMinorVersion() {
-    return WrapperUtils.executeWithPlugins(
-        int.class,
-        this.pluginManager,
-        this.databaseMetaData,
-        "DatabaseMetaData.getDriverMinorVersion",
-        () -> this.databaseMetaData.getDriverMinorVersion());
+    return DriverInfo.MINOR_VERSION;
   }
 
   @Override

--- a/wrapper/src/main/version/software/amazon/jdbc/util/DriverInfo.java
+++ b/wrapper/src/main/version/software/amazon/jdbc/util/DriverInfo.java
@@ -26,6 +26,7 @@ public final class DriverInfo {
   public static final int MAJOR_VERSION = /*$version.major+";"$*//*-*/0;
   public static final int MINOR_VERSION = /*$version.minor+";"$*//*-*/1;
   public static final int PATCH_VERSION = /*$version.patch+";"$*//*-*/0;
+  public static final String REVISION_VERSION = "/*$version.revision$*/";
 
   // JDBC specification
   public static final String JDBC_VERSION = "4.2";


### PR DESCRIPTION
### Summary

Return the correct Wrapper driver version when `DatabaseMetaData#get*Version()` is called.

### Description

When `DatabaseMetaData#get*Version()` is called, the wrapper incorrectly returned the target driver's version instead of its own version, e.g. 45.0.0 instead of 1.0.0.
This fix the version reporting as well as include the Git commit ID in the version.
The driver now reports: 
`Amazon Web Services (AWS) Advanced JDBC Wrapper 1.0.0 ( Revision: b49968339f99d7f97dda95815ec41bff264b2c72 )`

Test code:
```java
    try (Connection conn = DriverManager.getConnection(CONNECTION_STRING, properties)) {
      DatabaseMetaData metadata = conn.getMetaData();
      String driverName = metadata.getDriverName();
      String driverVersion = metadata.getDriverVersion();
      int majorVersion = metadata.getDriverMajorVersion();
      int minorVersion = metadata.getDriverMinorVersion();

      System.out.println("driverName = " + driverName);
      System.out.println("driverVersion = " + driverVersion);
      System.out.println("majorVersion = " + majorVersion);
      System.out.println("minorVersion = " + minorVersion);
    }
```

Test output:
```
driverName = Amazon Web Services (AWS) Advanced JDBC Wrapper
driverVersion = Amazon Web Services (AWS) Advanced JDBC Wrapper 1.0.0 ( Revision: abe7ebc2e03bd14ec8cc399a4a706728dfa7435f )
majorVersion = 1
minorVersion = 0
```

### Additional Reviewers

@aaronchung-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.