### PR TITLE
fix: IAM_DEFAULT_PORT property to override host and dialect ports.

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/IamAuthConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/IamAuthConnectionPlugin.java
@@ -107,20 +107,7 @@ public class IamAuthConnectionPlugin extends AbstractConnectionPlugin {
       host = IAM_HOST.getString(props);
     }
 
-    int port = hostSpec.getPort();
-    if (!hostSpec.isPortSpecified()) {
-      if (StringUtils.isNullOrEmpty(IAM_DEFAULT_PORT.getString(props))) {
-        port = this.pluginService.getDialect().getDefaultPort();
-      } else {
-        port = IAM_DEFAULT_PORT.getInteger(props);
-        if (port <= 0) {
-          throw new IllegalArgumentException(
-              Messages.get(
-                  "IamAuthConnectionPlugin.invalidPort",
-                  new Object[] {port}));
-        }
-      }
-    }
+    int port = getPort(props, hostSpec);
 
     final String iamRegion = IAM_REGION.getString(props);
     final Region region = StringUtils.isNullOrEmpty(iamRegion)
@@ -243,6 +230,26 @@ public class IamAuthConnectionPlugin extends AbstractConnectionPlugin {
 
   public static void clearCache() {
     tokenCache.clear();
+  }
+
+  private int getPort(Properties props, HostSpec hostSpec) {
+    if (!StringUtils.isNullOrEmpty(IAM_DEFAULT_PORT.getString(props))) {
+      int defaultPort = IAM_DEFAULT_PORT.getInteger(props);
+      if (defaultPort > 0) {
+        return defaultPort;
+      } else {
+        LOGGER.finest(
+            () -> Messages.get(
+                "IamAuthConnectionPlugin.invalidPort",
+                new Object[] {defaultPort}));
+      }
+    }
+
+    if (hostSpec.isPortSpecified()) {
+      return hostSpec.getPort();
+    } else {
+      return this.pluginService.getDialect().getDefaultPort();
+    }
   }
 
   private Region getRdsRegion(final String hostname) throws SQLException {

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -162,7 +162,7 @@ HostSelector.noHostsMatchingRole=No hosts were found matching the requested ''{0
 IamAuthConnectionPlugin.unsupportedHostname=Unsupported AWS hostname {0}. Amazon domain name in format *.AWS-Region.rds.amazonaws.com or *.rds.AWS-Region.amazonaws.com.cn is expected.
 IamAuthConnectionPlugin.useCachedIamToken=Use cached IAM token = ''{0}''
 IamAuthConnectionPlugin.generatedNewIamToken=Generated new IAM token = ''{0}''
-IamAuthConnectionPlugin.invalidPort=Port number: {0} is not valid. Port number should be greater than zero.
+IamAuthConnectionPlugin.invalidPort=Port number: {0} is not valid. Port number should be greater than zero. Falling back to default port.
 IamAuthConnectionPlugin.unhandledException=Unhandled exception: ''{0}''
 IamAuthConnectionPlugin.connectException=Error occurred while opening a connection: ''{0}''
 


### PR DESCRIPTION
### Summary

Fix in the IamAuthConnectionPlugin to prioritize the override property IAM_DEFAULT_PORT then Hosts port, and then Dialect port. 

### Description

Fix in the IamAuthConnectionPlugin to prioritize the override property IAM_DEFAULT_PORT then Hosts port, and then Dialect port. 
This also results in change of behaviour. When an invalid port value is specified for IAM_DEFAULT_PORT, it no longer throws an exception, but rather logs a warning and then falls back on either the Host port or Dialect default port. 


### Additional Reviewers

@sergiyv-improving @karenc-bq @aaron-congo @crystall-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.