### PR TITLE
feat: default list of connection plugins

### DIFF
--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -66,13 +66,21 @@ Plugins are loaded and managed through the Connection Plugin Manager and may be 
 | `wrapperProfileName` | `String` | No       | Driver configuration profile name. Instead of listing plugin codes with `wrapperPlugins`, the driver profile can be set with this parameter. <br><br> Example: See [below](#configuration-profiles). | `null`        |
 
 To use a built-in plugin, specify its relevant plugin code for the `wrapperPlugins`.
-For instance, to use the [FailoverConnectionPlugin](../../wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java) and the [Host Monitoring Connection Plugin](../../wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java):
+The default value for `wrapperPlugins` is `auroraConnectionTracker,failover,efm`. These 3 plugins are enabled by default. To read more about these plugins, see the [List of Available Plugins](#list-of-available-plugins) section.
+To override the default plugins, simply provide a new value for `wrapperPlugins`.
+For instance, to use the [IAM Authentication Connection Plugin](./using-plugins/UsingTheIamAuthenticationPlugin.md) and the [Failover Connection Plugin](./using-plugins/UsingTheFailoverPlugin.md):
 
 ```java
-properties.setProperty("wrapperPlugins", "failover,efm");
+properties.setProperty("wrapperPlugins", "iam,failover");
 ```
 
 > :exclamation:**NOTE**: The plugins will be initialized and executed in the order they have been specified.
+
+Provide an empty string to disable all plugins:
+```java
+properties.setProperty("wrapperPlugins", "");
+```
+The Wrapper behaves like the target driver when no plugins are used.
 
 ### Configuration Profiles
 An alternative way of loading plugins is to use a configuration profile. You can create custom configuration profiles that specify which plugins the AWS JDBC Driver should load. After creating the profile, set the [`wrapperProfileName`](#connection-plugin-manager-parameters) parameter to the name of the created profile.

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -75,7 +75,7 @@ public class ConnectionPluginManager implements CanReleaseResources {
         }
       };
 
-  protected static final String DEFAULT_PLUGINS = "";
+  protected static final String DEFAULT_PLUGINS = "auroraConnectionTracker,failover,efm";
 
   private static final Logger LOGGER = Logger.getLogger(ConnectionPluginManager.class.getName());
   private static final String ALL_METHODS = "*";
@@ -87,7 +87,7 @@ public class ConnectionPluginManager implements CanReleaseResources {
   private final ReentrantLock lock = new ReentrantLock();
 
   protected Properties props = new Properties();
-  protected ArrayList<ConnectionPlugin> plugins;
+  protected List<ConnectionPlugin> plugins;
   protected final ConnectionProvider connectionProvider;
   protected final ConnectionWrapper connectionWrapper;
   protected PluginService pluginService;

--- a/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
@@ -154,4 +154,10 @@ public class ConnectionStringHelper {
     DriverHelper.setTcpKeepAlive(TestEnvironment.getCurrent().getCurrentDriver(), props, false);
     return props;
   }
+
+  public static Properties getDefaultPropertiesWithNoPlugins() {
+    final Properties properties = getDefaultProperties();
+    properties.setProperty(PropertyDefinition.PLUGINS.name, "");
+    return properties;
+  }
 }

--- a/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
@@ -16,28 +16,13 @@
 
 package integration.refactored.container;
 
+import integration.refactored.DatabaseEngine;
 import integration.refactored.DriverHelper;
 import java.util.Properties;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.util.StringUtils;
 
 public class ConnectionStringHelper {
-
-  public static String getClusterUrl() {
-    return getUrl(
-        TestEnvironment.getCurrent().getCurrentDriver(),
-        TestEnvironment.getCurrent()
-            .getInfo()
-            .getDatabaseInfo()
-            .getClusterEndpoint(),
-        TestEnvironment.getCurrent()
-            .getInfo()
-            .getDatabaseInfo()
-            .getInstances()
-            .get(0)
-            .getEndpointPort(),
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
-  }
 
   public static String getUrl() {
     return getUrl(
@@ -62,15 +47,17 @@ public class ConnectionStringHelper {
   }
 
   public static String getUrl(TestDriver testDriver, String host, int port, String databaseName) {
-    return DriverHelper.getDriverProtocol(
-        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver)
+    final DatabaseEngine databaseEngine = TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine();
+    final String requiredParameters = DriverHelper.getDriverRequiredParameters(databaseEngine, testDriver);
+    return DriverHelper.getDriverProtocol(databaseEngine, testDriver)
         + host
         + ":"
         + port
         + "/"
         + databaseName
-        + DriverHelper.getDriverRequiredParameters(
-        TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine(), testDriver);
+        + requiredParameters
+        + (requiredParameters.startsWith("?") ? "&" : "?")
+        + "wrapperPlugins=\"\"";
   }
 
   public static String getWrapperUrl() {

--- a/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
@@ -249,13 +249,12 @@ public class BasicConnectivityTests {
                 .getEndpoint()
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
-            + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"";
+            + DriverHelper.getDriverRequiredParameters();
 
     LOGGER.finest("Connecting to " + url);
 
     try (Connection conn =
-        DriverManager.getConnection(url, ConnectionStringHelper.getDefaultProperties())) {
+        DriverManager.getConnection(url, ConnectionStringHelper.getDefaultPropertiesWithNoPlugins())) {
 
       assertTrue(conn instanceof ConnectionWrapper);
       assertTrue(conn.isValid(10));

--- a/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
@@ -65,7 +65,7 @@ public class BasicConnectivityTests {
   public void test_DirectConnection(TestDriver testDriver) throws SQLException {
     LOGGER.info(testDriver.toString());
 
-    final Properties props = ConnectionStringHelper.getDefaultProperties();
+    final Properties props = ConnectionStringHelper.getDefaultPropertiesWithNoPlugins();
     DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
     DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
 
@@ -113,6 +113,7 @@ public class BasicConnectivityTests {
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
     DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
     DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
 
     String url =
         ConnectionStringHelper.getWrapperUrl(
@@ -159,6 +160,7 @@ public class BasicConnectivityTests {
         TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getPassword());
     DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
     DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
 
     TestInstanceInfo instanceInfo =
         TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(0);
@@ -204,6 +206,7 @@ public class BasicConnectivityTests {
         TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getPassword());
     DriverHelper.setConnectTimeout(props, 10, TimeUnit.SECONDS);
     DriverHelper.setSocketTimeout(props, 10, TimeUnit.SECONDS);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
 
     TestInstanceInfo instanceInfo =
         TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(0);
@@ -246,7 +249,8 @@ public class BasicConnectivityTests {
                 .getEndpoint()
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
-            + DriverHelper.getDriverRequiredParameters();
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"";
 
     LOGGER.finest("Connecting to " + url);
 
@@ -271,7 +275,7 @@ public class BasicConnectivityTests {
         SQLException.class,
         () -> {
           Connection conn =
-              DriverManager.getConnection(url, ConnectionStringHelper.getDefaultProperties());
+              DriverManager.getConnection(url, ConnectionStringHelper.getDefaultPropertiesWithNoPlugins());
           conn.close();
         });
   }
@@ -301,6 +305,7 @@ public class BasicConnectivityTests {
     final Properties props = new Properties();
     props.setProperty(PropertyDefinition.USER.name, username);
     props.setProperty(PropertyDefinition.PASSWORD.name, password);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
 
     LOGGER.finest("Connecting to " + url);
 

--- a/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.ds.AwsWrapperDataSource;
 import software.amazon.jdbc.util.StringUtils;
 import software.amazon.jdbc.wrapper.ConnectionWrapper;
@@ -68,6 +69,7 @@ public class DataSourceTests {
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     try (final Connection conn =
@@ -128,6 +130,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     try (final Connection conn =
@@ -171,6 +174,7 @@ public class DataSourceTests {
         "user", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
     targetDataSourceProps.setProperty(
         "password", TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     try (final Connection conn = ds.getConnection()) {
@@ -205,6 +209,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(
@@ -227,6 +232,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(
@@ -258,6 +264,7 @@ public class DataSourceTests {
             .getInstances()
             .get(0)
             .getEndpoint());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(
@@ -287,6 +294,7 @@ public class DataSourceTests {
             .getInstances()
             .get(0)
             .getEndpoint());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     Connection conn =
@@ -339,6 +347,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(
@@ -371,6 +380,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(
@@ -401,6 +411,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(
@@ -422,6 +433,7 @@ public class DataSourceTests {
     ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
 
     final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
     ds.setJdbcUrl(
         DriverHelper.getDriverProtocol()
@@ -479,7 +491,8 @@ public class DataSourceTests {
             + "user="
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername()
             + "&password="
-            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()
+            + "&wrapperPlugins=\"\"");
 
     try (final Connection conn = ds.getConnection()) {
       assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
@@ -515,7 +528,8 @@ public class DataSourceTests {
                 .getEndpointPort()
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
-            + DriverHelper.getDriverRequiredParameters());
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"");
 
     try (final Connection conn =
         ds.getConnection(
@@ -546,7 +560,8 @@ public class DataSourceTests {
                 .getEndpoint()
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
-            + DriverHelper.getDriverRequiredParameters());
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -568,6 +583,7 @@ public class DataSourceTests {
     ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
 
     final Properties targetDataSourceProps = new Properties();
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
     ds.setJdbcUrl(
         DriverHelper.getDriverProtocol()
@@ -578,7 +594,8 @@ public class DataSourceTests {
                 .get(0)
                 .getEndpoint()
             + "/"
-            + DriverHelper.getDriverRequiredParameters());
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -616,7 +633,8 @@ public class DataSourceTests {
             + "user="
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername()
             + "&password="
-            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+            + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword()
+            + "&wrapperPlugins=\"\"");
 
     try (final Connection conn = ds.getConnection()) {
       assertTrue(conn.isWrapperFor(DriverHelper.getConnectionClass()));
@@ -643,7 +661,8 @@ public class DataSourceTests {
                 .getEndpoint()
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
-            + DriverHelper.getDriverRequiredParameters());
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"");
 
     try (final Connection conn =
         ds.getConnection(
@@ -684,7 +703,8 @@ public class DataSourceTests {
                 .get(0)
                 .getEndpointPort()
             + "/"
-            + DriverHelper.getDriverRequiredParameters());
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -733,7 +753,8 @@ public class DataSourceTests {
                 .getInstances()
                 .get(0)
                 .getEndpointPort()
-            + "/");
+            + "/"
+            + "?wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -763,7 +784,8 @@ public class DataSourceTests {
                 .get(0)
                 .getEndpointPort()
             + "/"
-            + DriverHelper.getDriverRequiredParameters());
+            + DriverHelper.getDriverRequiredParameters()
+            + "&wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -796,6 +818,7 @@ public class DataSourceTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     final Hashtable<String, Object> env = new Hashtable<>();
@@ -839,6 +862,7 @@ public class DataSourceTests {
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     final Hashtable<String, Object> env = new Hashtable<>();

--- a/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
@@ -69,7 +69,6 @@ public class DataSourceTests {
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
-    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     try (final Connection conn =
@@ -529,7 +528,8 @@ public class DataSourceTests {
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
             + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"");
+            + (DriverHelper.getDriverRequiredParameters().startsWith("?") ? "&" : "?")
+            + "wrapperPlugins=\"\"");
 
     try (final Connection conn =
         ds.getConnection(
@@ -561,7 +561,8 @@ public class DataSourceTests {
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
             + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"");
+            + (DriverHelper.getDriverRequiredParameters().startsWith("?") ? "&" : "?")
+            + "wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -595,7 +596,8 @@ public class DataSourceTests {
                 .getEndpoint()
             + "/"
             + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"");
+            + (DriverHelper.getDriverRequiredParameters().startsWith("?") ? "&" : "?")
+            + "wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -662,7 +664,8 @@ public class DataSourceTests {
             + "/"
             + TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName()
             + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"");
+            + (DriverHelper.getDriverRequiredParameters().startsWith("?") ? "&" : "?")
+            + "wrapperPlugins=\"\"");
 
     try (final Connection conn =
         ds.getConnection(
@@ -704,7 +707,8 @@ public class DataSourceTests {
                 .getEndpointPort()
             + "/"
             + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"");
+            + (DriverHelper.getDriverRequiredParameters().startsWith("?") ? "&" : "?")
+            + "wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -753,8 +757,7 @@ public class DataSourceTests {
                 .getInstances()
                 .get(0)
                 .getEndpointPort()
-            + "/"
-            + "?wrapperPlugins=\"\"");
+            + "/?wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -785,7 +788,8 @@ public class DataSourceTests {
                 .getEndpointPort()
             + "/"
             + DriverHelper.getDriverRequiredParameters()
-            + "&wrapperPlugins=\"\"");
+            + (DriverHelper.getDriverRequiredParameters().startsWith("?") ? "&" : "?")
+            + "wrapperPlugins=\"\"");
 
     assertThrows(
         SQLException.class,
@@ -862,7 +866,6 @@ public class DataSourceTests {
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
-    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     final Hashtable<String, Object> env = new Hashtable<>();

--- a/wrapper/src/test/java/integration/refactored/container/tests/HikariTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/HikariTests.java
@@ -48,7 +48,7 @@ public class HikariTests {
   public void testOpenConnectionWithUrl() throws SQLException {
 
     HikariDataSource ds = new HikariDataSource();
-    ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
+    ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl() + "?wrapperPlugins=\"\"");
     ds.setUsername(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
     ds.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
     ds.addDataSourceProperty(PropertyDefinition.PLUGINS.name, "");
@@ -98,8 +98,9 @@ public class HikariTests {
     targetDataSourceProps.setProperty(
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
-    targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
     targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
+    // For MariaDB tests, MariaDbDataSource only accepts the url parameter.
+    targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
     ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
 
     Connection conn = ds.getConnection();

--- a/wrapper/src/test/java/integration/refactored/container/tests/HikariTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/HikariTests.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.ds.AwsWrapperDataSource;
 import software.amazon.jdbc.wrapper.ConnectionWrapper;
 
@@ -50,6 +51,7 @@ public class HikariTests {
     ds.setJdbcUrl(ConnectionStringHelper.getWrapperUrl());
     ds.setUsername(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
     ds.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    ds.addDataSourceProperty(PropertyDefinition.PLUGINS.name, "");
 
     Connection conn = ds.getConnection();
 
@@ -97,6 +99,7 @@ public class HikariTests {
         "databaseName",
         TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
     targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
+    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
 
     Connection conn = ds.getConnection();

--- a/wrapper/src/test/java/integration/refactored/container/tests/SpringTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/SpringTests.java
@@ -58,6 +58,7 @@ public class SpringTests {
 
     Properties props = new Properties();
     props.setProperty(PropertyDefinition.LOGGER_LEVEL.name, "ALL");
+    props.setProperty(PropertyDefinition.PLUGINS.name, "");
     dataSource.setConnectionProperties(props);
 
     return dataSource;

--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginManagerTests.java
@@ -451,7 +451,7 @@ public class ConnectionPluginManagerTests {
   @Test
   public void testNoWrapperPlugins() throws SQLException {
     final Properties testProperties = new Properties();
-    testProperties.setProperty("wrapperPlugins", "");
+    testProperties.setProperty(PropertyDefinition.PLUGINS.name, "");
 
     final ConnectionPluginManager target = Mockito.spy(new ConnectionPluginManager(
         mockConnectionProvider,


### PR DESCRIPTION
### Summary

Set `auroraConnectionTracker`, `failover` and `efm` as the list of default connection plugins.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.