### PR TITLE
fix: prune null connections in the connection tracker

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -31,12 +31,14 @@ import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.NodeChangeOptions;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.cleanup.CanReleaseResources;
 import software.amazon.jdbc.plugin.failover.FailoverSQLException;
 import software.amazon.jdbc.util.RdsUrlType;
 import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.SubscribedMethodHelper;
 
-public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
+public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin implements
+    CanReleaseResources {
 
   static final String METHOD_ABORT = "Connection.abort";
   static final String METHOD_CLOSE = "Connection.close";
@@ -145,6 +147,11 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin {
         this.needUpdateCurrentWriter = true;
       }
     }
+  }
+
+  @Override
+  public void releaseResources() {
+    tracker.pruneNullConnections();
   }
 
   private HostSpec getWriter(final @NonNull List<HostSpec> hosts) {

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/OpenedConnectionTracker.java
@@ -169,4 +169,10 @@ public class OpenedConnectionTracker {
     builder.append("\n]");
     LOGGER.finest(Messages.get("OpenedConnectionTracker.invalidatingConnections", new Object[] {builder.toString()}));
   }
+
+  public void pruneNullConnections() {
+    openedConnections.forEach((key, queue) -> {
+      queue.removeIf(connectionWeakReference -> Objects.equals(connectionWeakReference.get(), null));
+    });
+  }
 }


### PR DESCRIPTION
### Summary

Prune null connections in the connection tracker

### Description

Some connections, after resources being released, remain in the connection tracker even though they are null. The existing methods that remove connections from queues do not check all the queues in the tracker and do not consider null connections, which allows them to linger. This PR adds a method to remove null connections from the tracker.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.