### PR TITLE
fix: unwrap Savepoint objects when passing them in as parameters.

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/wrapper/ConnectionWrapper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/wrapper/ConnectionWrapper.java
@@ -650,7 +650,13 @@ public class ConnectionWrapper implements Connection, CanReleaseResources {
         this.pluginManager,
         this.pluginService.getCurrentConnection(),
         "Connection.releaseSavepoint",
-        () -> this.pluginService.getCurrentConnection().releaseSavepoint(savepoint),
+        () -> {
+          if (savepoint instanceof SavepointWrapper) {
+            this.pluginService.getCurrentConnection().releaseSavepoint(((SavepointWrapper) savepoint).savepoint);
+          } else {
+            this.pluginService.getCurrentConnection().releaseSavepoint(savepoint);
+          }
+        },
         savepoint);
   }
 
@@ -675,7 +681,11 @@ public class ConnectionWrapper implements Connection, CanReleaseResources {
         this.pluginService.getCurrentConnection(),
         "Connection.rollback",
         () -> {
-          this.pluginService.getCurrentConnection().rollback(savepoint);
+          if (savepoint instanceof SavepointWrapper) {
+            this.pluginService.getCurrentConnection().rollback(((SavepointWrapper) savepoint).savepoint);
+          } else {
+            this.pluginService.getCurrentConnection().rollback(savepoint);
+          }
           this.pluginManagerService.setInTransaction(false);
         },
         savepoint);


### PR DESCRIPTION
### Summary

fix: unwrap Savepoint objects when passing them in as parameters.

### Description

Fixes #328

`SavepointWrappper` objects are passed to `ConnectionWrapper#*rollback(final Savepoint savepoint)` as parameters, which are then passed to the target driver's rollback methods.

PGJDBC internally explicitly casts the Savepoint parameter to an internal object: https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java#L1836
```java
PSQLSavepoint pgSavepoint = (PSQLSavepoint) savepoint;
```
Since the driver passed in a `SavepointWrappper` object, this line in pgjdbc will throw a `ClassCastException`.

The only solution is to unwrap the Savepoint object before passing it in.

### Additional Reviewers

@joyc-bq 
@aaronchung-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.