### PR TITLE
refactor: host alias logic in wrapper

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -315,11 +315,6 @@ tasks.register<Test>("test-all-mysql-aurora") {
         systemProperty("test-no-performance", "true")
         systemProperty("test-no-pg-driver", "true")
         systemProperty("test-no-pg-engine", "true")
-        systemProperty("test-no-mariadb-driver", "true")
-        systemProperty("test-no-mariadb-engine", "true")
-        systemProperty("test-no-iam", "true")
-        systemProperty("test-no-hikari", "true")
-        systemProperty("test-no-secrets-manager", "true")
     }
 }
 

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -315,6 +315,11 @@ tasks.register<Test>("test-all-mysql-aurora") {
         systemProperty("test-no-performance", "true")
         systemProperty("test-no-pg-driver", "true")
         systemProperty("test-no-pg-engine", "true")
+        systemProperty("test-no-mariadb-driver", "true")
+        systemProperty("test-no-mariadb-engine", "true")
+        systemProperty("test-no-iam", "true")
+        systemProperty("test-no-hikari", "true")
+        systemProperty("test-no-secrets-manager", "true")
     }
 }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -91,6 +91,8 @@ public class Driver implements java.sql.Driver {
       return null;
     }
 
+    LOGGER.finest("Opening connection to " + url);
+
     final String driverUrl = url.replaceFirst(PROTOCOL_PREFIX, "jdbc:");
     final java.sql.Driver driver = DriverManager.getDriver(driverUrl);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/HostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostListProvider.java
