### PR TITLE
feat: parse region from ARN

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
@@ -12,10 +12,10 @@ The following properties are required for the AWS Secrets Manager Connection Plu
 
 > **Note:** To use this plugin, you will need to set the following AWS Secrets Manager specific parameters.
 
-| Parameter                | Value  |                        Required                         | Description                                             | Example     | Default Value |
-|--------------------------|:------:|:-------------------------------------------------------:|:--------------------------------------------------------|:------------|---------------|
-| `secretsManagerSecretId` | String |                           Yes                           | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
-| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
+| Parameter                | Value  |                                                                                     Required                                                                                      | Description                                             | Example     | Default Value |
+|--------------------------|:------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------|:------------|---------------|
+| `secretsManagerSecretId` | String |                                                                                        Yes                                                                                        | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
+| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN. A Secret ARN has the following format: `arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters` | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
 
 ### Example
 [AwsSecretsManagerConnectionPluginPostgresqlExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsSecretsManagerConnectionPluginPostgresqlExample.java)

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
@@ -8,15 +8,15 @@ The AWS Advanced JDBC Driver supports usage of database credentials stored as se
 To enable the AWS Secrets Manager Connection Plugin, add the plugin code `awsSecretsManager` to the [`wrapperPlugins`](../UsingTheJdbcDriver.md#connection-plugin-manager-parameters) value, or to the current [driver profile](../UsingTheJdbcDriver.md#connection-plugin-manager-parameters).
 
 ## AWS Secrets Manager Connection Plugin Parameters
-The following properties are required for the AWS Secrets Manager Connection Plugin to retrieve database credentials from the AWS Secrets Manager. 
+The following properties are required for the AWS Secrets Manager Connection Plugin to retrieve database credentials from the AWS Secrets Manager.
 
 > **Note:** To use this plugin, you will need to set the following AWS Secrets Manager specific parameters.
 
-| Parameter                | Value  | Required | Description                                             | Example     | Default Value |
-|--------------------------|:------:|:--------:|:--------------------------------------------------------|:------------|---------------|
-| `secretsManagerSecretId` | String |   Yes    | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
-| `secretsManagerRegion`   | String |   Yes    | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
+| Parameter                | Value  |                        Required                         | Description                                             | Example     | Default Value |
+|--------------------------|:------:|:-------------------------------------------------------:|:--------------------------------------------------------|:------------|---------------|
+| `secretsManagerSecretId` | String |                           Yes                           | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
+| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
 
 ### Example
-[AwsSecretsManagerConnectionPluginPostgresqlExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsSecretsManagerConnectionPluginPostgresqlExample.java) 
+[AwsSecretsManagerConnectionPluginPostgresqlExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsSecretsManagerConnectionPluginPostgresqlExample.java)
 demonstrates using the AWS Advanced JDBC Driver to make a connection to a PostgreSQL database using credentials fetched from the AWS Secrets Manager.

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
@@ -32,6 +32,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
@@ -59,7 +61,10 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
 
   protected static final Map<Pair<String, Region>, Secret> secretsCache = new ConcurrentHashMap<>();
 
-  private final Pair<String, Region> secretKey;
+  private static final Pattern SECRETS_ARN_PATTERN =
+      Pattern.compile("^arn:aws:secretsmanager:(?<region>[^:\\n]*):[^:\\n]*:([^:/\\n]*[:/])?(.*)$");
+
+  final Pair<String, Region> secretKey;
   private final BiFunction<HostSpec, Region, SecretsManagerClient>
       secretsManagerClientFunc;
   private final Function<String, GetSecretValueRequest> getSecretValueRequestFunc;
@@ -109,12 +114,18 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
               new Object[] {SECRET_ID_PROPERTY.name}));
     }
 
-    final String regionString = REGION_PROPERTY.getString(props);
-    if (StringUtils.isNullOrEmpty(regionString)) {
-      throw new RuntimeException(
-          Messages.get(
-              "AwsSecretsManagerConnectionPlugin.missingRequiredConfigParameter",
-              new Object[] {REGION_PROPERTY.name}));
+    final Matcher matcher = SECRETS_ARN_PATTERN.matcher(secretId);
+    String regionString;
+    if (matcher.matches()) {
+      regionString = matcher.group("region");
+    } else {
+      regionString = REGION_PROPERTY.getString(props);
+      if (StringUtils.isNullOrEmpty(regionString)) {
+        throw new RuntimeException(
+            Messages.get(
+                "AwsSecretsManagerConnectionPlugin.missingRequiredConfigParameter",
+                new Object[] {REGION_PROPERTY.name}));
+      }
     }
 
     final Region region = Region.of(regionString);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
@@ -114,18 +114,19 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
               new Object[] {SECRET_ID_PROPERTY.name}));
     }
 
-    final Matcher matcher = SECRETS_ARN_PATTERN.matcher(secretId);
     String regionString;
-    if (matcher.matches()) {
-      regionString = matcher.group("region");
-    } else {
-      regionString = REGION_PROPERTY.getString(props);
-      if (StringUtils.isNullOrEmpty(regionString)) {
+    if (StringUtils.isNullOrEmpty(props.getProperty(REGION_PROPERTY.name))) {
+      final Matcher matcher = SECRETS_ARN_PATTERN.matcher(secretId);
+      if (matcher.matches()) {
+        regionString = matcher.group("region");
+      } else {
         throw new RuntimeException(
             Messages.get(
                 "AwsSecretsManagerConnectionPlugin.missingRequiredConfigParameter",
                 new Object[] {REGION_PROPERTY.name}));
       }
+    } else {
+      regionString = REGION_PROPERTY.getString(props);
     }
 
     final Region region = Region.of(regionString);


### PR DESCRIPTION
### Summary

Parse AWS Region if the secret ID provided to the Secrets Manager connection plugin is an ARN string, so that secretsManagerRegion is no longer a required parameter for ARNs.

Addresses #391  

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.