### PR TITLE
fix: add null checks to WrapperUtils.getConnectionFromSqlObject() (#348)

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -524,6 +524,9 @@ public class WrapperUtils {
   }
 
   public static Connection getConnectionFromSqlObject(final Object obj) {
+    if (obj == null) {
+      return null;
+    }
     try {
       if (obj instanceof Connection) {
         return (Connection) obj;
@@ -532,11 +535,11 @@ public class WrapperUtils {
         return stmt.getConnection();
       } else if (obj instanceof ResultSet) {
         final ResultSet rs = (ResultSet) obj;
-        return rs.getStatement().getConnection();
+        return rs.getStatement() != null ? rs.getStatement().getConnection() : null;
       }
     } catch (final SQLException | UnsupportedOperationException e) {
-      // Do nothing. The UnsupportedOperationException comes from ResultSets returned by DataCacheConnectionPlugin and
-      // will be triggered when getStatement is called.
+      // Do nothing. The UnsupportedOperationException comes from ResultSets returned by
+      // DataCacheConnectionPlugin and will be triggered when getStatement is called.
     }
 
     return null;


### PR DESCRIPTION
### Summary

add null checks to WrapperUtils.getConnectionFromSqlObject()
### Description

Add null checks to WrapperUtils.getConnectionFromSqlObject()
Addresses issue https://github.com/awslabs/aws-advanced-jdbc-wrapper/issues/348

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.