### PR TITLE
fix failing HikariCP integration test

### DIFF
--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -16,17 +16,16 @@ you need to specify what property names the underlying datasource uses.
 For example, one datasource implementation could use the method `setUser` to set the datasource username,
 while another might use the method `setUsername` for the same task. See the table below for a list of configurable property names.
 
-> **:warning: Note:** If the same connection property is provided both explicitly in the connection URL and in the datasource properties, the value set in the connection URL will take precedence. 
+> **:warning: Note:** If the same connection property is provided both explicitly in the connection URL and in the datasource properties, the value set in the datasource properties will take precedence. 
 
-| Property                    | Configuration Method           | Description                                                                                       | Type     | Required                                                                                                                                 | Example                                |
-|-----------------------------|--------------------------------|---------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
-| Server name                 | `setServerPropertyName`        | The name of the server or host property.                                                          | `String` | Yes, if no URL is provided.                                                                                                              | `serverName`                           |
-| Database name               | `setDatabasePropertyName`      | The name of the database property.                                                                | `String` | No                                                                                                                                       | `databaseName`                         |
-| Port name                   | `setPortPropertyName`          | The name of the port property.                                                                    | `String` | No                                                                                                                                       | `port`                                 |
-| URL name                    | `setUrlPropertyName`           | The name of the URL property.                                                                     | `String` | No, but some drivers, such as MariaDb, require some parameters to be included in the URL so it is recommended to provide this parameter. | `url`                                  |
-| JDBC URL                    | `setJdbcUrl`                   | The URL to connect with.                                                                          | `String` | No, if there is enough information provided by the other properties that can be used to create a URL.                                    | `jdbc:postgresql://localhost/postgres` |
-| JDBC protocol               | `setJdbcProtocol`              | The JDBC protocol that will be used.                                                              | `String` | Yes, if the JDBC URL has not been set.                                                                                                   | `jdbc:postgresql:`                     |
-| Underlying DataSource class | `setTargetDataSourceClassName` | The fully qualified class name of the underlying DataSource class the AWS JDBC Driver should use. | `String` | Yes, if the JDBC URL has not been set.                                                                                                   | `org.postgresql.ds.PGSimpleDataSource` |
+| Property                    | Configuration Method           | Description                                                                                       | Type     | Required                                                                                                                                                                                                                          | Example                              |
+|-----------------------------|--------------------------------|---------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| Server name                 | `setServerName`                | The name of the server.                                                                           | `String` | Yes, if no URL is provided.                                                                                                                                                                                                       | `db-server.mydomain.com`             |
+| Server port            | `setServerPort`    | The server port.                                                                                  | `String` | No                                                                                                                                                                                                                                | `5432`                               |
+| Database name               | `setDatabase`                  | The name of the database.                                                                         | `String` | No                                                                                                                                                                                                                                | `testDatabase`                       |
+| JDBC URL                    | `setJdbcUrl`                   | The URL to connect with.                                                                          | `String` | No. Either URL or server name should be set. If both URL and server name have been set, URL will take precedence. Please note that some drivers, such as MariaDb, require some parameters to be included particularly in the URL.                                                                                                                            | `jdbc:postgresql://localhost/postgres` |
+| JDBC protocol               | `setJdbcProtocol`              | The JDBC protocol that will be used.                                                              | `String` | Yes, if the JDBC URL has not been set.                                                                                                                                                                                            | `jdbc:postgresql:`                   |
+| Underlying DataSource class | `setTargetDataSourceClassName` | The fully qualified class name of the underlying DataSource class the AWS JDBC Driver should use. | `String` | Yes, if the JDBC URL has not been set.                                                                                                                                                                                            | `org.postgresql.ds.PGSimpleDataSource` |
 
 ## Using the AwsWrapperDataSource with Connection Pooling Frameworks
 
@@ -63,21 +62,20 @@ To use the AWS JDBC Driver with a connection pool, you must:
    ```java
    // Note: jdbcProtocol is required when connecting via server name
    ds.addDataSourceProperty("jdbcProtocol", "jdbc:postgresql:");
-   ds.addDataSourceProperty("serverPropertyName", "serverName");
-   
-   ds.addDataSourceProperty("databasePropertyName", "databaseName");
-   ds.addDataSourceProperty("portPropertyName", "port");
+   ds.addDataSourceProperty("serverName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
+   ds.addDataSourceProperty("serverPort", "5432");
+   ds.addDataSourceProperty("database", "postgres");
    ```
 
-4. Configure the driver-specific datasource:
+4. Set the driver-specific datasource:
    ```java
    ds.addDataSourceProperty("targetDataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
-   
+    ```
+
+5. Configure the driver-specific datasource, if needed. This step is optional:
+   ```java
    Properties targetDataSourceProps = new Properties();
-   targetDataSourceProps.setProperty("serverName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
-   targetDataSourceProps.setProperty("databaseName", "postgres");
-   targetDataSourceProps.setProperty("port", "5432");
-   
+   targetDataSourceProps.setProperty("socketTimeout", "10");
    ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
    ```
 

--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -11,10 +11,7 @@ To establish a connection with the AwsWrapperDataSource, you must:
 
 ### Configurable DataSource Properties
 
