### PR TITLE
fix: use instance endpoint during monitoring connection status updates

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -38,6 +38,7 @@ public class HostSpec {
   protected Set<String> aliases = ConcurrentHashMap.newKeySet();
   protected Set<String> allAliases = ConcurrentHashMap.newKeySet();
   protected long weight; // Greater or equal 0. Lesser the weight, the healthier node.
+  protected String ipAddress;
 
   public HostSpec(final String host) {
     this.host = host;
@@ -167,6 +168,15 @@ public class HostSpec {
   public String toString() {
     return String.format("HostSpec[host=%s, port=%d, %s, %s, weight=%d]",
         this.host, this.port, this.role, this.availability, this.weight);
+  }
+
+  public String getIpAddress() {
+    return ipAddress;
+  }
+
+  public void setIpAddress(String ipAddress) {
+    this.ipAddress = ipAddress;
+    this.addAlias(ipAddress);
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -93,7 +93,12 @@ public class HostSpec {
    * @param role     the role of this host (writer or reader).
    */
   public HostSpec(final HostSpec copyHost, final HostRole role) {
-    this(copyHost.getHost(), copyHost.getPort(), role, copyHost.getAvailability());
+    this(copyHost, copyHost.getHost(), role);
+  }
+
+  public HostSpec(final HostSpec copyHost, final String newHostUrl, final HostRole role) {
+    this(newHostUrl, copyHost.getPort(), role, copyHost.getAvailability());
+    this.addAlias(copyHost.asAliases().toArray(new String[] {}));
   }
 
   public String getHost() {
@@ -168,15 +173,6 @@ public class HostSpec {
   public String toString() {
     return String.format("HostSpec[host=%s, port=%d, %s, %s, weight=%d]",
         this.host, this.port, this.role, this.availability, this.weight);
-  }
-
-  public String getIpAddress() {
-    return ipAddress;
-  }
-
-  public void setIpAddress(String ipAddress) {
-    this.ipAddress = ipAddress;
-    this.addAlias(ipAddress);
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -110,16 +110,6 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
     return connectInternal(hostSpec, forceConnectFunc);
   }
 
-  private String getInstanceEndpointPattern(final String url) {
-    if (StringUtils.isNullOrEmpty(this.clusterInstanceTemplate)) {
-      this.clusterInstanceTemplate = AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.getString(this.props) == null
-          ? rdsHelper.getRdsInstanceHostPattern(url)
-          : AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.getString(this.props);
-    }
-
-    return this.clusterInstanceTemplate;
-  }
-
   @Override
   public <T, E extends Exception> T execute(final Class<T> resultClass, final Class<E> exceptionClass,
       final Object methodInvokeOn, final String methodName, final JdbcCallable<T, E> jdbcMethodFunc,
@@ -168,7 +158,9 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
       if (resultSet.next()) {
         instanceName = resultSet.getString(1);
       }
-      String instanceEndpoint = getInstanceEndpointPattern(host.getHost());
+      String instanceEndpoint = rdsHelper.getInstanceEndpointPattern(
+          host.getHost(),
+          AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN.getString(this.props));
       instanceEndpoint = host.isPortSpecified() ? instanceEndpoint + ":" + host.getPort() : instanceEndpoint;
       return instanceEndpoint.replace("?", instanceName);
     } catch (final SQLException e) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -258,7 +258,7 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
     try (final Statement stmt = connection.createStatement()) {
       try (final ResultSet rs = stmt.executeQuery(this.pluginService.getDialect().getHostAliasQuery())) {
         while (rs.next()) {
-          hostSpec.addAlias(rs.getString(1));
+          hostSpec.setIpAddress(rs.getString(1));
         }
       }
     } catch (final SQLException sqlException) {

--- a/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
@@ -16,8 +16,10 @@
 
 package software.amazon.jdbc.util;
 
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import software.amazon.jdbc.hostlistprovider.AuroraHostListProvider;
 
 public class RdsUtils {
 
@@ -279,5 +281,11 @@ public class RdsUtils {
     } else {
       return RdsUrlType.OTHER;
     }
+  }
+
+  public String getInstanceEndpointPattern(final String url, String instanceHostPattern) {
+    return instanceHostPattern == null
+        ? this.getRdsInstanceHostPattern(url)
+        : instanceHostPattern;
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
@@ -295,7 +295,8 @@ class HostMonitoringConnectionPluginTest {
     when(resultSet.getString(eq(1))).thenReturn("second alias");
 
     plugin.connect(protocol, hostSpec, properties, true, () -> connection);
-    verify(hostSpec, times(2)).addAlias(stringArgumentCaptor.capture());
+    verify(hostSpec, times(1)).addAlias(stringArgumentCaptor.capture());
+    verify(hostSpec, times(1)).setIpAddress(stringArgumentCaptor.capture());
     final List<String> captures = stringArgumentCaptor.getAllValues();
     assertEquals(2, captures.size());
     assertEquals("hostSpec alias", captures.get(0));


### PR DESCRIPTION
### Summary

If the initial connection is established using an cluster endpoint, use an instance endpoint when verifying connection in EFM plugin or fallback to the IP address.

### Description

Integration Test Run: https://github.com/Bit-Quill/aws-advanced-jdbc-wrapper/actions/runs/4878286818

#### Before
```
2023-05-02T16:49:34.965-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:38.065-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:41.142-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:44.217-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:47.296-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:50.375-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:53.460-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:56.551-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:49:59.640-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:50:02.715-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is *alive*.
2023-05-02T16:50:05.732-07:00 TRACE 55820 --- [       Thread-4] s.a.j.p.efm.MonitorConnectionContext     : Host [atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/](http://atlas-postgres-2.cluster-ro-....us-east-2.rds.amazonaws.com/) is not *responding* 1.
```

#### After
```
 Host mysql-instance-1.....us-east-2.rds.amazonaws.com is *alive*. 
 Host mysql-instance-1.....us-east-2.rds.amazonaws.com is *alive*. 
 Host mysql-instance-1.....us-east-2.rds.amazonaws.com is *alive*. 
 Host mysql-instance-1.....us-east-2.rds.amazonaws.com is *alive*. 
 Host mysql-instance-1.....us-east-2.rds.amazonaws.com is *alive*. 
 Host mysql-instance-1.....us-east-2.rds.amazonaws.com is *alive*. 
```

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.