### PR TITLE
fix: Let wrapperLoggerLevel values be case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/#semantic-versioning-200).
 
+## [?]
+### :bug: Fixed
+- Values for the `wrapperLoggerLevel` parameter are no longer case-sensitive ([#PR #481](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/481)).
+
 ## [2.1.2] - 2023-5-21
 ### :crab: Changed
 - Explicitly check for 28000 and 28P01 SQLStates in the IAM authentication plugin after SQLExceptions are thrown ([PR #456](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/456) and [PR #457](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/457)).

--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -110,7 +110,7 @@ public class Driver implements java.sql.Driver {
 
     final String logLevelStr = PropertyDefinition.LOGGER_LEVEL.getString(info);
     if (!StringUtils.isNullOrEmpty(logLevelStr)) {
-      final Level logLevel = Level.parse(logLevelStr);
+      final Level logLevel = Level.parse(logLevelStr.toUpperCase());
       final Logger rootLogger = Logger.getLogger("");
       for (final Handler handler : rootLogger.getHandlers()) {
         if (handler instanceof ConsoleHandler) {


### PR DESCRIPTION
### Summary

Let wrapperLoggerLevel values be case insensitive

### Description

The driver currently only accepts capitalized values for the `wrapperLoggerLevel` parameter. This PR will accept any capitalization.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.