### PR TITLE
remove compileOnly dependencies for postgres and mariadb

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
     compileOnly("software.amazon.awssdk:secretsmanager:2.20.49")
     compileOnly("com.fasterxml.jackson.core:jackson-databind:2.14.2")
     compileOnly("mysql:mysql-connector-java:8.0.31")
-    compileOnly("org.postgresql:postgresql:42.5.0")
-    compileOnly("org.mariadb.jdbc:mariadb-java-client:3.1.0")
     compileOnly("org.osgi:org.osgi.core:4.3.0")
 
     testImplementation("org.junit.platform:junit-platform-commons:1.9.0")


### PR DESCRIPTION
this will make it impossible to import any of those packages into the wrapper source
The only time we need to import these dependencies are for tests

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.