### PR TITLE
fix: pass in a copy of shared connection properties in reader failover

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -128,9 +128,8 @@ public class DriverConnectionProvider implements ConnectionProvider {
       }
     }
 
-    LOGGER.finest(() -> "Connecting to " + urlBuilder);
-    LOGGER.finest(() -> PropertyUtils.logProperties(props, "Connecting with properties: \n"));
-
+    LOGGER.finest(() -> "Connecting to " + urlBuilder +
+        PropertyUtils.logProperties(props, "\nwith properties: \n"));
     return this.driver.connect(urlBuilder.toString(), props);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/ClusterAwareReaderFailoverHandler.java
@@ -393,10 +393,11 @@ public class ClusterAwareReaderFailoverHandler implements ReaderFailoverHandler 
       LOGGER.fine(
           () -> Messages.get(
               "ClusterAwareReaderFailoverHandler.attemptingReaderConnection",
-              new Object[] {this.newHost.getUrl()}));
+              new Object[] {this.newHost.getUrl(), initialConnectionProps}));
 
       try {
-        final Connection conn = pluginService.forceConnect(this.newHost, initialConnectionProps);
+        final Properties copy = new Properties(initialConnectionProps);
+        final Connection conn = pluginService.forceConnect(this.newHost, copy);
         pluginService.setAvailability(this.newHost.asAliases(), HostAvailability.AVAILABLE);
         LOGGER.fine(
             () -> Messages.get(

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -52,7 +52,7 @@ AwsWrapperDataSource.missingDriver=Can't find a suitable driver for ''{0}''
 
 # Cluster Aware Reader Failover Handler
 ClusterAwareReaderFailoverHandler.interruptedThread=Thread was interrupted.
-ClusterAwareReaderFailoverHandler.attemptingReaderConnection=Trying to connect to reader: ''{0}''
+ClusterAwareReaderFailoverHandler.attemptingReaderConnection=Trying to connect to reader: ''{0}'', with properties ''{1}''
 ClusterAwareReaderFailoverHandler.successfulReaderConnection=Connected to reader: ''{0}''
 ClusterAwareReaderFailoverHandler.failedReaderConnection=Failed to connect to reader: ''{0}''
 ClusterAwareReaderFailoverHandler.invalidTopology=''{0}'' was called with an invalid (null or empty) topology.


### PR DESCRIPTION
### Summary

<!--- General summary / title -->

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.