### PR TITLE
Remove isMultiWriterCluster flag and ignore stale records when querying the topology

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -16,6 +16,9 @@
 
 package software.amazon.jdbc;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -39,6 +42,8 @@ public class HostSpec {
   protected Set<String> allAliases = ConcurrentHashMap.newKeySet();
   protected long weight; // Greater or equal 0. Lesser the weight, the healthier node.
   protected String hostId;
+  protected String lastUpdateTime;
+  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
   public HostSpec(final String host) {
     this.host = host;
@@ -47,6 +52,7 @@ public class HostSpec {
     this.role = HostRole.WRITER;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
+    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
   }
 
   public HostSpec(final String host, final int port) {
@@ -56,6 +62,7 @@ public class HostSpec {
     this.role = HostRole.WRITER;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
+    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
   }
 
   public HostSpec(final String host, final int port, final HostRole role) {
@@ -65,6 +72,7 @@ public class HostSpec {
     this.role = role;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
+    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
   }
 
   public HostSpec(final String host, final int port, final HostRole role, final HostAvailability availability) {
@@ -74,6 +82,7 @@ public class HostSpec {
     this.role = role;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
+    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
   }
 
   public HostSpec(final String host, final int port, final HostRole role, final HostAvailability availability,
@@ -84,6 +93,18 @@ public class HostSpec {
     this.role = role;
     this.allAliases.add(this.asAlias());
     this.weight = weight;
+    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
+  }
+
+  public HostSpec(final String host, final int port, final HostRole role, final HostAvailability availability,
+      final long weight, final String lastUpdateTime) {
+    this.host = host;
+    this.port = port;
+    this.availability = availability;
+    this.role = role;
+    this.allAliases.add(this.asAlias());
+    this.weight = weight;
+    this.lastUpdateTime = lastUpdateTime;
   }
 
   /**
@@ -118,6 +139,10 @@ public class HostSpec {
 
   public void setAvailability(final HostAvailability availability) {
     this.availability = availability;
+  }
+
+  public String getLastUpdateTime() {
+    return this.lastUpdateTime;
   }
 
   public Set<String> getAliases() {
@@ -180,13 +205,13 @@ public class HostSpec {
   }
 
   public String toString() {
-    return String.format("HostSpec[host=%s, port=%d, %s, %s, weight=%d]",
-        this.host, this.port, this.role, this.availability, this.weight);
+    return String.format("HostSpec[host=%s, port=%d, %s, %s, weight=%d, %s]",
+        this.host, this.port, this.role, this.availability, this.weight, this.lastUpdateTime);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.host, this.port, this.availability, this.role, this.weight);
+    return Objects.hash(this.host, this.port, this.availability, this.role, this.weight, this.lastUpdateTime);
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpec.java
@@ -18,7 +18,6 @@ package software.amazon.jdbc;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
@@ -42,8 +41,7 @@ public class HostSpec {
   protected Set<String> allAliases = ConcurrentHashMap.newKeySet();
   protected long weight; // Greater or equal 0. Lesser the weight, the healthier node.
   protected String hostId;
-  protected String lastUpdateTime;
-  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+  protected Timestamp lastUpdateTime;
 
   public HostSpec(final String host) {
     this.host = host;
@@ -52,7 +50,7 @@ public class HostSpec {
     this.role = HostRole.WRITER;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
-    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
+    this.lastUpdateTime = Timestamp.from(Instant.now());
   }
 
   public HostSpec(final String host, final int port) {
@@ -62,7 +60,7 @@ public class HostSpec {
     this.role = HostRole.WRITER;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
-    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
+    this.lastUpdateTime = Timestamp.from(Instant.now());
   }
 
   public HostSpec(final String host, final int port, final HostRole role) {
@@ -72,7 +70,7 @@ public class HostSpec {
     this.role = role;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
-    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
+    this.lastUpdateTime = Timestamp.from(Instant.now());
   }
 
   public HostSpec(final String host, final int port, final HostRole role, final HostAvailability availability) {
@@ -82,7 +80,7 @@ public class HostSpec {
     this.role = role;
     this.allAliases.add(this.asAlias());
     this.weight = DEFAULT_WEIGHT;
-    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
+    this.lastUpdateTime = Timestamp.from(Instant.now());
   }
 
   public HostSpec(final String host, final int port, final HostRole role, final HostAvailability availability,
@@ -93,11 +91,11 @@ public class HostSpec {
     this.role = role;
     this.allAliases.add(this.asAlias());
     this.weight = weight;
-    this.lastUpdateTime = formatter.format(Timestamp.from(Instant.now()).toLocalDateTime());
+    this.lastUpdateTime = Timestamp.from(Instant.now());
   }
 
   public HostSpec(final String host, final int port, final HostRole role, final HostAvailability availability,
-      final long weight, final String lastUpdateTime) {
+      final long weight, final Timestamp lastUpdateTime) {
     this.host = host;
     this.port = port;
     this.availability = availability;
@@ -141,7 +139,7 @@ public class HostSpec {
     this.availability = availability;
   }
 
-  public String getLastUpdateTime() {
+  public Timestamp getLastUpdateTime() {
     return this.lastUpdateTime;
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraMysqlDialect.java
@@ -27,7 +27,7 @@ public class AuroraMysqlDialect extends MysqlDialect implements TopologyAwareDat
   @Override
   public String getTopologyQuery() {
     return "SELECT SERVER_ID, CASE WHEN SESSION_ID = 'MASTER_SESSION_ID' THEN TRUE ELSE FALSE END, "
-        + "CPU, REPLICA_LAG_IN_MILLISECONDS "
+        + "CPU, REPLICA_LAG_IN_MILLISECONDS, LAST_UPDATE_TIMESTAMP "
         + "FROM information_schema.replica_host_status "
         // filter out nodes that haven't been updated in the last 5 minutes
         + "WHERE time_to_sec(timediff(now(), LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID' ";

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
@@ -40,7 +40,7 @@ public class AuroraPgDialect extends PgDialect implements TopologyAwareDatabaseC
   @Override
   public String getTopologyQuery() {
     return "SELECT SERVER_ID, CASE WHEN SESSION_ID = 'MASTER_SESSION_ID' THEN TRUE ELSE FALSE END, "
-        + "CPU, COALESCE(REPLICA_LAG_IN_MSEC, 0) "
+        + "CPU, COALESCE(REPLICA_LAG_IN_MSEC, 0), LAST_UPDATE_TIMESTAMP "
         + "FROM aurora_replica_status() "
         // filter out nodes that haven't been updated in the last 5 minutes
         + "WHERE EXTRACT(EPOCH FROM(NOW() - LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID' ";

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/TopologyAwareDatabaseCluster.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/TopologyAwareDatabaseCluster.java
@@ -26,6 +26,7 @@ public interface TopologyAwareDatabaseCluster {
    * corresponds to less node load/utilization
    * 4 - A number (or null) that represent a node lag comparing to a writer node. Lesser number
    * corresponds to small lag in time.
+   * 5 - A timestamp that represents the last time a node was updated
    */
   String getTopologyQuery();
 

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/AuroraHostListProvider.java
@@ -24,7 +24,6 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -412,11 +411,11 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
     final boolean isWriter = resultSet.getBoolean(2);
     final float cpuUtilization = resultSet.getFloat(3);
     final float nodeLag = resultSet.getFloat(4);
-    String lastUpdateTime;
+    Timestamp lastUpdateTime;
     try {
-      lastUpdateTime = convertTimestampToString(resultSet.getTimestamp(5));
+      lastUpdateTime = resultSet.getTimestamp(5);
     } catch (WrongArgumentException e) {
-      lastUpdateTime = convertTimestampToString(Timestamp.from(Instant.now()));
+      lastUpdateTime = Timestamp.from(Instant.now());
     }
 
     // Calculate weight based on node lag in time and CPU utilization.
@@ -425,7 +424,7 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
     return createHost(hostName, isWriter, weight, lastUpdateTime);
   }
 
-  private HostSpec createHost(String host, final boolean isWriter, final long weight, final String lastUpdateTime) {
+  private HostSpec createHost(String host, final boolean isWriter, final long weight, final Timestamp lastUpdateTime) {
     host = host == null ? "?" : host;
     final String endpoint = getHostEndpoint(host);
     final int port = this.clusterInstanceTemplate.isPortSpecified()
@@ -442,11 +441,6 @@ public class AuroraHostListProvider implements DynamicHostListProvider {
     hostSpec.addAlias(host);
     hostSpec.setHostId(host);
     return hostSpec;
-  }
-
-  private String convertTimestampToString(Timestamp timestamp) {
-    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-    return timestamp == null ? null : formatter.format(timestamp.toLocalDateTime());
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -321,14 +321,9 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
   }
 
   public boolean isFailoverEnabled() {
-    final boolean isMultiWriterCluster = this.pluginService.getHosts().stream()
-        .filter(h -> h.getRole() == HostRole.WRITER)
-        .count() > 1;
-
     return this.enableFailoverSetting
         && !RdsUrlType.RDS_PROXY.equals(this.rdsUrlType)
-        && !Utils.isNullOrEmpty(this.pluginService.getHosts())
-        && !isMultiWriterCluster;
+        && !Utils.isNullOrEmpty(this.pluginService.getHosts());
   }
 
   private void initSettings() {


### PR DESCRIPTION
### Summary

Remove the isMultiWriterCluster flag from the AuroraTopologyService and add checks for stale topology records.

### Description

Multi writer clusters are not longer supported, so the isMultiWriterCluster flag that was used to disable failover has been removed. Additionally, checks have been added to ensure stale writer records that are obtained post writer-failover are not being used.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.