### PR TITLE
Prevent disabled tests from being run during hibernate tests

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -281,6 +281,7 @@ tasks.register<Test>("test-hibernate-only") {
         systemProperty("test-no-performance", "true")
         systemProperty("test-no-mariadb-driver", "true")
         systemProperty("test-no-mariadb-engine", "true")
+        systemProperty("test-no-graalvm", "true")
         systemProperty("test-hibernate-only", "true")
     }
 }

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironment.java
@@ -585,7 +585,7 @@ public class TestEnvironment implements AutoCloseable {
       case OPENJDK8:
         return "openjdk:8-jdk-alpine";
       case OPENJDK11:
-        return "adoptopenjdk/openjdk11:alpine";
+        return "amazoncorretto:11.0.19-alpine3.17";
       case GRAALVM:
         return "ghcr.io/graalvm/jdk:22.2.0";
       default:

--- a/wrapper/src/test/java/integration/refactored/host/TestEnvironmentProvider.java
+++ b/wrapper/src/test/java/integration/refactored/host/TestEnvironmentProvider.java
@@ -178,12 +178,13 @@ public class TestEnvironmentProvider implements TestTemplateInvocationContextPro
                     DatabaseInstances.MULTI_INSTANCE,
                     2,
                     DatabaseEngineDeployment.DOCKER,
-                    TargetJvm.OPENJDK8,
+                    testHibernateOnly ? TargetJvm.OPENJDK11 : TargetJvm.OPENJDK8,
                     TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
                     noHikari ? null : TestEnvironmentFeatures.HIKARI,
                     noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
                     noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
-                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null,
+                    testHibernateOnly ? TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY : null)));
       }
       if (!noPgEngine && !noOpenJdk) {
         resultContextList.add(
@@ -193,12 +194,13 @@ public class TestEnvironmentProvider implements TestTemplateInvocationContextPro
                     DatabaseInstances.MULTI_INSTANCE,
                     2,
                     DatabaseEngineDeployment.DOCKER,
-                    TargetJvm.OPENJDK8,
+                    testHibernateOnly ? TargetJvm.OPENJDK11 : TargetJvm.OPENJDK8,
                     TestEnvironmentFeatures.NETWORK_OUTAGES_ENABLED,
                     noHikari ? null : TestEnvironmentFeatures.HIKARI,
                     noMysqlDriver ? TestEnvironmentFeatures.SKIP_MYSQL_DRIVER_TESTS : null,
                     noPgDriver ? TestEnvironmentFeatures.SKIP_PG_DRIVER_TESTS : null,
-                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null)));
+                    noMariadbDriver ? TestEnvironmentFeatures.SKIP_MARIADB_DRIVER_TESTS : null,
+                    testHibernateOnly ? TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY : null)));
       }
       if (!noMariadbEngine && !noOpenJdk) {
         resultContextList.add(


### PR DESCRIPTION
### Summary

Prevent disabled tests from being run during hibernate tests

### Description

Running hibernate tests also ran unrelated tests (SpringTests, for example), which have now been excluded. The adoptopen jdk image was also replaced with an amazon corretto image to work with the arm64 architecture.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.