### PR TITLE
fix: checkstyle and properties being overridden

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -27,4 +27,5 @@
   <suppress files="[\\/]MysqlConnectorJDataSourceHelper\.java" checks="IllegalImport"/>
   <suppress files="[\\/]PgDataSourceHelper\.java" checks="IllegalImport"/>
   <suppress files="[\\/]test[\\/]" checks="IllegalImport"/>
+  <suppress files="[\\/]ExtendedFormatter\.java" checks="Header"/>
 </suppressions>

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -110,8 +110,9 @@ public class DriverConnectionProvider implements ConnectionProvider {
       final @NonNull Properties props)
       throws SQLException {
 
+    final Properties copy = PropertyUtils.copyProperties(props);
     final ConnectInfo connectInfo =
-        this.targetDriverDialect.prepareConnectInfo(protocol, hostSpec, props);
+        this.targetDriverDialect.prepareConnectInfo(protocol, hostSpec, copy);
 
     LOGGER.finest(() -> "Connecting to " + connectInfo.url
         + PropertyUtils.logProperties(connectInfo.props, "\nwith properties: \n"));


### PR DESCRIPTION

### Summary

Fix:
- checkstyle failure due to modified license
- driver connection provider passing original properties resulting properties being overridden for subsequent connections.

Changes derived from PR #468 

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.