### PR TITLE
chore: add driver-specific imports to the checkstyle warning list

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License").
+  ~ You may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+  "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+  <suppress files="[\\/]MySQLExceptionHandler\.java" checks="IllegalImport"/>
+  <suppress files="[\\/]MysqlDialect\.java" checks="IllegalImport"/>
+</suppressions>

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -23,4 +23,5 @@
 <suppressions>
   <suppress files="[\\/]MySQLExceptionHandler\.java" checks="IllegalImport"/>
   <suppress files="[\\/]MysqlDialect\.java" checks="IllegalImport"/>
+  <suppress files="[\\/]test[\\/]" checks="IllegalImport"/>
 </suppressions>

--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -29,7 +29,7 @@
     </module>
     <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
     <module name="SuppressionFilter">
-        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+        <property name="file" value="${suppressionFile}"
                   default="checkstyle-suppressions.xml" />
         <property name="optional" value="true"/>
     </module>
@@ -350,6 +350,11 @@
             <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
                       default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true"/>
+        </module>
+        <module name="IllegalImport">
+            <property name="regexp" value="true"/>
+            <property name="illegalPkgs" value="com\.mysql\.*, org\.postgresql\.*, org\.mariadb\.*"/>
+            <property name="illegalClasses" value="software\.amazon\.jdbc\.exceptions\.MySQLExceptionHandler"/>
         </module>
     </module>
 </module>

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -93,6 +93,10 @@ checkstyle {
     maxWarnings = 0
     configDirectory.set(File(rootDir, "config/checkstyle"))
     configFile = configDirectory.get().file("google_checks.xml").asFile
+
+    // Checkstyle will throw an error if a driver-specific import is detected in the new changes.
+    // If the change is intentional, add the file to the suppression filter in checkstyle-suppressions.xml.
+    configProperties = mapOf("suppressionFile" to configDirectory.get().file("checkstyle-suppressions.xml").asFile)
 }
 
 spotless {


### PR DESCRIPTION
### Summary

Add Illegal Import check for driver-specific imports.

### Description

If a new file adds `com.mysql.cj.exceptions.WrongArgumentException` to the code, the checkstyle will throw the following error.
```
[ant:checkstyle] [WARN] C:\Users\Kache\source\repos\bq-wrapper\wrapper\src\main\java\software\amazon\jdbc\hostlistprovider\AuroraHostListProvider.java:19:1: Illegal import - com.mysql.cj.exceptions.WrongArgumentException. [IllegalImport]

Execution failed for task ':aws-advanced-jdbc-wrapper:checkstyleMain'.
> A failure occurred while executing org.gradle.api.plugins.quality.internal.CheckstyleAction
   > Checkstyle rule violations were found. See the report at: file:///C:/Users/Kache/source/repos/bq-wrapper/wrapper/build/reports/checkstyle/main.html
     Checkstyle files with violations: 1
     Checkstyle violations by severity: [warning:1]
```

This is to prevent unintentionally introducing references that rely on having specific dependencies in the classpath. Helps prevent issues such as #444

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.