### PR TITLE
chore: only run aurora integration tests

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -45,7 +45,7 @@ jobs:
           echo "TEMP_AWS_SESSION_TOKEN=${creds[2]}" >> $GITHUB_ENV
       - name: Run integration tests
         run: |
-          ./gradlew --no-parallel --no-daemon test-all-environments
+          ./gradlew --no-parallel --no-daemon test-all-aurora
         env:
           AURORA_CLUSTER_DOMAIN: ${{ secrets.DB_CONN_SUFFIX }}
           AURORA_DB_REGION: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
### Summary

Only run Aurora Integration tests in the manually triggered workflow.

### Description

`run-standard-integration-tests.yml` already runs all the docker tests and it runs for all commits to main and all pull requests. We can simplify and speed up the other workflow to only run the Aurora integration tests.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.