### PR TITLE
fix: aurora_connection_tracker not subscribed to close or abort methods

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AuroraConnectionTrackerPlugin.java
@@ -49,6 +49,8 @@ public class AuroraConnectionTrackerPlugin extends AbstractConnectionPlugin impl
           add("connect");
           add("forceConnect");
           add("notifyNodeListChanged");
+          add(METHOD_ABORT);
+          add(METHOD_CLOSE);
         }
       });
 


### PR DESCRIPTION
### Summary

aurora_connection_tracker was not subscribed to `Connection.close` or `Connection.abort`, therefore `invalidateCurrentConnection` was never called:
```java
      if ((methodName.equals(METHOD_CLOSE) || methodName.equals(METHOD_ABORT))) {
        tracker.invalidateCurrentConnection(currentHostSpec, this.pluginService.getCurrentConnection());
      }
```

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.