### PR TITLE
fix: add 28000 to login exception list

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/exceptions/PgExceptionHandler.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/exceptions/PgExceptionHandler.java
@@ -35,7 +35,10 @@ public class PgExceptionHandler implements ExceptionHandler {
       "XX" // internal error (backend)
   );
 
-  public static final String ACCESS_ERROR = "28P01";
+  public static final List<String> ACCESS_ERROR = Arrays.asList(
+      "28P01",
+      "28000" // PAM authentication errors
+  );
 
   @Override
   public boolean isNetworkException(final Throwable throwable) {


### PR DESCRIPTION
### Summary

Add 28000 to the access exception codes list.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.