### PR TITLE
Fix bug where topology query could execute indefinitely

### DIFF
--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -28,6 +28,7 @@ AuroraHostListProvider.invalidQuery=Error obtaining host list. Provided database
 AuroraHostListProvider.invalidDialect=Expecting a dialect that supports a cluster topology.
 AuroraHostListProvider.invalidDialectForGetHostRole=An Aurora dialect is required to analyze a host's role. The detected dialect was ''{0}''
 AuroraHostListProvider.errorGettingHostRole=An error occurred while obtaining the connected host's role. This could occur if the connection is broken or if you are not connected to an Aurora database.
+AuroraHostListProvider.errorGettingNetworkTimeout=An error occurred while getting the connection network timeout: {0}
 
 # AWS Credentials Manager
 AwsCredentialsManager.nullProvider=The configured AwsCredentialsProvider was null. If you have configured the AwsCredentialsManager to use a custom AwsCredentialsProviderHandler, please ensure the handler does not return null.


### PR DESCRIPTION
The topology query is not monitored by the EFM plugin. If the user has no socket timeout and the topology query is executed against a down instance, it could execute indefinitely. This PR temporarily sets a socket timeout for the topology query if none was set by the user.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.