### PR TITLE
Add configuration for reader load balancing in autocommit-on mode

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -2,19 +2,6 @@
 
 The read-write splitting plugin adds functionality to switch between writer/reader instances via calls to the `Connection#setReadOnly` method. Upon calling `setReadOnly(true)`, the plugin will establish a connection to a random reader instance and direct subsequent queries to this instance. Future calls to `setReadOnly` will switch between the established writer and reader connections according to the boolean argument you supply to the `setReadOnly` method.
 
-### Session State Limitations with the Read-Write Splitting Plugin
-
-There are many session state attributes that can change during a session, and many ways to change them. Consequently, the read-write splitting plugin has limited support for transferring session state between connections. The following attributes will be automatically transferred when switching connections:
-
-- autocommit value
-- transaction isolation level
-
-All other session state attributes will be lost when switching connections. There are two scenarios when the plugin may switch a connection:
-1. You have loaded the plugin but have kept reader load balancing disabled. In this case, the connection will switch between the writer/reader when calling `setReadOnly`.
-2. You have loaded the plugin and have enabled reader load balancing. In this case, the connection will still switch between the writer/reader when calling `setReadOnly`. It will also switch at transaction boundaries. See the section on [reader load balancing](#reader-load-balancing) for more information on what is consided a transaction boundary.
-
-If your SQL workflow depends on session state attributes that are not mentioned above, you will need to re-configure those attributes whenever the connection is switched. If you have loaded the plugin but have kept reader load balancing disabled, you will need to re-configure these attributes after each call to `setReadOnly`. If reader load balancing is enabled, you will also need to re-configure these attributes after each transaction boundary. Since reader load balancing frequently switches the connection, we recommend that you keep it disabled if your workflow depends on session state attributes that are not automatically transferred.
-
 ### Loading the Read-Write Splitting Plugin
 
 The read-write splitting plugin is not loaded by default. To load the plugin, include it in the `wrapperPlugins` connection parameter:
@@ -30,31 +17,27 @@ If you would like to use the read-write splitting plugin without the failover pl
 final Properties properties = new Properties();
 properties.setProperty(PropertyDefinition.PLUGINS.name, "auroraHostList,readWriteSplitting");
 ```
-### Reader Load Balancing
+
+### Reader load balancing
 
 The plugin can also load balance queries among available reader instances by enabling the `loadBalanceReadOnlyTraffic` connection parameter. This parameter is disabled by default. To enable it, set the following connection parameter:
 ```
 properties.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.name, "true");
 ```
 
-Once this parameter is enabled and `setReadOnly(true)` has been called on the `Connection` object, the plugin will switch to a new randomly selected reader instance at each transaction boundary. The following scenarios are considered transaction boundaries:
+Once this parameter is enabled and `setReadOnly(true)` has been called on the `Connection` object, the plugin will switch to a new randomly selected reader instance at each transaction boundary while autocommit is off. The following scenarios are considered transaction boundaries:
 - After calling `commit()` or `rollback()`
 - After executing `COMMIT`, `ROLLBACK` or `ABORT` as a SQL statement
-- After executing any SQL statement while autocommit is on, with the following exceptions:
-    - The statement started a transaction via `BEGIN` or `START TRANSACTION`
-    - The statement began with `SET`, `USE`, or `SHOW`
 
-### Limitations with Reader Load Balancing
+By default, the plugin will not load balance queries while autocommit is on, even if `loadBalanceReadOnlyTraffic` is set to true. To enable load balancing with autocommit enabled, set `loadBalanceReadOnlyTraffic` to true and `readerBalanceAutoCommitStatementLimit` to a positive value X. The plugin will then load balance after every X statements executed while in read-only mode with autocommit on. If you would instead like to load balance after every X statements matching a custom regex, set the `readerBalanceAutoCommitStatementRegex` parameter (note that `readerBalanceAutoCommitStatementLimit` must also be set to a positive value).
 
-When reader load balancing is enabled, the read-write splitting plugin will analyze methods and statements executed against the Connection object to determine when the connection is at a transaction boundary. This analysis does not support SQL strings containing multiple statements. If your SQL strings contain multiple statements, we recommend that you do not enable reader load balancing as the resulting behavior is not defined. If a SQL string with multiple statements is provided, the plugin will only analyze the first statement.
-
-### Using the Read-Write Splitting Plugin against RDS/Aurora Clusters
+### Using the Read-Write Splitting Plugin against RDS/Aurora clusters
 
 When using the read-write splitting plugin against RDS or Aurora clusters, you do not have to supply multiple instance URLs in the connection string. Instead, supply just the URL for the initial instance to which you're connecting. You must also include either the failover plugin or the Aurora host list plugin in your plugin chain so that the driver knows to query Aurora for its topology. See the section on [loading the read-write splitting plugin](#loading-the-read-write-splitting-plugin) for more info.
-### Using the Read-Write Splitting Plugin against Non-RDS Clusters
+
+### Using the Read-Write Splitting Plugin against non-RDS clusters
 
 If you are using the read-write splitting plugin against a cluster that is not hosted on RDS or Aurora, the plugin will not be able to automatically acquire the cluster topology. Instead, you must supply the topology information in the connection string as a comma-delimited list of multiple instance URLs. If you are using a single writer instance, the first instance in the list must be the writer instance and you must enable the `singleWriterConnectionString` property:
-
 ```
 properties.setProperty(ConnectionStringHostListProvider.SINGLE_WRITER_CONNECTION_STRING.name, "true");
 String connectionUrl = "jdbc:aws-wrapper:mysql://writer-instance-1.com,reader-instance-1.com,reader-instance-2.com/database-name"
