### PR TITLE
fix: fetch instance endpoint to the host alias  for custom domains

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -560,7 +560,7 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
         }
         sb.append("[").append(entry.getKey()).append("]:\n")
             .append("\tisPrimaryCluster: ")
-            .append(isPrimaryCluster == null ? false : isPrimaryCluster).append("\n")
+            .append(isPrimaryCluster != null && isPrimaryCluster).append("\n")
             .append("\tsuggestedPrimaryCluster: ")
             .append(suggestedPrimaryClusterId).append("\n")
             .append("\tHosts: ");

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -59,7 +59,7 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
   private final RdsUtils rdsHelper;
   private String retrieveInstanceQuery;
   private String instanceNameCol;
-  private String clusterInstanceTemplate;
+  private String clusterInstanceTemplate = "";
   private final OpenedConnectionTracker tracker;
 
   AuroraConnectionTrackerPlugin(PluginService pluginService, Properties props) {
@@ -99,7 +99,7 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
         : hostSpec;
 
     if (conn != null) {
-      if (rdsHelper.isRdsClusterDns(currentHostSpec.getHost())) {
+      if (!rdsHelper.isRdsInstance(currentHostSpec.getHost())) {
         currentHostSpec.addAlias(getInstanceEndpoint(conn, currentHostSpec));
       }
     }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPluginTest.java
@@ -44,6 +44,7 @@ import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.hostlistprovider.AuroraHostListProvider;
 import software.amazon.jdbc.plugin.failover.FailoverSQLException;
 import software.amazon.jdbc.util.RdsUtils;
 
@@ -88,7 +89,7 @@ public class AuroraConnectionTrackerPluginTest {
       final boolean isInitialConnection) throws SQLException {
     final HostSpec hostSpec = new HostSpec("instance1");
     when(mockPluginService.getCurrentHostSpec()).thenReturn(hostSpec);
-    when(mockRdsUtils.isRdsClusterDns("instance1")).thenReturn(false);
+    when(mockRdsUtils.isRdsInstance("instance1")).thenReturn(true);
 
     final AuroraConnectionTrackerPlugin plugin = new AuroraConnectionTrackerPlugin(
         mockPluginService,
@@ -116,7 +117,7 @@ public class AuroraConnectionTrackerPluginTest {
       final boolean isInitialConnection) throws SQLException {
     final HostSpec hostSpec = new HostSpec("writerCluster");
     when(mockPluginService.getCurrentHostSpec()).thenReturn(hostSpec);
-    when(mockRdsUtils.isRdsClusterDns("writerCluster")).thenReturn(true);
+    when(mockRdsUtils.isRdsInstance("writerCluster")).thenReturn(false);
     when(mockResultSet.next()).thenReturn(true, false); // ResultSet should only have 1 row.
     when(mockResultSet.getString(any(String.class))).thenReturn("writerInstance");
 
@@ -138,6 +139,72 @@ public class AuroraConnectionTrackerPluginTest {
     final Set<String> aliases = hostSpec.getAliases();
     assertEquals(1, aliases.size());
     assertEquals("writerInstance", aliases.toArray()[0]);
+  }
+
+  @ParameterizedTest
+  @MethodSource("trackNonRdsInstanceUrlParameters")
+  public void testTrackNewConnections_nonRdsInstanceUrl(
+      final String endpoint,
+      final boolean isInitialConnection,
+      final String expected) throws SQLException {
+    final Properties properties = new Properties();
+    AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.set(properties, "?.pattern");
+    final HostSpec hostSpec = new HostSpec(endpoint);
+    when(mockPluginService.getCurrentHostSpec()).thenReturn(hostSpec);
+    when(mockRdsUtils.isRdsInstance(endpoint)).thenReturn(false);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getString(any())).thenReturn(endpoint);
+
+    final AuroraConnectionTrackerPlugin plugin = new AuroraConnectionTrackerPlugin(
+        mockPluginService,
+        properties,
+        mockRdsUtils,
+        mockTracker);
+
+    final Connection actualConnection = plugin.connect(
+        "protocol",
+        hostSpec,
+        properties,
+        isInitialConnection,
+        mockConnectionFunction);
+
+    assertEquals(mockConnection, actualConnection);
+    verify(mockTracker).populateOpenedConnectionQueue(eq(hostSpec), eq(mockConnection));
+    final Set<String> aliases = hostSpec.getAliases();
+    assertEquals(1, aliases.size());
+    assertEquals(expected, aliases.toArray()[0]);
+  }
+
+  @ParameterizedTest
+  @MethodSource("trackNonRdsInstanceUrlWithoutClusterHostInstancePatternParameters")
+  public void testTrackNewConnections_nonRdsInstanceUrl_withoutClusterInstanceHostPattern(
+      final String endpoint,
+      final boolean isInitialConnection,
+      final String expected) throws SQLException {
+    final HostSpec hostSpec = new HostSpec(endpoint);
+    when(mockPluginService.getCurrentHostSpec()).thenReturn(hostSpec);
+    when(mockRdsUtils.isRdsInstance(endpoint)).thenReturn(false);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getString(any())).thenReturn("instance-1");
+
+    final AuroraConnectionTrackerPlugin plugin = new AuroraConnectionTrackerPlugin(
+        mockPluginService,
+        EMPTY_PROPERTIES,
+        mockRdsUtils,
+        mockTracker);
+
+    final Connection actualConnection = plugin.connect(
+        "protocol",
+        hostSpec,
+        EMPTY_PROPERTIES,
+        isInitialConnection,
+        mockConnectionFunction);
+
+    assertEquals(mockConnection, actualConnection);
+    verify(mockTracker).populateOpenedConnectionQueue(eq(hostSpec), eq(mockConnection));
+    final Set<String> aliases = hostSpec.getAliases();
+    assertEquals(1, aliases.size());
+    assertEquals(expected, aliases.toArray()[0]);
   }
 
   @Test
@@ -197,6 +264,22 @@ public class AuroraConnectionTrackerPluginTest {
         Arguments.of("postgresql", false),
         Arguments.of("otherProtocol", true),
         Arguments.of("otherProtocol", false)
+    );
+  }
+
+  private static Stream<Arguments> trackNonRdsInstanceUrlParameters() {
+    return Stream.of(
+        Arguments.of("custom.domain", true, "custom.domain.pattern"),
+        Arguments.of("instanceName", false, "instanceName.pattern"),
+        Arguments.of("8.8.8.8", true, "8.8.8.8.pattern")
+    );
+  }
+
+  private static Stream<Arguments> trackNonRdsInstanceUrlWithoutClusterHostInstancePatternParameters() {
+    return Stream.of(
+        Arguments.of("custom.domain", true, "instance-1"),
+        Arguments.of("instanceName", false, "instance-1"),
+        Arguments.of("8.8.8.8", true, "instance-1")
     );
   }
 }


### PR DESCRIPTION
### Summary

Fetch the instance endpoint and add it to the host aliases for connections established using custom domains.

### Description

AuroraConnectionTrackerPlugin only looks up the instance endpoint for the current connection if the initial hostname is a cluster endpoint. 

If the connection is established via a custom domain or via the IP address, the AuroraConnectionTracker will not be able to track the opened connection since the tracker uses instance endpoints to track connections.
```
[2023-04-04 20:07:01.240150500] [FINEST ] software.amazon.jdbc.plugin.OpenedConnectionTracker populateOpenedConnectionQueue
 [Internal Error] The driver is unable to track this opened connection because the instance endpoint is unknown. 
[2023-04-04 20:07:01.259151100] [FINEST ] software.amazon.jdbc.plugin.OpenedConnectionTracker logOpenedConnections
 Opened Connections Tracked: 
[

] 
```

This behaviour leads to side effects where the user application may attempt to use an outdated connection in their workflows such as the issue raised in #386 

This change ensures the wrapper looks up the instance endpoints for other types of endpoints.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.