### PR TITLE
fix: ensure extra ? in the parameters do not get filtered out when parsing the URL

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
@@ -142,7 +142,7 @@ public class ConnectionUrlParser {
   // Get the properties from a given url of the generic format:
   // "protocol//[hosts][/database][?properties]"
   public static void parsePropertiesFromUrl(String url, Properties props) {
-    String[] urlParameters = url.split("\\?");
+    String[] urlParameters = url.split("\\?", 1);
     if (urlParameters.length == 1) {
       return;
     }

--- a/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlParserTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlParserTest.java
@@ -81,6 +81,14 @@ class ConnectionUrlParserTest {
     assertEquals(props.getProperty("param"), expected);
   }
 
+  @ParameterizedTest
+  @MethodSource("urlWithQuestionMarksParams")
+  void testParsingUrlsWithQuestionMarks(final String url, final String expected) {
+    Properties props = new Properties();
+    ConnectionUrlParser.parsePropertiesFromUrl(url, props);
+    assertEquals(props.getProperty("param"), expected);
+  }
+
   private static Stream<Arguments> testGetHostsFromConnectionUrlArguments() {
     return Stream.of(
         Arguments.of("protocol//", new ArrayList<HostSpec>()),
@@ -125,6 +133,14 @@ class ConnectionUrlParserTest {
         Arguments.of("protocol//host/db?param=" + StringUtils.encode("value&"), "value&"),
         Arguments.of("protocol//host/db?param=" + StringUtils.encode("value"
             + new String(Character.toChars(0x007E))), "value~")
+    );
+  }
+
+  private static Stream<Arguments> urlWithQuestionMarksParams() {
+    return Stream.of(
+        Arguments.of("protocol//host/db?param=foo", "foo"),
+        Arguments.of("protocol//host:1234/db?param=?.foo", "?.foo"),
+        Arguments.of("protocol//host?param=?", "?")
     );
   }
 }


### PR DESCRIPTION
### Summary
The `clusterInstanceHostPattern` parameter requires the following format "?.cluster.com", when setting the clusterInstanceHostPattern in the connection string, the extra question mark gets lost in the process, resulting an exception.

### Description



### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.