@@ -39,4 +39,6 @@ public interface HostListProvider {
    *                      determine the host role
    */
   HostRole getHostRole(Connection connection) throws SQLException;
+
+  HostSpec identifyConnection(Connection connection) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -152,6 +152,7 @@ public class HostSpec {
   public void resetAliases() {
     this.aliases.clear();
     this.allAliases.clear();
+    this.allAliases.add(this.asAlias());
   }
 
   public String getUrl() {

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -38,6 +38,7 @@ public class HostSpec {
   protected Set<String> aliases = ConcurrentHashMap.newKeySet();
   protected Set<String> allAliases = ConcurrentHashMap.newKeySet();
   protected long weight; // Greater or equal 0. Lesser the weight, the healthier node.
+  protected String hostId;
 
   public HostSpec(final String host) {
     this.host = host;
@@ -148,12 +149,25 @@ public class HostSpec {
     });
   }
 
+  public void resetAliases() {
+    this.aliases.clear();
+    this.allAliases.clear();
+  }
+
   public String getUrl() {
     String url = isPortSpecified() ? host + ":" + port : host;
     if (!url.endsWith("/")) {
       url += "/";
     }
     return url;
+  }
+
+  public String getHostId() {
+    return hostId;
+  }
+
+  public void setHostId(String hostId) {
+    this.hostId = hostId;
   }
 
   public String asAlias() {

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -151,4 +151,8 @@ public interface PluginService extends ExceptionHandler {
   Dialect getDialect();
 
   void updateDialect(final @NonNull Connection connection) throws SQLException;
+
+  HostSpec identifyConnection(final Connection connection) throws SQLException;
+
+  void fillAliases(final Connection connection, final HostSpec hostSpec) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -503,7 +503,11 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
   @Override
   public void fillAliases(Connection connection, HostSpec hostSpec) throws SQLException {
-    if (hostSpec == null || !hostSpec.getAliases().isEmpty()) {
+    if (hostSpec == null) {
+      return;
+    }
+
+    if (!hostSpec.getAliases().isEmpty()) {
       LOGGER.finest(() -> Messages.get("PluginServiceImpl.nonEmptyAliases", new Object[] {hostSpec.getAliases()}));
       return;
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -503,7 +503,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
   @Override
   public void fillAliases(Connection connection, HostSpec hostSpec) throws SQLException {
-    if (!hostSpec.getAliases().isEmpty()) {
+    if (hostSpec == null || !hostSpec.getAliases().isEmpty()) {
       LOGGER.finest(() -> Messages.get("PluginServiceImpl.nonEmptyAliases", new Object[] {hostSpec.getAliases()}));
       return;
     }
@@ -524,8 +524,8 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
     // Add the instance endpoint if the current connection is associated with a topology aware database cluster.
     final HostSpec host = this.identifyConnection(connection);
-    if (host != this.currentHostSpec) {
-      hostSpec.addAlias(host.asAlias());
+    if (host != null) {
+      hostSpec.addAlias(host.asAliases().toArray(new String[] {}));
     }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -510,6 +510,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
 
     hostSpec.addAlias(hostSpec.asAlias());
 
+    // Add the host name and port, this host name is usually the internal IP address.
     try (final Statement stmt = connection.createStatement()) {
       try (final ResultSet rs = stmt.executeQuery(this.getDialect().getHostAliasQuery())) {
         while (rs.next()) {
@@ -521,6 +522,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
       LOGGER.finest(() -> Messages.get("PluginServiceImpl.failedToRetrieveHostPort"));
     }
 
+    // Add the instance endpoint if the current connection is associated with a topology aware database cluster.
     final HostSpec host = this.identifyConnection(connection);
     if (host != this.currentHostSpec) {
       hostSpec.addAlias(host.asAlias());

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -337,7 +338,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   @Override
   public void refreshHostList() throws SQLException {
     final List<HostSpec> updatedHostList = this.getHostListProvider().refresh();
-    if (updatedHostList != null) {
+    if (!Objects.equals(updatedHostList, this.hosts)) {
       updateHostAvailability(updatedHostList);
       setNodeList(this.hosts, updatedHostList);
     }
@@ -346,7 +347,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   @Override
   public void refreshHostList(final Connection connection) throws SQLException {
     final List<HostSpec> updatedHostList = this.getHostListProvider().refresh(connection);
-    if (updatedHostList != null) {
+    if (!Objects.equals(updatedHostList, this.hosts)) {
       updateHostAvailability(updatedHostList);
       setNodeList(this.hosts, updatedHostList);
     }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -495,7 +495,7 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   @Override
   public HostSpec identifyConnection(Connection connection) throws SQLException {
     if (!(this.getDialect() instanceof TopologyAwareDatabaseCluster)) {
-      return this.getCurrentHostSpec();
+      return null;
     }
 
     return this.hostListProvider.identifyConnection(connection);

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -622,9 +622,7 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
         final List<HostSpec> topology = this.refresh(connection);
 
         if (topology == null) {
-          final HostSpec host = new HostSpec(getHostEndpoint(instanceName));
-          host.setHostId(instanceName);
-          return host;
+          return null;
         }
         return topology
             .stream()

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -619,7 +619,7 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
       if (resultSet.next()) {
         final String instanceName = resultSet.getString(1);
 
-        final List<HostSpec> topology = this.refresh(connection);
+        final List<HostSpec> topology = this.getCachedTopology();
 
         if (topology == null) {
           return null;

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
@@ -109,4 +109,9 @@ public class ConnectionStringHostListProvider implements StaticHostListProvider 
   public HostRole getHostRole(Connection connection) {
     throw new UnsupportedOperationException("ConnectionStringHostListProvider does not support getHostRole");
   }
+
+  @Override
+  public HostSpec identifyConnection(Connection connection) throws SQLException {
+    return this.hostList.get(0);
+  }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
@@ -17,10 +17,13 @@
 package software.amazon.jdbc.hostlistprovider;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
@@ -112,6 +115,27 @@ public class ConnectionStringHostListProvider implements StaticHostListProvider 
 
   @Override
   public HostSpec identifyConnection(Connection connection) throws SQLException {
-    return this.hostList.get(0);
+    try (final Statement stmt = connection.createStatement();
+        final ResultSet resultSet = stmt.executeQuery(this.hostListProviderService.getDialect().getHostAliasQuery())) {
+      if (resultSet.next()) {
+        final String instance = resultSet.getString(1);
+
+        final List<HostSpec> topology = this.refresh(connection);
+
+        if (topology == null) {
+          return null;
+        }
+
+        return topology
+            .stream()
+            .filter(host -> Objects.equals(instance, host.getHostId()))
+            .findAny()
+            .orElse(null);
+      }
+    } catch (final SQLException e) {
+      throw new SQLException(Messages.get("ConnectionStringHostListProvider.errorIdentifyConnection"), e);
+    }
+
+    throw new SQLException(Messages.get("ConnectionStringHostListProvider.errorIdentifyConnection"));
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -93,9 +93,7 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
         : hostSpec;
 
     if (conn != null) {
-      if (!rdsHelper.isRdsInstance(currentHostSpec.getHost())) {
-        currentHostSpec.addAlias(getInstanceEndpoint(conn, currentHostSpec));
-      }
+      this.pluginService.fillAliases(conn, hostSpec);
     }
 
     tracker.populateOpenedConnectionQueue(currentHostSpec, conn);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -82,6 +82,7 @@ public class OpenedConnectionTracker {
    * @param hostSpec The {@link HostSpec} object containing the url of the node.
    */
   public void invalidateAllConnections(final HostSpec hostSpec) {
+    invalidateAllConnections(hostSpec.getHost());
     invalidateAllConnections(hostSpec.getAliases().toArray(new String[] {}));
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -60,7 +60,7 @@ public class OpenedConnectionTracker {
     final Set<String> aliases = hostSpec.asAliases();
 
     // Check if the connection was established using a cluster endpoint
-    final String host = hostSpec.getHost();
+    final String host = hostSpec.asAlias();
     if (rdsUtils.isRdsInstance(host)) {
       trackConnection(host, conn);
       return;
@@ -82,7 +82,7 @@ public class OpenedConnectionTracker {
    * @param hostSpec The {@link HostSpec} object containing the url of the node.
    */
   public void invalidateAllConnections(final HostSpec hostSpec) {
-    invalidateAllConnections(hostSpec.getHost());
+    invalidateAllConnections(hostSpec.asAlias());
     invalidateAllConnections(hostSpec.getAliases().toArray(new String[] {}));
   }
 
@@ -98,7 +98,7 @@ public class OpenedConnectionTracker {
 
   public void invalidateCurrentConnection(final HostSpec hostSpec, final Connection connection) {
     final String host = rdsUtils.isRdsInstance(hostSpec.getHost())
-        ? hostSpec.getHost()
+        ? hostSpec.asAlias()
         : hostSpec.getAliases().stream().filter(rdsUtils::isRdsInstance).findFirst().orElse(null);
 
     if (StringUtils.isNullOrEmpty(host)) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -241,32 +241,6 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
     this.monitorService = null;
   }
 
-  /**
-   * Generate a set of node keys representing the node to monitor.
-   *
-   * @param driverProtocol Driver protocol for provided connection
-   * @param connection the connection to a specific node.
-   * @param hostSpec host details to add node keys to
-   */
-  private void generateHostAliases(
-      final @NonNull String driverProtocol,
-      final @NonNull Connection connection,
-      final @NonNull HostSpec hostSpec) {
-
-    hostSpec.addAlias(hostSpec.asAlias());
-
-    try (final Statement stmt = connection.createStatement()) {
-      try (final ResultSet rs = stmt.executeQuery(this.pluginService.getDialect().getHostAliasQuery())) {
-        while (rs.next()) {
-          hostSpec.addAlias(rs.getString(1));
-        }
-      }
-    } catch (final SQLException sqlException) {
-      // log and ignore
-      LOGGER.finest(() -> Messages.get("HostMonitoringConnectionPlugin.failedToRetrieveHostPort"));
-    }
-  }
-
   @Override
   public OldConnectionSuggestedAction notifyConnectionChanged(final EnumSet<NodeChangeOptions> changes) {
 
@@ -298,7 +272,8 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
     final Connection conn = connectFunc.call();
 
     if (conn != null) {
-      generateHostAliases(driverProtocol, conn, hostSpec);
+      hostSpec.resetAliases();
+      this.pluginService.fillAliases(conn, hostSpec);
     }
 
     return conn;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -179,7 +179,9 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
           this.monitorService.stopMonitoring(monitorContext);
 
           if (monitorContext.isNodeUnhealthy()) {
-            this.pluginService.setAvailability(this.getMonitoringHostSpec().asAliases(), HostAvailability.NOT_AVAILABLE);
+            this.pluginService.setAvailability(
+                this.getMonitoringHostSpec().asAliases(),
+                HostAvailability.NOT_AVAILABLE);
 
             final boolean isConnectionClosed;
             try {
@@ -305,11 +307,19 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
           LOGGER.finest("Monitoring HostSpec is associated with a cluster endpoint, "
               + "plugin needs to identify the cluster connection.");
           this.monitoringHostSpec = this.pluginService.identifyConnection(this.pluginService.getCurrentConnection());
+          if (this.monitoringHostSpec == null) {
+            throw new RuntimeException(Messages.get(
+                "HostMonitoringConnectionPlugin.unableToIdentifyConnection",
+                new Object[] {
+                    this.pluginService.getCurrentHostSpec().getHost(),
+                    this.pluginService.getHostListProvider()}));
+          }
           this.pluginService.fillAliases(this.pluginService.getCurrentConnection(), monitoringHostSpec);
         }
       } catch (SQLException e) {
-        // Log and ignore
+        // Log and throw.
         LOGGER.finest(Messages.get("HostMonitoringConnectionPlugin.errorIdentifyingConnection", new Object[] {e}));
+        throw new RuntimeException(e);
       }
     }
     return this.monitoringHostSpec;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorImpl.java
@@ -260,8 +260,10 @@ public class MonitorImpl implements Monitor {
                   monitoringConnProperties.remove(p);
                 });
 
+        LOGGER.finest(() -> "Opening a monitoring connection to " + this.hostSpec.getUrl());
         startNano = this.getCurrentTimeNano();
         this.monitoringConn = this.pluginService.forceConnect(this.hostSpec, monitoringConnProperties);
+        LOGGER.finest(() -> "Opened monitoring connection: " + this.monitoringConn);
         return new ConnectionStatus(true, this.getCurrentTimeNano() - startNano);
       }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorServiceImpl.java
@@ -90,16 +90,9 @@ public class MonitorServiceImpl implements MonitorService {
       final int failureDetectionCount) {
 
     if (nodeKeys.isEmpty()) {
-      LOGGER.warning(
-          () -> Messages.get(
-              "MonitorServiceImpl.emptyAliasSet",
-              new Object[] {hostSpec}));
-      try {
-        this.pluginService.fillAliases(connectionToAbort, hostSpec);
-      } catch (SQLException e) {
-        // Log and ignore the error.
-        LOGGER.finest(Messages.get("MonitorServiceImpl.errorPopulatingAliases", new Object[] {e}));
-      }
+      throw new IllegalArgumentException(Messages.get(
+          "MonitorServiceImpl.emptyAliasSet",
+          new Object[] {hostSpec}));
     }
 
     final Monitor monitor;

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -28,7 +28,8 @@ AuroraHostListProvider.invalidQuery=Error obtaining host list. Provided database
 AuroraHostListProvider.invalidDialect=Expecting a dialect that supports a cluster topology.
 AuroraHostListProvider.invalidDialectForGetHostRole=An Aurora dialect is required to analyze a host's role. The detected dialect was ''{0}''
 AuroraHostListProvider.errorGettingHostRole=An error occurred while obtaining the connected host's role. This could occur if the connection is broken or if you are not connected to an Aurora database.
-AuroraHostListProvider.errorIdentifyingConnection=An error occurred while obtaining the connection's host ID.
+AuroraHostListProvider.errorIdentifyConnection=An error occurred while obtaining the connection's host ID.
+AuroraHostListProvider.invalidDialectForIdentifyConnection=An Aurora dialect is required to analyze the instance associated with this connection. The detected dialect was ''{0}''
 
 # AWS Credentials Manager
 AwsCredentialsManager.nullProvider=The configured AwsCredentialsProvider was null. If you have configured the AwsCredentialsManager to use a custom AwsCredentialsProviderHandler, please ensure the handler does not return null.
@@ -140,7 +141,7 @@ Failover.noOperationsAfterConnectionClosed=No operations allowed after connectio
 HostMonitoringConnectionPlugin.activatedMonitoring=Executing method ''{0}'', monitoring is activated.
 HostMonitoringConnectionPlugin.monitoringDeactivated=Monitoring deactivated for method ''{0}''.
 HostMonitoringConnectionPlugin.unavailableNode=Node ''{0}'' is unavailable.
-HostMonitoringConnectionPlugin.unsupportedDriverProtocol=Driver protocol ''{0}'' is not supported.
+HostMonitoringConnectionPlugin.errorIdentifyingConnection=Error occurred while identifying connection: ''{0}''.
 
 # IAM Auth Connection Plugin
 IamAuthConnectionPlugin.unsupportedHostname=Unsupported AWS hostname {0}. Amazon domain name in format *.AWS-Region.rds.amazonaws.com or *.rds.AWS-Region.amazonaws.com.cn is expected.

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -79,6 +79,7 @@ ClusterAwareWriterFailoverHandler.alreadyWriter=Current reader connection is act
 
 # Connection String Host List Provider
 ConnectionStringHostListProvider.parsedListEmpty=Can''t parse connection string: ''{0}''.
+ConnectionStringHostListProvider.errorIdentifyConnection=An error occurred while obtaining the connection's host ID.
 
 # Connection Plugin Manager
 ConnectionPluginManager.configurationProfileNotFound=Configuration profile ''{0}'' not found.
@@ -142,6 +143,7 @@ HostMonitoringConnectionPlugin.activatedMonitoring=Executing method ''{0}'', mon
 HostMonitoringConnectionPlugin.monitoringDeactivated=Monitoring deactivated for method ''{0}''.
 HostMonitoringConnectionPlugin.unavailableNode=Node ''{0}'' is unavailable.
 HostMonitoringConnectionPlugin.errorIdentifyingConnection=Error occurred while identifying connection: ''{0}''.
+HostMonitoringConnectionPlugin.unableToIdentifyConnection=Unable to identify the given connection: ''{0}'', please ensure the correct host list provider is specified. The host list provider in use is: ''{1}''.
 
 # IAM Auth Connection Plugin
 IamAuthConnectionPlugin.unsupportedHostname=Unsupported AWS hostname {0}. Amazon domain name in format *.AWS-Region.rds.amazonaws.com or *.rds.AWS-Region.amazonaws.com.cn is expected.

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -178,7 +178,7 @@ PluginServiceImpl.hostListException=Exception while getting a host list.
 PluginServiceImpl.hostAliasNotFound=Can''t find any host by the following aliases: ''{0}''.
 PluginServiceImpl.hostsChangelistEmpty=There are no changes in the hosts' availability.
 PluginServiceImpl.failedToRetrieveHostPort=Could not retrieve Host:Port for connection.
-PluginServiceImpl.nonEmptyAliases=fillAliases called when HostSpec already contains the following aliases: ''{0}''. Please reset HostSpec aliases before calling this method.
+PluginServiceImpl.nonEmptyAliases=fillAliases called when HostSpec already contains the following aliases: ''{0}''. Please reset HostSpec aliases before calling this method if you need to re-fill them.
 
 # Property Utils
 PropertyUtils.setMethodDoesNotExistOnTarget=Set method for property ''{0}'' does not exist on target ''{1}''.

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -28,6 +28,7 @@ AuroraHostListProvider.invalidQuery=Error obtaining host list. Provided database
 AuroraHostListProvider.invalidDialect=Expecting a dialect that supports a cluster topology.
 AuroraHostListProvider.invalidDialectForGetHostRole=An Aurora dialect is required to analyze a host's role. The detected dialect was ''{0}''
 AuroraHostListProvider.errorGettingHostRole=An error occurred while obtaining the connected host's role. This could occur if the connection is broken or if you are not connected to an Aurora database.
+AuroraHostListProvider.errorIdentifyingConnection=An error occurred while obtaining the connection's host ID.
 
 # AWS Credentials Manager
 AwsCredentialsManager.nullProvider=The configured AwsCredentialsProvider was null. If you have configured the AwsCredentialsManager to use a custom AwsCredentialsProviderHandler, please ensure the handler does not return null.
@@ -139,7 +140,6 @@ Failover.noOperationsAfterConnectionClosed=No operations allowed after connectio
 HostMonitoringConnectionPlugin.activatedMonitoring=Executing method ''{0}'', monitoring is activated.
 HostMonitoringConnectionPlugin.monitoringDeactivated=Monitoring deactivated for method ''{0}''.
 HostMonitoringConnectionPlugin.unavailableNode=Node ''{0}'' is unavailable.
-HostMonitoringConnectionPlugin.failedToRetrieveHostPort=Could not retrieve Host:Port for connection.
 HostMonitoringConnectionPlugin.unsupportedDriverProtocol=Driver protocol ''{0}'' is not supported.
 
 # IAM Auth Connection Plugin
@@ -164,8 +164,9 @@ MonitorThreadContainer.emptyNodeKeys=Provided node keys are empty.
 MonitorImpl.contextNullWarning=Parameter 'context' should not be null.
 
 # Monitor Service Impl
-MonitorServiceImpl.nullMonitorParam=Parameter monitor' should not be null.
-MonitorServiceImpl.emptyAliasSet=Empty alias set passed for {0}. Set should not be empty.
+MonitorServiceImpl.nullMonitorParam=Parameter 'monitor' should not be null.
+MonitorServiceImpl.emptyAliasSet=Empty alias set passed for ''{0}''. Set should not be empty.
+MonitorServiceImpl.errorPopulatingAliases=Error occurred while populating aliases: ''{0}''.
 
 # Plugin Service Impl
 PluginServiceImpl.hostListEmpty=Current host list is empty.
@@ -173,6 +174,8 @@ PluginServiceImpl.releaseResources=Releasing resources.
 PluginServiceImpl.hostListException=Exception while getting a host list.
 PluginServiceImpl.hostAliasNotFound=Can''t find any host by the following aliases: ''{0}''.
 PluginServiceImpl.hostsChangelistEmpty=There are no changes in the hosts' availability.
+PluginServiceImpl.failedToRetrieveHostPort=Could not retrieve Host:Port for connection.
+PluginServiceImpl.nonEmptyAliases=fillAliases called when HostSpec already contains the following aliases: ''{0}''. Please reset HostSpec aliases before calling this method.
 
 # Property Utils
 PropertyUtils.setMethodDoesNotExistOnTarget=Set method for property ''{0}'' does not exist on target ''{1}''.

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -86,5 +86,5 @@ tasks.register<Test>("in-container") {
 
     // modify below filter to select specific integration tests
     // see https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html
-    filter.includeTestsMatching("integration.refactored.container.tests.*")
+    filter.includeTestsMatching("integration.refactored.container.tests.AuroraFailoverTest.testServerFailoverWithIdleConnections")
 }

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -86,5 +86,5 @@ tasks.register<Test>("in-container") {
 
     // modify below filter to select specific integration tests
     // see https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html
-    filter.includeTestsMatching("integration.refactored.container.tests.AuroraFailoverTest.testServerFailoverWithIdleConnections")
+    filter.includeTestsMatching("integration.refactored.container.tests.*")
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/PluginServiceImplTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/PluginServiceImplTests.java
@@ -526,13 +526,18 @@ public class PluginServiceImplTests {
         new HostSpec("hostB", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE),
         new HostSpec("hostC", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE)
     );
+    final List<HostSpec> newHostSpecs2 = Arrays.asList(
+        new HostSpec("hostA", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE),
+        new HostSpec("hostB", HostSpec.NO_PORT, HostRole.READER, HostAvailability.NOT_AVAILABLE),
+        new HostSpec("hostC", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE)
+    );
     final List<HostSpec> expectedHostSpecs = Arrays.asList(
         new HostSpec("hostA", HostSpec.NO_PORT, HostRole.READER, HostAvailability.NOT_AVAILABLE),
         new HostSpec("hostB", HostSpec.NO_PORT, HostRole.READER, HostAvailability.NOT_AVAILABLE),
         new HostSpec("hostC", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE));
     final List<HostSpec> expectedHostSpecs2 = Arrays.asList(
         new HostSpec("hostA", HostSpec.NO_PORT, HostRole.READER, HostAvailability.NOT_AVAILABLE),
-        new HostSpec("hostB", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE),
+        new HostSpec("hostB", HostSpec.NO_PORT, HostRole.READER, HostAvailability.NOT_AVAILABLE),
         new HostSpec("hostC", HostSpec.NO_PORT, HostRole.READER, HostAvailability.AVAILABLE));
 
     PluginServiceImpl.hostAvailabilityExpiringCache.put("hostA/", HostAvailability.NOT_AVAILABLE,
@@ -540,7 +545,7 @@ public class PluginServiceImplTests {
     PluginServiceImpl.hostAvailabilityExpiringCache.put("hostB/", HostAvailability.NOT_AVAILABLE,
         PluginServiceImpl.DEFAULT_HOST_AVAILABILITY_CACHE_EXPIRE_NANO);
     when(hostListProvider.refresh()).thenReturn(newHostSpecs);
-    when(hostListProvider.refresh(newConnection)).thenReturn(newHostSpecs);
+    when(hostListProvider.refresh(newConnection)).thenReturn(newHostSpecs2);
 
     PluginServiceImpl target = spy(
         new PluginServiceImpl(

--- a/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
@@ -469,7 +469,7 @@ class AuroraHostListProviderTest {
         "jdbc:someprotocol://url"));
     when(mockResultSet.next()).thenReturn(true);
     when(mockResultSet.getString(eq(1))).thenReturn("instance-a-1");
-    when(auroraHostListProvider.refresh(eq(mockConnection))).thenReturn(cachedTopology);
+    when(auroraHostListProvider.refresh()).thenReturn(cachedTopology);
 
     final HostSpec actual = auroraHostListProvider.identifyConnection(mockConnection);
     assertEquals("instance-a-1.xyz.us-east-2.rds.amazonaws.com", actual.getHost());

--- a/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
@@ -435,10 +435,7 @@ class AuroraHostListProviderTest {
     when(mockResultSet.getString(eq(1))).thenReturn("instance-1");
     when(auroraHostListProvider.refresh(eq(mockConnection))).thenReturn(null);
 
-    final HostSpec actual = auroraHostListProvider.identifyConnection(mockConnection);
-
-    assertEquals("instance-1.pattern", actual.getHost());
-    assertEquals("instance-1", actual.getHostId());
+    assertNull(auroraHostListProvider.identifyConnection(mockConnection));
   }
 
   @Test

--- a/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProviderTest.java
@@ -92,6 +92,7 @@ class AuroraHostListProviderTest {
     when(mockConnection.createStatement()).thenReturn(mockStatement);
     when(mockStatement.executeQuery(queryCaptor.capture())).thenReturn(mockResultSet);
     when(mockHostListProviderService.getDialect()).thenReturn(mockTopologyAwareDialect);
+    when(((TopologyAwareDatabaseCluster) mockTopologyAwareDialect).getNodeIdQuery()).thenReturn("nodeIdQuery");
   }
 
   @AfterEach
@@ -105,7 +106,7 @@ class AuroraHostListProviderTest {
     AuroraHostListProvider provider = new AuroraHostListProvider(
         protocol, mockHostListProviderService, new Properties(), originalUrl);
     provider.init();
-    //provider.clusterId = "cluster-id";
+    // provider.clusterId = "cluster-id";
     return provider;
   }
 
@@ -378,7 +379,7 @@ class AuroraHostListProviderTest {
     List<HostSpec> topologyProvider1 = provider1.refresh(Mockito.mock(Connection.class));
     assertEquals(topologyClusterA, topologyProvider1);
 
-    //AuroraHostListProvider.logCache();
+    // AuroraHostListProvider.logCache();
 
     AuroraHostListProvider provider2 = Mockito.spy(
         getAuroraHostListProvider("jdbc:something://", mockHostListProviderService,
@@ -397,7 +398,7 @@ class AuroraHostListProviderTest {
     assertEquals("cluster-a.cluster-xyz.us-east-2.rds.amazonaws.com/",
         AuroraHostListProvider.suggestedPrimaryClusterIdCache.get(provider1.clusterId));
 
-    //AuroraHostListProvider.logCache();
+    // AuroraHostListProvider.logCache();
 
     topologyProvider1 = provider1.forceRefresh(Mockito.mock(Connection.class));
     assertEquals(topologyClusterA, topologyProvider1);
@@ -405,6 +406,76 @@ class AuroraHostListProviderTest {
     assertTrue(provider1.isPrimaryClusterId);
     assertTrue(provider2.isPrimaryClusterId);
 
-    //AuroraHostListProvider.logCache();
+    // AuroraHostListProvider.logCache();
+  }
+
+  @Test
+  void testIdentifyConnectionWithInvalidNodeIdQuery() throws SQLException {
+    auroraHostListProvider = Mockito.spy(getAuroraHostListProvider(
+        "jdbc:someprotocol://",
+        mockHostListProviderService,
+        "jdbc:someprotocol://url"));
+
+    when(mockResultSet.next()).thenReturn(false);
+    assertThrows(SQLException.class, () -> auroraHostListProvider.identifyConnection(mockConnection));
+
+    when(mockConnection.createStatement()).thenThrow(new SQLException("exception"));
+    assertThrows(SQLException.class, () -> auroraHostListProvider.identifyConnection(mockConnection));
+  }
+
+  @Test
+  void testIdentifyConnectionNullTopology() throws SQLException {
+    auroraHostListProvider = Mockito.spy(getAuroraHostListProvider(
+        "jdbc:someprotocol://",
+        mockHostListProviderService,
+        "jdbc:someprotocol://url"));
+    auroraHostListProvider.clusterInstanceTemplate = new HostSpec("?.pattern");
+
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getString(eq(1))).thenReturn("instance-1");
+    when(auroraHostListProvider.refresh(eq(mockConnection))).thenReturn(null);
+
+    final HostSpec actual = auroraHostListProvider.identifyConnection(mockConnection);
+
+    assertEquals("instance-1.pattern", actual.getHost());
+    assertEquals("instance-1", actual.getHostId());
+  }
+
+  @Test
+  void testIdentifyConnectionHostNotInTopology() throws SQLException {
+    final List<HostSpec> cachedTopology = Collections.singletonList(
+        new HostSpec("instance-a-1.xyz.us-east-2.rds.amazonaws.com", HostSpec.NO_PORT, HostRole.WRITER));
+
+    auroraHostListProvider = Mockito.spy(getAuroraHostListProvider(
+        "jdbc:someprotocol://",
+        mockHostListProviderService,
+        "jdbc:someprotocol://url"));
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getString(eq(1))).thenReturn("instance-1");
+    when(auroraHostListProvider.refresh(eq(mockConnection))).thenReturn(cachedTopology);
+
+    assertNull(auroraHostListProvider.identifyConnection(mockConnection));
+  }
+
+  @Test
+  void testIdentifyConnectionHostInTopology() throws SQLException {
+    final HostSpec expectedHost = new HostSpec(
+        "instance-a-1.xyz.us-east-2.rds.amazonaws.com",
+        HostSpec.NO_PORT,
+        HostRole.WRITER);
+    expectedHost.setHostId("instance-a-1");
+    final List<HostSpec> cachedTopology = Collections.singletonList(expectedHost);
+
+    auroraHostListProvider = Mockito.spy(getAuroraHostListProvider(
+        "jdbc:someprotocol://",
+        mockHostListProviderService,
+        "jdbc:someprotocol://url"));
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getString(eq(1))).thenReturn("instance-a-1");
+    when(auroraHostListProvider.refresh(eq(mockConnection))).thenReturn(cachedTopology);
+
+    final HostSpec actual = auroraHostListProvider.identifyConnection(mockConnection);
+    assertEquals("instance-a-1.xyz.us-east-2.rds.amazonaws.com", actual.getHost());
+    assertEquals("instance-a-1", actual.getHostId());
   }
 }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPluginTest.java
@@ -29,6 +29,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -119,7 +120,7 @@ public class AuroraConnectionTrackerPluginTest {
   public void testInvalidateOpenedConnections() throws SQLException {
     final FailoverSQLException expectedException = new FailoverSQLException("reason", "sqlstate");
     final HostSpec originalHost = new HostSpec("host");
-    when(mockPluginService.getCurrentHostSpec()).thenReturn(originalHost);
+    when(mockPluginService.getHosts()).thenReturn(Collections.singletonList(originalHost));
     doThrow(expectedException).when(mockSqlFunction).call();
 
     final AuroraConnectionTrackerPlugin plugin = new AuroraConnectionTrackerPlugin(

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -380,6 +380,16 @@ public class ConcurrencyTests {
     }
 
     public void updateDialect(final @NonNull Connection connection) throws SQLException { }
+
+    @Override
+    public HostSpec identifyConnection(Connection connection) throws SQLException {
+      return null;
+    }
+
+    @Override
+    public void fillAliases(Connection connection, HostSpec hostSpec) throws SQLException {
+
+    }
   }
 
   public static class TestConnection implements Connection {

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPluginTest.java
@@ -61,6 +61,7 @@ import software.amazon.jdbc.OldConnectionSuggestedAction;
 import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.dialect.Dialect;
 import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.RdsUrlType;
 import software.amazon.jdbc.util.RdsUtils;
 
 class HostMonitoringConnectionPluginTest {
@@ -138,6 +139,7 @@ class HostMonitoringConnectionPluginTest {
     when(hostSpec.getAliases()).thenReturn(new HashSet<>(Collections.singletonList("host:port")));
     when(connection.createStatement()).thenReturn(statement);
     when(statement.executeQuery(any())).thenReturn(resultSet);
+    when(rdsUtils.identifyRdsType(any())).thenReturn(RdsUrlType.RDS_INSTANCE);
 
     properties.put("failureDetectionEnabled", Boolean.TRUE.toString());
     properties.put("failureDetectionTime", String.valueOf(FAILURE_DETECTION_TIME));

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/MonitorServiceImplTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/MonitorServiceImplTest.java
@@ -42,6 +42,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PluginService;
 
 class MonitorServiceImplTest {
 
@@ -59,6 +60,7 @@ class MonitorServiceImplTest {
   @Mock private Future<?> task;
   @Mock private HostSpec hostSpec;
   @Mock private JdbcConnection connection;
+  @Mock private PluginService pluginService;
 
   private Properties properties;
   private AutoCloseable closeable;
@@ -79,7 +81,7 @@ class MonitorServiceImplTest {
 
     doReturn(task).when(executorService).submit(any(Monitor.class));
 
-    monitorService = new MonitorServiceImpl(monitorInitializer, executorServiceInitializer);
+    monitorService = new MonitorServiceImpl(pluginService, monitorInitializer, executorServiceInitializer);
   }
 
   @AfterEach

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/MultiThreadedDefaultMonitorServiceTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/MultiThreadedDefaultMonitorServiceTest.java
@@ -54,6 +54,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PluginService;
 
 /**
  * Multithreaded tests for {@link MultiThreadedDefaultMonitorServiceTest}. Repeats each testcase
@@ -69,6 +70,7 @@ class MultiThreadedDefaultMonitorServiceTest {
   @Mock Monitor monitor;
   @Mock Properties properties;
   @Mock JdbcConnection connection;
+  @Mock PluginService pluginService;
 
   private final AtomicInteger counter = new AtomicInteger(0);
   private final AtomicInteger concurrentCounter = new AtomicInteger(0);
@@ -399,7 +401,7 @@ class MultiThreadedDefaultMonitorServiceTest {
   private List<MonitorServiceImpl> generateServices(final int numServices) {
     final List<MonitorServiceImpl> services = new ArrayList<>();
     for (int i = 0; i < numServices; i++) {
-      services.add(new MonitorServiceImpl(monitorInitializer, executorServiceInitializer));
+      services.add(new MonitorServiceImpl(pluginService, monitorInitializer, executorServiceInitializer));
     }
     return services;
   }

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPluginTest.java
@@ -523,5 +523,10 @@ class FailoverConnectionPluginTest {
     public HostRole getHostRole(Connection conn) {
       return HostRole.WRITER;
     }
+
+    @Override
+    public HostSpec identifyConnection(Connection connection) throws SQLException {
+      return new HostSpec("foo");
+    }
   }
 }


### PR DESCRIPTION
### Summary

### Integration Test Run
https://github.com/Bit-Quill/aws-advanced-jdbc-wrapper/actions/runs/4920404497

### Description

# Issues fixed
1. After failover Aurora Connection Tracker incorrectly invalidates the newly promoted writer
2. After failover Aurora Connection Tracker incorrectly invalidates a random reader that is neither the old or new writer.
3. If the initial connection is established using an cluster endpoint, EFM plugin uses the cluster endpoint as the monitoring endpoint

## Issue 1 Solution

Issue one is caused by the following check. 
```java
  private boolean isRoleChanged(final EnumSet<NodeChangeOptions> changes) {
    return changes.contains(NodeChangeOptions.PROMOTED_TO_WRITER)
        || changes.contains(NodeChangeOptions.PROMOTED_TO_READER);
  }
```

We need to remove the check for `PROMOTED_TO_WRITER`

## Issue 2 & 3
Issues 2 and 3 are both caused by missing or incorrect instance endpoint in the hostspec's aliases. Issues 2 and 3 were originally fixed in #428 and #428, and the fixes contain a lot of similarities. This refactoring centralizes the logic populating the aliases and make it less error prone.

More information in respective tickets:
https://github.com/orgs/awslabs/projects/91/views/13?pane=issue&itemId=27190320 
https://github.com/orgs/awslabs/projects/91/views/13?pane=issue&itemId=27190427

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.