### PR TITLE
fix - ReconnectToWriterHandler success flag by fixing isCurrentHostWr…

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareWriterFailoverHandler.java
@@ -293,14 +293,12 @@ public class ClusterAwareWriterFailoverHandler implements WriterFailoverHandler 
     }
 
     private boolean isCurrentHostWriter(final List<HostSpec> latestTopology) {
-      final Set<String> currentAliases = this.originalWriterHost.getAliases();
       final HostSpec latestWriter = getWriter(latestTopology);
-      if (currentAliases == null) {
-        return false;
-      }
-      final Set<String> latestWriterAliases = latestWriter.getAliases();
+      final Set<String> latestWriterAllAliases = latestWriter.asAliases();
+      final Set<String> currentAliases = this.originalWriterHost.getAliases();
 
-      return latestWriterAliases.stream().anyMatch(currentAliases::contains);
+      return (currentAliases != null)
+          && (latestWriterAllAliases.stream().anyMatch(currentAliases::contains));
     }
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -801,5 +801,4 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
 
     return conn;
   }
-
 }


### PR DESCRIPTION
…iter()

Fix isCurrentHostWrite() which the ReconnectToWriterHandler success flag uses. Added more checks on host aliases fields to make it more robust

### Summary

<!--- General summary / title -->

The ClusterAwareWriterFailoverHandler has a sub class ReconnectToWriterHandler. It returns a success flag. In some scenarios is was returning back success=false. This was because the success flag is based on the isCurrentHostWrite() method which was incorrectly returning false. It does this by comparing the aliases of the originalWriterHost to the newWriterHost. This fix changes the to use the HostSpec.allAlias fields to make it more robust in case different HostSpec objects pointing to the same host have some differing aliases fields. 

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->
@sergiyv-improving @karenc-bq @aaron-congo @joyc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.