### PR TITLE
fix: close aws secrets manager client

### DIFF
--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPluginTest.java
@@ -97,7 +97,7 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         mockService,
         TEST_PROPS,
-        (r) -> mockSecretsManagerClient,
+        (host, r) -> mockSecretsManagerClient,
         (id) -> mockGetValueRequest);
   }
 
@@ -181,7 +181,7 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", protocol),
         TEST_PROPS,
-        (r) -> mockSecretsManagerClient,
+        (host, r) -> mockSecretsManagerClient,
         (id) -> mockGetValueRequest);
 
     // Fail the initial connection attempt with cached secret.
@@ -270,7 +270,7 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", TEST_PG_PROTOCOL),
         TEST_PROPS,
-        (r) -> mockSecretsManagerClient,
+        (host, r) -> mockSecretsManagerClient,
         (id) -> mockGetValueRequest);
 
     // Fail the initial connection attempt with a wrapped exception.
@@ -301,7 +301,7 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", TEST_MYSQL_PROTOCOL),
         TEST_PROPS,
-        (r) -> mockSecretsManagerClient,
+        (host, r) -> mockSecretsManagerClient,
         (id) -> mockGetValueRequest);
 
     final CJException targetException = new CJException("28000");
@@ -331,7 +331,7 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", TEST_PG_PROTOCOL),
         TEST_PROPS,
-        (r) -> mockSecretsManagerClient,
+        (host, r) -> mockSecretsManagerClient,
         (id) -> mockGetValueRequest);
 
     final PSQLException targetException = new PSQLException("login error", PSQLState.INVALID_PASSWORD, null);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPluginTest.java
@@ -97,8 +97,8 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         mockService,
         TEST_PROPS,
-        mockSecretsManagerClient,
-        mockGetValueRequest);
+        (r) -> mockSecretsManagerClient,
+        (id) -> mockGetValueRequest);
   }
 
   @AfterEach
@@ -181,8 +181,8 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", protocol),
         TEST_PROPS,
-        mockSecretsManagerClient,
-        mockGetValueRequest);
+        (r) -> mockSecretsManagerClient,
+        (id) -> mockGetValueRequest);
 
     // Fail the initial connection attempt with cached secret.
     // Second attempt should be successful.
@@ -270,8 +270,8 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", TEST_PG_PROTOCOL),
         TEST_PROPS,
-        mockSecretsManagerClient,
-        mockGetValueRequest);
+        (r) -> mockSecretsManagerClient,
+        (id) -> mockGetValueRequest);
 
     // Fail the initial connection attempt with a wrapped exception.
     // Second attempt should be successful.
@@ -301,8 +301,8 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", TEST_MYSQL_PROTOCOL),
         TEST_PROPS,
-        mockSecretsManagerClient,
-        mockGetValueRequest);
+        (r) -> mockSecretsManagerClient,
+        (id) -> mockGetValueRequest);
 
     final CJException targetException = new CJException("28000");
     final SQLException wrappedException = new SQLException(targetException);
@@ -331,8 +331,8 @@ public class AwsSecretsManagerConnectionPluginTest {
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, TEST_PROPS, "url", TEST_PG_PROTOCOL),
         TEST_PROPS,
-        mockSecretsManagerClient,
-        mockGetValueRequest);
+        (r) -> mockSecretsManagerClient,
+        (id) -> mockGetValueRequest);
 
     final PSQLException targetException = new PSQLException("login error", PSQLState.INVALID_PASSWORD, null);
     final SQLException wrappedException = new SQLException(targetException);


### PR DESCRIPTION
### Summary

Close SecretsManagerClient to prevent leaking PoolingHttpClientConnectionManager.

### Description

AWSSecretsManagerPlugin creates a new SecretsManagerClient for each connection, which creates a new PoolingHttpClientConnectionManager. The driver never closes these SecretsManagerClient so as the user application runs on the number of PoolingHttpClientConnectionManager instances just keep climbing.

### Additional Reviewers

@joyc-bq 
@aaronchung-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.