@@ -62,9 +45,38 @@ String connectionUrl = "jdbc:aws-wrapper:mysql://writer-instance-1.com,reader-in
 
 Additionally, you should avoid using the Aurora host list plugin and the failover plugin in this scenario, as they are designed to specifically operate against Aurora databases.
 
+### Limitations
+
+#### General plugin limitations
+
+When a Statement or ResultSet object is created, it is internally bound to the physical database connection established at the time of object creation. There is no standard JDBC functionality to change the underlying connection used by Statement or ResultSet objects. Consequently, even if the read-write plugin switches the internal connection, any Statements/ResultSets created before this event will continue using the old database connection. This  bypasses any desired functionality provided by the read-write plugin. To prevent these scenarios, an exception will be thrown if your code uses any Statements/ResultSets created before a change in internal connection. To solve this problem, please ensure you create new Statement/ResultSet objects after each change in internal connection. See the section on [scenarios that cause a change in internal connection](#scenarios-that-cause-a-change-in-internal-connection) for more info.
+
+#### Reader load balancing limitations
+
+When reader load balancing is enabled and autocommit is off, the read-write splitting plugin will analyze statements executed to determine when `COMMIT`, `ROLLBACK` or `ABORT` is executed. This analysis does not support SQL strings containing multiple statements. If your SQL strings contain multiple statements, we recommend that you do not enable reader load balancing as the resulting behavior is not defined. If a SQL string with multiple statements is provided, the plugin will only analyze the first statement.
+
+#### Session State Limitations
+
+There are many session state attributes that can change during a session, and many ways to change them. Consequently, the read-write splitting plugin has limited support for transferring session state between connections. The following attributes will be automatically transferred when switching connections:
+
+- autocommit value
+- transaction isolation level
+
+All other session state attributes will be lost when switching connections. See the section on [scenarios that cause a change in internal connection](#scenarios-that-cause-a-change-in-internal-connection) for info on when the connection is switched.
+
+If your SQL workflow depends on session state attributes that are not mentioned above, you will need to re-configure those attributes whenever the connection is switched as described in the [scenarios that cause a change in internal connection](#scenarios-that-cause-a-change-in-internal-connection) section. Since reader load balancing frequently switches the connection, we recommend that you keep it disabled if your workflow depends on session state attributes that are not automatically transferred.
+
+### Scenarios that cause a change in internal connection
+
+1. If you have loaded the plugin, the connection will switch between the writer/reader when calling `setReadOnly`.
+2. If you have set the `loadBalanceReadOnlyTraffic` parameter to true, the connection will also switch at transaction boundaries while read-only is true and autocommit is off. By default, the plugin will not load balance queries while autocommit is on. See the section on [reader load balancing](#reader-load-balancing) for more information.
+3. If you have set the `loadBalanceReadOnlyTraffic` parameter to true and the `readerBalanceAutoCommitStatementLimit` parameter to a positive value X, the connection will also switch after every X statements executed while autocommit is on and read-only is true. You can optionally set the readerBalanceAutoCommitStatementRegex parameter to switch after every X statements matching a given regex. See the section on [reader load balancing](#reader-load-balancing) for more information.
+
 ### Read Write Splitting Plugin Parameters
 
-| Parameter | Value | Required | Description | Default Value |
-| --- | --- | --- | --- | --- |
-| `loadBalanceReadOnlyTraffic` | Boolean | No  | Set to `true` to load balance queries among available reader instances. Once enabled, load balancing will automatically be performed for reader instances when the connection has been set to read-only mode via `Connection#setReadOnly` | `false` |
+| Parameter                               | Value   | Required | Description                                                                                                                                                                                                                                                                                                                                                                  | Default Value                                                              |
+|-----------------------------------------|---------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `loadBalanceReadOnlyTraffic`            | Boolean | No       | Set to `true` to load balance queries among available reader instances when the connection has been set to read-only mode via `Connection#setReadOnly` and autocommit-off mode via `Connection.setAutoCommit`. To load balance while autocommit is on, also set the `readerBalanceAutoCommitStatementLimit` parameter.                                                       | `false`                                                                    |
+| `readerBalanceAutoCommitStatementLimit` | Integer | No       | Set to a positive value X to load balance reader instances after every X queries while autocommit is on. To use this value, the connection must also be in read-only mode and have `loadBalanceReadOnlyTraffic` enabled. To configure the plugin to switch after every X queries matching a custom regex, set the `readerBalanceAutoCommitStatementRegex` parameter as well. | `0` (Reader balancing is disabled while autocommit is on)                  |
+| `readerBalanceAutoCommitStatementRegex` | String  | No       | Set to your desired regex R to load balance reader instances after every X queries matching R while autocommit is on, where X is defined by `readerBalanceAutoCommitStatementLimit`. To use this value, the connection must also be in read-only mode and have `loadBalanceReadOnlyTraffic` enabled and `readerBalanceAutoCommitStatementLimit` set to a positive value.     | `null` (All executes count towards `readerBalanceAutoComimtStatementLimit` |
 

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -53,7 +53,7 @@ When a Statement or ResultSet object is created, it is internally bound to the p
 
 #### Reader load balancing limitations
 
-When reader load balancing is enabled and autocommit is off, the read-write splitting plugin will analyze statements executed to determine when `COMMIT`, `ROLLBACK` or `ABORT` is executed. This analysis does not support SQL strings containing multiple statements. If your SQL strings contain multiple statements, we recommend that you do not enable reader load balancing as the resulting behavior is not defined. If a SQL string with multiple statements is provided, the plugin will only analyze the first statement.
+When reader load balancing is enabled and autocommit is off, the read-write splitting plugin will analyze SQL statements executed to determine if `COMMIT`, `ROLLBACK` or `ABORT` are executed. In addition to `commit()` and `rollback()`, these statements indicate a transaction boundary. This analysis does not support SQL strings containing multiple statements. If your SQL strings use `COMMIT`, `ROLLBACK`, or `ABORT` and they contain multiple statements, we recommend that you do not enable reader load balancing as the plugin will not detect the transaction boundary if these keywords are not the first statement.
 
 #### Session State Limitations
 

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheReadWriteSplittingPlugin.md
@@ -27,7 +27,7 @@ properties.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.n
 
 Once this parameter is enabled and `setReadOnly(true)` has been called, the plugin will load balance readers while autocommit is off. The reader switch will occur at each transaction boundary. The following scenarios are considered transaction boundaries:
 - After calling `commit()` or `rollback()`
-- After executing `COMMIT`, `ROLLBACK` or `ABORT` as a SQL statement (see limitations [here](#multi-statement-sql-limitations-with-reader-load-balancing))
+- After executing `COMMIT` or `ROLLBACK` as a SQL statement (see limitations [here](#multi-statement-sql-limitations-with-reader-load-balancing))
 
 By default, the plugin will not load balance queries while autocommit is on, even if `loadBalanceReadOnlyTraffic` is enabled. To enable load balancing with autocommit on, set `loadBalanceReadOnlyTraffic` to true and `readerBalanceAutoCommitStatementLimit` to a positive value X. The plugin will then load balance after every X statements executed in read-only mode with autocommit on. If you would like to load balance after every X statements matching a custom regex, set the `readerBalanceAutoCommitStatementRegex` parameter as well.
 
@@ -53,7 +53,7 @@ When a Statement or ResultSet object is created, it is internally bound to the p
 
 #### Multi-statement SQL limitations with reader load balancing
 
-When reader load balancing is enabled and autocommit is off, the read-write splitting plugin will analyze SQL statements executed to determine if `COMMIT`, `ROLLBACK` or `ABORT` are executed. In addition to `commit()` and `rollback()`, these statements indicate a transaction boundary. This analysis does not support SQL strings containing multiple statements. If your SQL strings use `COMMIT`, `ROLLBACK`, or `ABORT` and they contain multiple statements, we recommend that you do not enable reader load balancing as the plugin will not detect the transaction boundary if these keywords are not the first statement.
+When reader load balancing is enabled and autocommit is off, the read-write splitting plugin will analyze SQL statements executed to determine if `COMMIT` or `ROLLBACK` are executed. In addition to `commit()` and `rollback()`, these statements indicate a transaction boundary. This analysis does not support SQL strings containing multiple statements. If your SQL strings use `COMMIT` or `ROLLBACK` and they contain multiple statements, we recommend that you do not enable reader load balancing as the plugin will not detect the transaction boundary if these keywords are not the first statement.
 
 #### Session state limitations
 

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -317,7 +317,8 @@ public class ConnectionPluginManager implements CanReleaseResources {
     if (conn != null && conn != this.pluginService.getCurrentConnection()
         && !sqlMethodAnalyzer.isMethodClosingSqlObject(methodName)) {
       final SQLException e =
-          new SQLException(Messages.get("ConnectionPluginManager.methodInvokedAgainstOldConnection"));
+          new SQLException(Messages.get("ConnectionPluginManager.methodInvokedAgainstOldConnection",
+              new Object[] {methodInvokeOn}));
       throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, e);
     }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -363,7 +363,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
 
     final Connection currentConnection = this.pluginService.getCurrentConnection();
     this.isTransactionBoundary =
-        sqlMethodAnalyzer.doesCloseTransaction(currentConnection, methodName, args);
+        sqlMethodAnalyzer.isTransactionBoundary(currentConnection, methodName, args);
   }
 
   private boolean isSetReadOnlyMethod(String methodName, Object[] args) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -362,7 +362,10 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
             methodName, args, this.readerBalanceAutoCommitStatementRegex)) {
       this.autoCommitStatementCount++;
     }
-    this.isTransactionBoundary = isTransactionBoundary(methodName, args);
+
+    final Connection currentConnection = this.pluginService.getCurrentConnection();
+    this.isTransactionBoundary =
+        sqlMethodAnalyzer.doesCloseTransaction(currentConnection, methodName, args);
   }
 
   private boolean isSetReadOnlyMethod(String methodName, Object[] args) {
@@ -387,11 +390,6 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
     }
 
     return false;
-  }
-
-  private boolean isTransactionBoundary(final String methodName, final Object[] args) {
-    final Connection currentConnection = this.pluginService.getCurrentConnection();
-    return sqlMethodAnalyzer.doesCloseTransaction(currentConnection, methodName, args);
   }
 
   private void updateInternalConnectionInfo() throws SQLException {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -379,6 +379,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
         && this.loadBalanceReadOnlyTraffic
         && this.isReadOnlyMode
         && this.isAutoCommitMode
+        && methodName.contains(".execute")
         && (this.readerBalanceAutoCommitStatementRegex == null
           || sqlMethodAnalyzer.doesSqlMatchPattern(
               methodName, args, this.readerBalanceAutoCommitStatementRegex));

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -67,6 +67,8 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
           add("Connection.commit");
           add("Connection.rollback");
           add("Connection.createStatement");
+          add("Connection.prepareCall");
+          add("Connection.prepareStatement");
           add("Connection.setAutoCommit");
           add("Connection.setReadOnly");
           add("Statement.execute");

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -88,15 +88,6 @@ public class SqlMethodAnalyzer {
     return isStatementClosingTransaction(statement);
   }
 
-  public boolean isExecuteDml(final String methodName, final Object[] args) {
-    if (!(methodName.contains("execute") && args != null && args.length >= 1)) {
-      return false;
-    }
-
-    final String statement = getFirstSqlStatement(String.valueOf(args[0]));
-    return isStatementDml(statement);
-  }
-
   public boolean isStatementDml(final String statement) {
     return !isStatementStartingTransaction(statement)
         && !isStatementClosingTransaction(statement)

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -21,6 +21,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SqlMethodAnalyzer {
@@ -187,5 +188,13 @@ public class SqlMethodAnalyzer {
 
   public boolean isMethodClosingSqlObject(String methodName) {
     return methodName.endsWith(".close") || methodName.endsWith(".abort");
+  }
+
+  public boolean doesSqlMatchPattern(String methodName, Object[] args, Pattern pattern) {
+    if (!(methodName.contains("execute") && args != null && args.length >= 1)) {
+      return false;
+    }
+
+    return pattern.matcher(String.valueOf(args[0])).matches();
   }
 }

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -78,7 +78,7 @@ ConnectionPluginManager.configurationProfileNotFound=Configuration profile ''{0}
 ConnectionPluginManager.releaseResources=Releasing resources.
 ConnectionPluginManager.unknownPluginCode=Unknown plugin code: ''{0}''.
 ConnectionPluginManager.unableToLoadPlugin=Unable to load connection plugin factory: ''{0}''.
-ConnectionPluginManager.methodInvokedAgainstOldConnection=The current method was invoked on an object using an old connection. If you are invoking a method on a Statement, please ensure the connection was not switched before execution. If you are invoking a method on a ResultSet, please ensure the connection was not switched before invocation.
+ConnectionPluginManager.methodInvokedAgainstOldConnection=The internal connection has changed since ''{0}'' was created. This is likely due to failover or read-write splitting functionality. To ensure you are using the updated connection, please re-create Statement and ResultSet objects after the internal connection has changed.
 
 # Connection Url Builder
 ConnectionUrlBuilder.missingJdbcProtocol=Missing JDBC protocol and/or host name. Could not construct URL.

--- a/wrapper/src/test/java/integration/refactored/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/ReadWriteSplittingTests.java
@@ -435,7 +435,7 @@ public class ReadWriteSplittingTests {
   // Tests use Aurora specific SQL to identify instance name
   @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
   public void test_readerLoadBalancing_singleReader() throws SQLException {
-    Properties props = new Properties(this.staticHostListProps);
+    Properties props = this.staticHostListProps;
     props.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.name, "true");
     props.setProperty(ReadWriteSplittingPlugin.READER_BALANCE_AUTOCOMMIT_STATEMENT_LIMIT.name, "1");
     try (final Connection conn = DriverManager.getConnection(getStaticHostListUrl(), props)) {
@@ -456,7 +456,7 @@ public class ReadWriteSplittingTests {
   @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
   @EnableOnNumOfInstances(min = 3)
   public void test_readerLoadBalancing_autocommitTrue_defaultSettings() throws SQLException {
-    Properties props = new Properties(this.auroraHostListProps);
+    Properties props = this.auroraHostListProps;
     props.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.name, "true");
     try (final Connection conn = DriverManager.getConnection(getClusterUrl(), props)) {
       final String writerConnectionId = queryInstanceId(conn);
@@ -479,7 +479,7 @@ public class ReadWriteSplittingTests {
   @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
   public void test_readerLoadBalancing_autocommitTrue_regex() throws SQLException {
     String regexTrigger = "SELECT 9";
-    Properties props = new Properties(this.auroraHostListProps);
+    Properties props = this.auroraHostListProps;
     props.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.name, "true");
     props.setProperty(ReadWriteSplittingPlugin.READER_BALANCE_AUTOCOMMIT_STATEMENT_LIMIT.name, "2");
     props.setProperty(ReadWriteSplittingPlugin.READER_BALANCE_AUTOCOMMIT_STATEMENT_REGEX.name, regexTrigger);
@@ -508,7 +508,7 @@ public class ReadWriteSplittingTests {
   @EnableOnNumOfInstances(min = 3)
   @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
   public void test_readerLoadBalancing_switchAutoCommit() throws SQLException {
-    Properties props = new Properties(this.auroraHostListProps);
+    Properties props = this.auroraHostListProps;
     props.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.name, "true");
     props.setProperty(ReadWriteSplittingPlugin.READER_BALANCE_AUTOCOMMIT_STATEMENT_LIMIT.name, "2");
     try (final Connection conn = DriverManager.getConnection(getClusterUrl(), props)) {
@@ -569,7 +569,7 @@ public class ReadWriteSplittingTests {
   // Tests use Aurora specific SQL to identify instance name
   @EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
   public void test_transactionResolutionUnknown() throws SQLException {
-    Properties props = new Properties(this.staticHostListProps);
+    Properties props = this.staticHostListProps;
     props.setProperty(ReadWriteSplittingPlugin.LOAD_BALANCE_READ_ONLY_TRAFFIC.name, "true");
     try (final Connection conn = DriverManager.getConnection(getProxiedStaticHostListUrl(), props)) {
       final String writerConnectionId = queryInstanceId(conn);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -382,6 +382,7 @@ public class ReadWriteSplittingPluginTest {
         mockReaderConn1);
 
     plugin.setReadOnlyMode(true);
+    plugin.setAutoCommitMode(false);
     plugin.setIsTransactionBoundary(true);
 
     executeQuery(plugin, "begin");

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -416,7 +416,7 @@ public class ReadWriteSplittingPluginTest {
         mockVoidFunction,
         new Object[] {});
 
-    assertTrue(plugin.getIsTransactionBoundary());
+    assertFalse(plugin.getIsTransactionBoundary());
     verify(mockPluginService, never()).connect(any(), any());
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -109,20 +109,6 @@ class SqlMethodAnalyzerTest {
   }
 
   @ParameterizedTest
-  @MethodSource("isExecuteDmlQueries")
-  void testIsExecuteDml(final String methodName, final String sql, final boolean expected) {
-    final Object[] args;
-    if (sql != null) {
-      args = new Object[] {sql};
-    } else {
-      args = new Object[] {};
-    }
-
-    final boolean actual = sqlMethodAnalyzer.isExecuteDml(methodName, args);
-    assertEquals(expected, actual);
-  }
-
-  @ParameterizedTest
   @MethodSource("isSettingAutoCommitQueries")
   void testIsStatementSettingAutoCommit(final String methodName, final String sql,
       final boolean expected) {
@@ -194,20 +180,6 @@ class SqlMethodAnalyzerTest {
         Arguments.of("Connection.rollback", null, true),
         Arguments.of("Connection.close", null, true),
         Arguments.of("Connection.abort", null, true)
-    );
-  }
-
-  private static Stream<Arguments> isExecuteDmlQueries() {
-    return Stream.of(
-        Arguments.of("Connection.commit", null, false),
-        Arguments.of("Statement.execute", " START  TRANSACTION   READ  ONLY", false),
-        Arguments.of("Statement.execute", " begin ; ", false),
-        Arguments.of("Statement.execute", " rollback ; ", false),
-        Arguments.of("Statement.execute", "   SET autocommit = 0 ; ", false),
-        Arguments.of("Statement.execute", "   SHOW DATABASES ; ", false),
-        Arguments.of("Statement.execute", "   USE mydatabase ; ", false),
-        Arguments.of("Statement.executeQuery", "   SELECT 1; ", true),
-        Arguments.of("Statement.executeUpdate", "INSERT INTO test_table VALUES (1)", true)
     );
   }
 


### PR DESCRIPTION
- User can configure reader load balancing to pick a new reader while autocommit is on after every X statements matching a given regex 
- By default, reader load balancing is disabled while autocommit is on
- If the user sets the autocommit-on statement limit to a positive value, the regex will match every SQL statement by default. This can be configured to another regex pattern