### PR TITLE
Remove logic that changes connection to a writer

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -433,16 +433,6 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
     }
   }
 
-  private void connectToWriterIfRequired(final Boolean readOnly) throws SQLException {
-    if (shouldReconnectToWriter(readOnly) && !Utils.isNullOrEmpty(this.pluginService.getHosts())) {
-      try {
-        connectTo(getCurrentWriter());
-      } catch (final SQLException e) {
-        failover(getCurrentWriter());
-      }
-    }
-  }
-
   /**
    * Checks if the given host index points to the primary host.
    *
@@ -462,7 +452,6 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
           () -> Messages.get(
               "Failover.parameterValue",
               new Object[] {"explicitlyReadOnly", this.explicitlyReadOnly}));
-      connectToWriterIfRequired(this.explicitlyReadOnly);
     }
   }
 
@@ -487,10 +476,6 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
 
   boolean shouldPerformWriterFailover() {
     return this.explicitlyReadOnly == null || !this.explicitlyReadOnly;
-  }
-
-  private boolean shouldReconnectToWriter(final Boolean readOnly) {
-    return readOnly != null && !readOnly && !isWriter(this.pluginService.getCurrentHostSpec());
   }
 
   /**


### PR DESCRIPTION
### Summary

Remove logic that changes connection to a writer when setReadOnly(false) is called on reader connection.
https://github.com/awslabs/aws-advanced-jdbc-wrapper/issues/426

### Additional Reviewers

@karenc-bq 
@aaron-congo 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.