-To allow the AWS Advanced JDBC Driver to work with multiple driver-specific datasources,
-you need to specify what property names the underlying datasource uses.
-For example, one datasource implementation could use the method `setUser` to set the datasource username,
-while another might use the method `setUsername` for the same task. See the table below for a list of configurable property names.
+See the table below for a list of configurable properties.
 
 > **:warning: Note:** If the same connection property is provided both explicitly in the connection URL and in the datasource properties, the value set in the datasource properties will take precedence. 
 

--- a/examples/AWSDriverExample/src/main/java/software/amazon/DatasourceExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/DatasourceExample.java
@@ -32,9 +32,6 @@ public class DatasourceExample {
 
     // Configure the property names for the underlying driver-specific data source:
     ds.setJdbcProtocol("jdbc:postgresql:");
-    ds.setDatabasePropertyName("databaseName");
-    ds.setServerPropertyName("serverName");
-    ds.setPortPropertyName("port");
 
     // Specify the driver-specific data source:
     ds.setTargetDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");
@@ -42,8 +39,8 @@ public class DatasourceExample {
     // Configure the driver-specific data source:
     Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("serverName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
-    targetDataSourceProps.setProperty("databaseName", "employees");
-    targetDataSourceProps.setProperty("port", "5432");
+    targetDataSourceProps.setProperty("database", "employees");
+    targetDataSourceProps.setProperty("serverPort", "5432");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     // Try and make a connection:

--- a/examples/AWSDriverExample/src/main/java/software/amazon/ReadWriteSplittingSpringJdbcTemplateExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/ReadWriteSplittingSpringJdbcTemplateExample.java
@@ -79,18 +79,15 @@ public class ReadWriteSplittingSpringJdbcTemplateExample {
   private static DataSource getSimplePostgresDataSource() {
     AwsWrapperDataSource ds = new AwsWrapperDataSource();
     ds.setJdbcProtocol("jdbc:postgresql:");
-    ds.setDatabasePropertyName("databaseName");
-    ds.setServerPropertyName("serverName");
-    ds.setPortPropertyName("port");
+    ds.setServerName(DATABASE_URL);
+    ds.setDatabase(DATABASE_NAME);
+    ds.setServerPort("5432");
 
     ds.setTargetDataSourceClassName("org.postgresql.ds.PGSimpleDataSource");
 
     Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty(
         PropertyDefinition.PLUGINS.name, "readWriteSplitting,failover,efm");
-    targetDataSourceProps.setProperty("serverName", DATABASE_URL);
-    targetDataSourceProps.setProperty("databaseName", DATABASE_NAME);
-    targetDataSourceProps.setProperty("port", "5432");
 
     ds.setUser(USERNAME);
     ds.setPassword(PASSWORD);
@@ -112,19 +109,15 @@ public class ReadWriteSplittingSpringJdbcTemplateExample {
 
     ds.setDataSourceClassName(AwsWrapperDataSource.class.getName());
     ds.addDataSourceProperty("jdbcProtocol", "jdbc:postgresql:");
-    ds.addDataSourceProperty("serverPropertyName", "serverName");
-
-    ds.addDataSourceProperty("databasePropertyName", "databaseName");
-    ds.addDataSourceProperty("portPropertyName", "port");
+    ds.addDataSourceProperty("serverName", DATABASE_URL);
+    ds.addDataSourceProperty("serverPort", "5432");
+    ds.addDataSourceProperty("database", DATABASE_NAME);
 
     ds.addDataSourceProperty("targetDataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
 
     Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name,
         "readWriteSplitting,failover,efm");
-    targetDataSourceProps.setProperty("serverName", DATABASE_URL);
-    targetDataSourceProps.setProperty("databaseName", DATABASE_NAME);
-    targetDataSourceProps.setProperty("port", "5432");
 
     ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
 

--- a/examples/HikariExample/src/main/java/software/amazon/HikariExample.java
+++ b/examples/HikariExample/src/main/java/software/amazon/HikariExample.java
@@ -43,20 +43,17 @@ public class HikariExample {
 
       // Configure AwsWrapperDataSource:
       ds.addDataSourceProperty("jdbcProtocol", "jdbc:postgresql:");
-      ds.addDataSourceProperty("databasePropertyName", "databaseName");
-      ds.addDataSourceProperty("portPropertyName", "portNumber");
-      ds.addDataSourceProperty("serverPropertyName", "serverName");
+      ds.addDataSourceProperty("database", DATABASE_NAME);
+      ds.addDataSourceProperty("serverPort", "5432");
+      ds.addDataSourceProperty("serverName", ENDPOINT);
 
       // Specify the driver-specific data source for AwsWrapperDataSource:
       ds.addDataSourceProperty("targetDataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
 
-      // Configuring PGSimpleDataSource:
-      Properties targetDataSourceProps = new Properties();
-      targetDataSourceProps.setProperty("serverName", ENDPOINT);
-      targetDataSourceProps.setProperty("databaseName", DATABASE_NAME);
-      targetDataSourceProps.setProperty("portNumber", "5432");
-
-      ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
+      // Configuring PGSimpleDataSource (optional):
+      // Properties targetDataSourceProps = new Properties();
+      // targetDataSourceProps.setProperty("socketTimeout", "10");
+      // ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
 
       // Attempt a connection:
       try (final Connection conn = ds.getConnection();

--- a/examples/HikariExample/src/main/java/software/amazon/HikariFailoverExample.java
+++ b/examples/HikariExample/src/main/java/software/amazon/HikariFailoverExample.java
@@ -46,9 +46,9 @@ public class HikariFailoverExample {
 
       // Configure AwsWrapperDataSource:
       ds.addDataSourceProperty("jdbcProtocol", "jdbc:postgresql:");
-      ds.addDataSourceProperty("databasePropertyName", "databaseName");
-      ds.addDataSourceProperty("portPropertyName", "portNumber");
-      ds.addDataSourceProperty("serverPropertyName", "serverName");
+      ds.addDataSourceProperty("serverName", ENDPOINT);
+      ds.addDataSourceProperty("portNumber", "5432");
+      ds.addDataSourceProperty("database", DATABASE_NAME);
 
       // The failover plugin throws failover-related exceptions that need to be handled explicitly by HikariCP,
       // otherwise connections will be closed immediately after failover. Set `ExceptionOverrideClassName` to provide
@@ -58,11 +58,10 @@ public class HikariFailoverExample {
       // Specify the driver-specific data source for AwsWrapperDataSource:
       ds.addDataSourceProperty("targetDataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
 
-      // Configuring PGSimpleDataSource:
       Properties targetDataSourceProps = new Properties();
-      targetDataSourceProps.setProperty("serverName", ENDPOINT);
-      targetDataSourceProps.setProperty("databaseName", DATABASE_NAME);
-      targetDataSourceProps.setProperty("portNumber", "5432");
+
+      // Configuring PGSimpleDataSource if needed:
+      // targetDataSourceProps.setProperty("ssl", "true");
 
       // Enable the failover and host monitoring connection plugins.
       targetDataSourceProps.setProperty("wrapperPlugins", "failover,efm");

--- a/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSourceFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ds/AwsWrapperDataSourceFactory.java
@@ -45,10 +45,9 @@ public class AwsWrapperDataSourceFactory implements ObjectFactory {
         "jdbcUrl",
         "targetDataSourceClassName",
         "jdbcProtocol",
-        "serverPropertyName",
-        "portPropertyName",
-        "urlPropertyName",
-        "databasePropertyName");
+        "serverName",
+        "serverPort",
+        "database");
 
     final Reference reference = (Reference) obj;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -87,6 +87,7 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
 
   static {
     PropertyDefinition.registerPluginProperties(HostMonitoringConnectionPlugin.class);
+    PropertyDefinition.registerPluginProperties("monitoring-");
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbDataSourceHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbDataSourceHelper.java
@@ -63,13 +63,7 @@ public class MariadbDataSourceHelper {
     // and include them to connect URL.
     PropertyDefinition.removeAllExcept(props, PropertyDefinition.DATABASE.name);
 
-    String finalUrl = buildUrl(
-        protocol,
-        hostSpec,
-        null,
-        null,
-        null,
-        props);
+    String finalUrl = buildUrl(protocol, hostSpec, props);
     LOGGER.finest(() -> "Connecting to " + finalUrl);
     mariaDbDataSource.setUrl(finalUrl);
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
 
@@ -54,14 +53,14 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
             : "";
     final boolean permitMysqlSchemeFlag = props.containsKey(PERMIT_MYSQL_SCHEME);
 
-    // "permitMysqlScheme" should be in Url rather than in properties.
-    String urlBuilder = protocol + hostSpec.getUrl() + databaseName
-        + (permitMysqlSchemeFlag ? "?" + PERMIT_MYSQL_SCHEME : "");
-
     // keep unknown properties (the ones that don't belong to AWS Wrapper Driver)
     // and use them to make a connection
     props.remove(PERMIT_MYSQL_SCHEME);
     PropertyDefinition.removeAllExceptCredentials(props);
+
+    // "permitMysqlScheme" should be in Url rather than in properties.
+    String urlBuilder = protocol + hostSpec.getUrl() + databaseName
+        + (permitMysqlSchemeFlag ? "?" + PERMIT_MYSQL_SCHEME : "");
 
     return new ConnectInfo(urlBuilder, props);
   }
@@ -71,11 +70,7 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
       final @NonNull DataSource dataSource,
       final @NonNull String protocol,
       final @NonNull HostSpec hostSpec,
-      final @NonNull Properties props,
-      final @Nullable String serverPropertyName,
-      final @Nullable String portPropertyName,
-      final @Nullable String urlPropertyName,
-      final @Nullable String databasePropertyName) throws SQLException {
+      final @NonNull Properties props) throws SQLException {
 
     // The logic is isolated to a separated class since it uses
     // direct reference to org.mariadb.jdbc.MariaDbDataSource

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJDataSourceHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJDataSourceHelper.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.targetdriverdialect;
 import com.mysql.cj.jdbc.MysqlDataSource;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
@@ -27,6 +28,9 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 
 public class MysqlConnectorJDataSourceHelper {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(MysqlConnectorJDataSourceHelper.class.getName());
 
   public void prepareDataSource(
       final @NonNull DataSource dataSource,
@@ -53,6 +57,7 @@ public class MysqlConnectorJDataSourceHelper {
     // keep unknown properties (the ones that don't belong to AWS Wrapper Driver)
     // and try to apply them to data source
     PropertyDefinition.removeAll(props);
+
     PropertyUtils.applyProperties(dataSource, props);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -21,7 +21,6 @@ import java.sql.SQLException;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 
 public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDialect {
@@ -46,11 +45,7 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
       final @NonNull DataSource dataSource,
       final @NonNull String protocol,
       final @NonNull HostSpec hostSpec,
-      final @NonNull Properties props,
-      final @Nullable String serverPropertyName,
-      final @Nullable String portPropertyName,
-      final @Nullable String urlPropertyName,
-      final @Nullable String databasePropertyName) throws SQLException {
+      final @NonNull Properties props) throws SQLException {
 
     // The logic is isolated to a separated class since it uses
     // direct reference to com.mysql.cj.jdbc.MysqlDataSource

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgDataSourceHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgDataSourceHelper.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.targetdriverdialect;
 
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.postgresql.ds.common.BaseDataSource;
@@ -27,6 +28,9 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 
 public class PgDataSourceHelper {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(PgDataSourceHelper.class.getName());
 
   private static final String BASE_DS_CLASS_NAME =
       org.postgresql.ds.common.BaseDataSource.class.getName();
@@ -56,6 +60,7 @@ public class PgDataSourceHelper {
     // keep unknown properties (the ones that don't belong to AWS Wrapper Driver)
     // and try to apply them to data source
     PropertyDefinition.removeAll(props);
+
     PropertyUtils.applyProperties(dataSource, props);
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -24,7 +24,6 @@ import java.util.Properties;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 
 public class PgTargetDriverDialect extends GenericTargetDriverDialect {
@@ -54,11 +53,7 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
       final @NonNull DataSource dataSource,
       final @NonNull String protocol,
       final @NonNull HostSpec hostSpec,
-      final @NonNull Properties props,
-      final @Nullable String serverPropertyName,
-      final @Nullable String portPropertyName,
-      final @Nullable String urlPropertyName,
-      final @Nullable String databasePropertyName) throws SQLException {
+      final @NonNull Properties props) throws SQLException {
 
     // The logic is isolated to a separated class since it uses
     // direct reference to org.postgresql.ds.common.BaseDataSource

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -20,7 +20,6 @@ import java.sql.SQLException;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.HostSpec;
 
 public interface TargetDriverDialect {
@@ -37,9 +36,5 @@ public interface TargetDriverDialect {
       final @NonNull DataSource dataSource,
       final @NonNull String protocol,
       final @NonNull HostSpec hostSpec,
-      final @NonNull Properties props,
-      final @Nullable String serverPropertyName,
-      final @Nullable String portPropertyName,
-      final @Nullable String urlPropertyName,
-      final @Nullable String databasePropertyName) throws SQLException;
+      final @NonNull Properties props) throws SQLException;
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialectManager.java
@@ -75,6 +75,7 @@ public class TargetDriverDialectManager implements TargetDriverDialectProvider {
       final @NonNull String dataSourceClass,
       final @NonNull Properties props) throws SQLException {
 
+    LOGGER.finest(() -> "Try to identify target driver dialect for data source class: " + dataSourceClass);
     return this.getDialect(props, (targetDriverDialect -> targetDriverDialect.isDialect(dataSourceClass)));
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialectManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialectManager.java
@@ -75,7 +75,6 @@ public class TargetDriverDialectManager implements TargetDriverDialectProvider {
       final @NonNull String dataSourceClass,
       final @NonNull Properties props) throws SQLException {
 
-    LOGGER.finest(() -> "Try to identify target driver dialect for data source class: " + dataSourceClass);
     return this.getDialect(props, (targetDriverDialect -> targetDriverDialect.isDialect(dataSourceClass)));
   }
 

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -47,8 +47,8 @@ AwsSecretsManagerConnectionPlugin.failedLogin=Login failed. SQLState=''{0}''
 AwsSecretsManagerConnectionPlugin.unhandledException=Unhandled exception: ''{0}''
 
 # AWS Wrapper Data Source
-AwsWrapperDataSource.missingTarget=Target data source class name or JDBC url is required.
-AwsWrapperDataSource.missingUrl=No JDBC URL was provided, or a JDBC URL couldn't be built from the provided information.
+AwsWrapperDataSource.missingJdbcProtocol=Missing JDBC protocol. Could not construct URL.
+AwsWrapperDataSource.missingTarget=JDBC url or Server name is required.
 AwsWrapperDataSource.missingDriver=Can't find a suitable driver for ''{0}''
 
 # Cluster Aware Reader Failover Handler

--- a/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ConnectionStringHelper.java
@@ -26,10 +26,6 @@ import software.amazon.jdbc.util.StringUtils;
 public class ConnectionStringHelper {
 
   public static String getUrl() {
-    return getUrl(null);
-  }
-
-  public static String getUrl(final String wrapperPlugins) {
     return getUrl(
         TestEnvironment.getCurrent().getCurrentDriver(),
         TestEnvironment.getCurrent()
@@ -44,20 +40,18 @@ public class ConnectionStringHelper {
             .getInstances()
             .get(0)
             .getPort(),
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName(),
-        wrapperPlugins);
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
   }
 
-  public static String getUrl(String host, int port, String databaseName, String wrapperPlugins) {
-    return getUrl(TestEnvironment.getCurrent().getCurrentDriver(), host, port, databaseName, wrapperPlugins);
+  public static String getUrl(String host, int port, String databaseName) {
+    return getUrl(TestEnvironment.getCurrent().getCurrentDriver(), host, port, databaseName);
   }
 
   public static String getUrl(
       TestDriver testDriver,
       String host,
       int port,
-      String databaseName,
-      String wrapperPlugins) {
+      String databaseName) {
     final DatabaseEngine databaseEngine = TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine();
     final String requiredParameters = DriverHelper.getDriverRequiredParameters(databaseEngine, testDriver);
     final String url = DriverHelper.getDriverProtocol(databaseEngine, testDriver)
@@ -66,10 +60,29 @@ public class ConnectionStringHelper {
         + port
         + "/"
         + databaseName
-        + requiredParameters
-        + (requiredParameters.startsWith("?") ? "&" : "?")
-        + "wrapperPlugins=";
-    return wrapperPlugins != null ? url + wrapperPlugins : url;
+        + requiredParameters;
+    return url;
+  }
+
+  public static String getUrlWithPlugins(String host, int port, String databaseName, String wrapperPlugins) {
+    final String url = getUrl(TestEnvironment.getCurrent().getCurrentDriver(), host, port, databaseName);
+    return url
+        + (url.contains("?") ? "&" : "?")
+        + "wrapperPlugins="
+        + wrapperPlugins;
+  }
+
+  public static String getUrlWithPlugins(
+      TestDriver testDriver,
+      String host,
+      int port,
+      String databaseName,
+      String wrapperPlugins) {
+    final String url = getUrl(testDriver, host, port, databaseName);
+    return url
+        + (url.contains("?") ? "&" : "?")
+        + "wrapperPlugins="
+        + wrapperPlugins;
   }
 
   /**

--- a/wrapper/src/test/java/integration/refactored/container/ProxyHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ProxyHelper.java
@@ -85,14 +85,15 @@ public class ProxyHelper {
   /** Allow traffic to and from server. */
   private static void enableConnectivity(Proxy proxy) {
     try {
-      final List<? extends Toxic> toxics = proxy.toxics().getAll().stream()
+      proxy.toxics().getAll().stream()
           .filter(t -> "DOWN-STREAM".equals(t.getName()) || "UP-STREAM".equals(t.getName()))
-          .collect(Collectors.toList());
-      if (toxics != null) {
-        for (Toxic toxic : toxics) {
-          toxic.remove();
-        }
-      }
+          .forEach(toxic1 -> {
+            try {
+              toxic1.remove();
+            } catch (IOException e) {
+              // ignore
+            }
+          });
     } catch (IOException ex) {
       // ignore
     }

--- a/wrapper/src/test/java/integration/refactored/container/ProxyHelper.java
+++ b/wrapper/src/test/java/integration/refactored/container/ProxyHelper.java
@@ -17,11 +17,12 @@
 package integration.refactored.container;
 
 import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.model.Toxic;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
-import integration.refactored.TestInstanceInfo;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class ProxyHelper {
 
@@ -84,13 +85,14 @@ public class ProxyHelper {
   /** Allow traffic to and from server. */
   private static void enableConnectivity(Proxy proxy) {
     try {
-      proxy.toxics().get("DOWN-STREAM").remove();
-    } catch (IOException ex) {
-      // ignore
-    }
-
-    try {
-      proxy.toxics().get("UP-STREAM").remove();
+      final List<? extends Toxic> toxics = proxy.toxics().getAll().stream()
+          .filter(t -> "DOWN-STREAM".equals(t.getName()) || "UP-STREAM".equals(t.getName()))
+          .collect(Collectors.toList());
+      if (toxics != null) {
+        for (Toxic toxic : toxics) {
+          toxic.remove();
+        }
+      }
     } catch (IOException ex) {
       // ignore
     }

--- a/wrapper/src/test/java/integration/refactored/container/TestDriverProvider.java
+++ b/wrapper/src/test/java/integration/refactored/container/TestDriverProvider.java
@@ -34,7 +34,6 @@ import integration.refactored.container.condition.EnableBasedOnEnvironmentFeatur
 import integration.refactored.container.condition.EnableBasedOnTestDriverExtension;
 import integration.refactored.container.condition.MakeSureFirstInstanceWriter;
 import integration.util.AuroraTestUtility;
-import java.net.InetAddress;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +47,8 @@ import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import software.amazon.jdbc.dialect.DialectManager;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialectManager;
 
 public class TestDriverProvider implements TestTemplateInvocationContextProvider {
   private static final Logger LOGGER = Logger.getLogger(TestDriverProvider.class.getName());
@@ -122,8 +123,8 @@ public class TestDriverProvider implements TestTemplateInvocationContextProvider
                     // Need to ensure that cluster details through API matches topology fetched through SQL
                     // Wait up to 5min
                     long startTimeNano = System.nanoTime();
-                    while ((instanceIDs.size()
-                        != testRequest.getNumOfInstances()
+                    while ((instanceIDs.size() != testRequest.getNumOfInstances()
+                        || instanceIDs.size() == 0
                         || !auroraUtil.isDBInstanceWriter(instanceIDs.get(0)))
                         && TimeUnit.NANOSECONDS.toMinutes(System.nanoTime() - startTimeNano) < 5) {
 
@@ -170,6 +171,8 @@ public class TestDriverProvider implements TestTemplateInvocationContextProvider
                   auroraUtil.makeSureInstancesUp(instanceIDs);
                   TestAuroraHostListProvider.clearCache();
                   TestPluginServiceImpl.clearHostAvailabilityCache();
+                  DialectManager.resetEndpointCache();
+                  TargetDriverDialectManager.resetCustomDialect();
                 }
               }
             });

--- a/wrapper/src/test/java/integration/refactored/container/tests/AdvancedPerformanceTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AdvancedPerformanceTest.java
@@ -310,7 +310,7 @@ public class AdvancedPerformanceTest {
             final Properties props = ConnectionStringHelper.getDefaultProperties();
             final Connection conn =
                 openConnectionWithRetry(
-                    ConnectionStringHelper.getUrl(
+                    ConnectionStringHelper.getUrlWithPlugins(
                         TestEnvironment.getCurrent()
                             .getInfo()
                             .getDatabaseInfo()

--- a/wrapper/src/test/java/integration/refactored/container/tests/AuroraFailoverTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AuroraFailoverTest.java
@@ -49,7 +49,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.TestTemplate;
@@ -374,7 +373,6 @@ public class AuroraFailoverTest {
   }
 
   @TestTemplate
-  @Disabled
   public void test_DataSourceWriterConnection_BasicFailover()
       throws SQLException, InterruptedException {
 
@@ -489,20 +487,14 @@ public class AuroraFailoverTest {
 
     // Configure the property names for the underlying driver-specific data source:
     ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
-    ds.setDatabasePropertyName("databaseName");
-    ds.setServerPropertyName("serverName");
-    ds.setPortPropertyName("port");
-    ds.setUrlPropertyName("url");
+    ds.setServerName(instanceEndpoint);
+    ds.setDatabase(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
 
     // Specify the driver-specific data source:
     ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
 
     // Configure the driver-specific data source:
     Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty("serverName", instanceEndpoint);
-    targetDataSourceProps.setProperty(
-        "databaseName",
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
     targetDataSourceProps.setProperty("wrapperPlugins", "failover");
 
     if (TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MARIADB

--- a/wrapper/src/test/java/integration/refactored/container/tests/AwsIamIntegrationTest.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/AwsIamIntegrationTest.java
@@ -223,19 +223,12 @@ public class AwsIamIntegrationTest {
   void test_AwsIam_UserAndPasswordPropertiesArePreserved() throws SQLException {
     final AwsWrapperDataSource ds = new AwsWrapperDataSource();
     ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
-    ds.setServerPropertyName("serverName");
-    ds.setDatabasePropertyName("databaseName");
-
+    ds.setServerName(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint());
+    ds.setDatabase(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
     ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
 
     final Properties props =
         initAwsIamProps(TestEnvironment.getCurrent().getInfo().getIamUsername(), "<anything>");
-    props.setProperty(
-        "serverName",
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getClusterEndpoint());
-    props.setProperty(
-        "databaseName",
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
     ds.setTargetDataSourceProperties(props);
 
     try (final Connection conn = ds.getConnection()) {

--- a/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/BasicConnectivityTests.java
@@ -73,7 +73,7 @@ public class BasicConnectivityTests {
     DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
 
     String url =
-        ConnectionStringHelper.getUrl(
+        ConnectionStringHelper.getUrlWithPlugins(
             testDriver,
             TestEnvironment.getCurrent()
                 .getInfo()
@@ -169,7 +169,7 @@ public class BasicConnectivityTests {
         TestEnvironment.getCurrent().getInfo().getProxyDatabaseInfo().getInstances().get(0);
 
     String url =
-        ConnectionStringHelper.getUrl(
+        ConnectionStringHelper.getUrlWithPlugins(
             testDriver,
             instanceInfo.getHost(),
             instanceInfo.getPort(),

--- a/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
+++ b/wrapper/src/test/java/integration/refactored/container/tests/DataSourceTests.java
@@ -63,23 +63,16 @@ public class DataSourceTests {
       throws SQLException, NamingException, IllegalAccessException {
     final AwsWrapperDataSource ds = new AwsWrapperDataSource();
     ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
-    ds.setServerPropertyName("serverName");
-    ds.setDatabasePropertyName("databaseName");
-
+    ds.setServerName(TestEnvironment.getCurrent()
+        .getInfo()
+        .getDatabaseInfo()
+        .getInstances()
+        .get(0)
+        .getHost());
+    ds.setDatabase(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
     ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
 
     final Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty(
-        "serverName",
-        TestEnvironment.getCurrent()
-            .getInfo()
-            .getDatabaseInfo()
-            .getInstances()
-            .get(0)
-            .getHost());
-    targetDataSourceProps.setProperty(
-        "databaseName",
-        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getDefaultDbName());
     targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
@@ -120,10 +113,9 @@ public class DataSourceTests {
 
     ds.setTargetDataSourceClassName(DriverHelper.getDataSourceClassname());
     ds.setJdbcProtocol(DriverHelper.getDriverProtocol());
-    ds.setUrlPropertyName("url");
+    ds.setJdbcUrl(ConnectionStringHelper.getUrl());
 
     final Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty("url", ConnectionStringHelper.getUrl());
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     final Hashtable<String, Object> env = new Hashtable<>();

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -639,7 +639,7 @@ public class AuroraTestUtility {
                   TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getInstance(id);
               try (final Connection conn =
                   DriverManager.getConnection(
-                      ConnectionStringHelper.getUrl(
+                      ConnectionStringHelper.getUrlWithPlugins(
                           instanceInfo.getHost(),
                           instanceInfo.getPort(),
                           TestEnvironment.getCurrent()

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperDataSourceTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperDataSourceTest.java
@@ -117,7 +117,7 @@ class AwsWrapperDataSourceTest {
   @Test
   public void testConnectionWithDataSourceClassNameAndUrl() throws SQLException {
     final String expectedUrl = "jdbc:postgresql://testserver/db";
-    ds.setJdbcUrl("jdbc:postgresql://testserver/db");
+    ds.setJdbcUrl(expectedUrl);
 
     try (final Connection conn = ds.getConnection("user", "pass")) {
       final List<String> urls = urlArgumentCaptor.getAllValues();

--- a/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperDataSourceTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ds/AwsWrapperDataSourceTest.java
@@ -63,23 +63,17 @@ class AwsWrapperDataSourceTest {
 
   @Test
   public void testGetConnectionWithNewCredentialsWithDataSource() throws SQLException {
-    final String expectedUrl1 = "protocol//testserver/?user=user1&password=pass1";
+    final String expectedUrl1 = "protocol//testserver/";
     final Properties expectedProperties1 = new Properties();
     expectedProperties1.setProperty("user", "user1");
     expectedProperties1.setProperty("password", "pass1");
-    expectedProperties1.setProperty("serverName", "testserver");
 
     final Properties expectedProperties2 = new Properties();
     expectedProperties2.setProperty("user", "user2");
     expectedProperties2.setProperty("password", "pass2");
-    expectedProperties2.setProperty("serverName", "testserver");
 
     ds.setJdbcProtocol("protocol");
-    ds.setServerPropertyName("serverName");
-
-    Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty("serverName", "testserver");
-    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    ds.setServerName("testserver");
 
     ds.getConnection("user1", "pass1");
     ds.getConnection("user2", "pass2");
@@ -89,7 +83,7 @@ class AwsWrapperDataSourceTest {
     assertEquals(2, urls.size());
     assertEquals(2, properties.size());
     assertEquals(expectedUrl1, urls.get(0));
-    assertEquals(expectedUrl1, urls.get(1)); // JDBC Url doesn't get updated when we are reusing the connection.
+    assertEquals(expectedUrl1, urls.get(1)); // JDBC Url doesn't get updated when we are reusing the data source.
     assertEquals(expectedProperties1, properties.get(0));
     assertEquals(expectedProperties2, properties.get(1));
   }
@@ -123,11 +117,7 @@ class AwsWrapperDataSourceTest {
   @Test
   public void testConnectionWithDataSourceClassNameAndUrl() throws SQLException {
     final String expectedUrl = "jdbc:postgresql://testserver/db";
-    ds.setUrlPropertyName("url");
-
-    final Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty("url", "jdbc:postgresql://testserver/db");
-    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    ds.setJdbcUrl("jdbc:postgresql://testserver/db");
 
     try (final Connection conn = ds.getConnection("user", "pass")) {
       final List<String> urls = urlArgumentCaptor.getAllValues();
@@ -156,20 +146,11 @@ class AwsWrapperDataSourceTest {
 
   @Test
   public void testConnectionWithDataSourceClassNameAndServerName() throws SQLException {
-    final String expectedUrl = "protocol//testServer/db?user=user&password=pass";
+    final String expectedUrl = "protocol//testServer/db";
 
     ds.setJdbcProtocol("protocol");
-    ds.setServerPropertyName("serverName");
-    ds.setDatabasePropertyName("databaseName");
-
-    final Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty(
-        "serverName",
-        "testServer");
-    targetDataSourceProps.setProperty(
-        "databaseName",
-        "db");
-    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    ds.setServerName("testServer");
+    ds.setDatabase("db");
 
     try (final Connection conn = ds.getConnection("user", "pass")) {
       final List<String> urls = urlArgumentCaptor.getAllValues();
@@ -184,14 +165,12 @@ class AwsWrapperDataSourceTest {
   @Test
   @DisableOnTestDriver(TestDriver.MARIADB)
   public void testConnectionWithDataSourceClassNameAndCredentialProperties() throws SQLException {
-    final String expectedUrl = "protocol//testServer/db?user=user&password=pass";
+    final String expectedUrl = "protocol//testServer/db";
     ds.setJdbcProtocol("protocol");
-    ds.setServerPropertyName("serverName");
-    ds.setDatabasePropertyName("databaseName");
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("serverName", "testServer");
-    targetDataSourceProps.setProperty("databaseName", "db");
+    targetDataSourceProps.setProperty("database", "db");
     targetDataSourceProps.setProperty("user", "user");
     targetDataSourceProps.setProperty("password", "pass");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
@@ -209,12 +188,10 @@ class AwsWrapperDataSourceTest {
   @Test
   public void testConnectionWithDataSourceClassNameMissingProtocol() {
     ds = new AwsWrapperDataSource();
-    ds.setServerPropertyName("serverName");
-    ds.setDatabasePropertyName("databaseName");
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("serverName", "testServer");
-    targetDataSourceProps.setProperty("databaseName", "db");
+    targetDataSourceProps.setProperty("database", "db");
     ds.setTargetDataSourceProperties(targetDataSourceProps);
 
     assertThrows(SQLException.class, () -> ds.getConnection("user", "pass"));
@@ -224,11 +201,7 @@ class AwsWrapperDataSourceTest {
   public void testConnectionWithDataSourceClassNameMissingServer() {
     ds = new AwsWrapperDataSource();
     ds.setJdbcProtocol("protocol");
-    ds.setDatabasePropertyName("databaseName");
-
-    final Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty("databaseName", "db");
-    ds.setTargetDataSourceProperties(targetDataSourceProps);
+    ds.setDatabase("db");
 
     assertThrows(SQLException.class, () -> ds.getConnection("user", "pass"));
   }
@@ -237,7 +210,6 @@ class AwsWrapperDataSourceTest {
   public void testConnectionWithDataSourceClassNameMissingDatabase() {
     ds = new AwsWrapperDataSource();
     ds.setJdbcProtocol("protocol");
-    ds.setServerPropertyName("serverName");
 
     final Properties targetDataSourceProps = new Properties();
     targetDataSourceProps.setProperty("serverName", "testServer");
@@ -249,7 +221,6 @@ class AwsWrapperDataSourceTest {
   @Test
   public void testConnectionWithUrlMissingPassword() {
     ds = new AwsWrapperDataSource();
-    ds.setUrlPropertyName("url");
     ds.setJdbcUrl("protocol://testserver/");
 
     assertThrows(SQLException.class, () -> ds.getConnection("user", ""));

--- a/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlBuilderTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlBuilderTest.java
@@ -39,7 +39,8 @@ class ConnectionUrlBuilderTest {
       final String db,
       final String expected,
       final Properties props) throws SQLException {
-    Properties properties = new Properties(props);
+    Properties properties = new Properties();
+    properties.putAll(props);
     properties.setProperty(server, server);
     properties.setProperty(port, "1234");
     properties.setProperty(db, db);
@@ -47,9 +48,6 @@ class ConnectionUrlBuilderTest {
     final String actual = ConnectionUrlBuilder.buildUrl(
         jdbcProtocol,
         host,
-        server,
-        port,
-        db,
         properties);
     assertEquals(expected, actual);
   }
@@ -70,9 +68,6 @@ class ConnectionUrlBuilderTest {
     assertThrows(SQLException.class, () -> ConnectionUrlBuilder.buildUrl(
         jdbcProtocol,
         host,
-        server,
-        port,
-        db,
         properties));
   }
 
@@ -87,7 +82,7 @@ class ConnectionUrlBuilderTest {
             "",
             "port",
             "database",
-            "protocol//fooUrl/database",
+            "protocol//fooUrl/database?port=1234&bar=baz",
             properties),
         Arguments.of(
             "protocol//",
@@ -95,7 +90,7 @@ class ConnectionUrlBuilderTest {
             " ",
             "port",
             "database",
-            "protocol//fooUrl/database",
+            "protocol//fooUrl/database?port=1234&bar=baz",
             properties),
         Arguments.of(
             "protocol",
@@ -103,24 +98,8 @@ class ConnectionUrlBuilderTest {
             "server",
             "port",
             "database",
-            "protocol//fooUrl/database",
-            properties),
-        Arguments.of(
-            "protocol",
-            null,
-            "server",
-            "port",
-            "database",
-            "protocol//server:1234/database",
-            null),
-        Arguments.of(
-            "protocol",
-            null,
-            "server",
-            "port",
-            "db",
-            "protocol//server:1234/",
-            null)
+            "protocol//fooUrl/database?port=1234&bar=baz&server=server",
+            properties)
     );
   }
 

--- a/wrapper/src/test/java/software/amazon/logging/ExtendedFormatter.java
+++ b/wrapper/src/test/java/software/amazon/logging/ExtendedFormatter.java
@@ -42,6 +42,7 @@ public class ExtendedFormatter extends SimpleFormatter {
    * - ( 5$) the log message
    * - ( 6$) the throwable and its backtrace, if any
    * - ( 7$) the thread name
+   * - ( 8$) the thread ID
    */
   private static final String format = LogManager.getLogManager()
       .getProperty(ExtendedFormatter.class.getName() + ".format");
@@ -92,7 +93,8 @@ public class ExtendedFormatter extends SimpleFormatter {
         record.getLevel().getLocalizedName(),
         message,
         throwable,
-        threadName);
+        threadName,
+        record.getThreadID());
   }
 
   private static String getThreadName(int logRecordThreadId) {

--- a/wrapper/src/test/resources/simplelogger.properties
+++ b/wrapper/src/test/resources/simplelogger.properties
@@ -22,3 +22,5 @@ org.slf4j.simpleLogger.defaultLogLevel=warn
 org.slf4j.simpleLogger.log.org.testcontainers=warn
 org.slf4j.simpleLogger.log.com.github.dockerjava=info
 org.slf4j.simpleLogger.log.integration.container=debug
+
+org.slf4j.simpleLogger.log.com.zaxxer.hikari=trace


### PR DESCRIPTION
### Summary

- Fix issue with HikariCP integration test.
- rework AwsWrapperDataSource: removed properties for property names, introduced a set of simple properties to set database, server name and server port.

### Additional Reviewers

@karenc-bq 
@aaron-congo 
@aaronchung-bitquill 
@crystall-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.