### PR TITLE
Put configuration parameters on first page with links to where they are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,56 @@ Enhanced Failure Monitoring (EFM) is a feature available from the [Host Monitori
 Please visit [this page](./docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#using-the-aws-jdbc-driver-with-plain-rds-databases) for more information.
 
 ## Getting Started
-For more information on how to obtain the AWS JDBC Driver, minimum requirements to use it, and how to integrate the AWS JDBC Driver into your project, please visit the [Getting Started page](./docs/GettingStarted.md).
+For more information on how to obtain the AWS JDBC Driver, minimum requirements to use it, 
+and how to integrate the AWS JDBC Driver into your project, please visit the 
+[Getting Started page](./docs/GettingStarted.md).
+### Maven Central
+You can find our driver by searching in The Central Repository with GroupId and ArtifactId [software.amazon:aws-advanced-jdbc-wrapper][mvn-search].
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/software.amazon.jdbc/aws-advanced-jdbc-wrapper/badge.svg)](https://maven-badges.herokuapp.com/maven-central/software.amazon.jdbc/aws-advanced-jdbc-wrapper)
+```xml
+<!-- Add the following dependency to your pom.xml, -->
+<!-- replacing LATEST with specific version as required -->
+
+<dependency>
+  <groupId>software.amazon</groupId>
+  <artifactId>aws-advanced-jdbc-wrapper</artifactId>
+  <version>LATEST</version>
+</dependency>
+```
+
+[mvn-search]: https://search.maven.org/search?q=g:software.amazon.jdbc "Search on Maven Central"
+
+## Properties
+
+| Parameter                              |                              Reference                               |                                                   Documentation Link                                                   |
+|----------------------------------------|:--------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------------------:|
+| `wrapperDialect`                       |                       `DialectManager.DIALECT`                       |            [Dialects](/docs/using-the-jdbc-driver/DatabaseDialects.md), and whether you should include it.             |
+| `wrapperPlugins`                       |                     `PropertyDefinition.PLUGINS`                     |                                                                                                                        |
+| `secretsManagerSecretId`               |        `AwsSecretsManagerConnectionPlugin.SECRET_ID_PROPERTY`        |         [SecretsManagerPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md)          |
+| `secretsManagerRegion`                 |         `AwsSecretsManagerConnectionPlugin.REGION_PROPERTY`          |         [SecretsManagerPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md)          |
+| `wrapperDriverName`                    |         `DriverMetaDataConnectionPlugin.WRAPPER_DRIVER_NAME`         | [DriverMetaDataConnectionPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheDriverMetadataConnectionPlugin.md) |
+| `failoverMode`                         |               `FailoverConnectionPlugin.FAILOVER_MODE`               |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `clusterInstanceHostPattern`           |        `AuroraHostListProvider.CLUSTER_INSTANCE_HOST_PATTERN`        |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `enableClusterAwareFailover`           |       `FailoverConnectionPlugin.ENABLE_CLUSTER_AWARE_FAILOVER`       |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `failoverClusterTopologyRefreshRateMs` | `FailoverConnectionPlugin.FAILOVER_CLUSTER_TOPOLOGY_REFRESH_RATE_MS` |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `failoverReaderConnectTimeoutMs`       |    `FailoverConnectionPlugin.FAILOVER_READER_CONNECT_TIMEOUT_MS`     |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `failoverTimeoutMs`                    |            `FailoverConnectionPlugin.FAILOVER_TIMEOUT_MS`            |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `failoverWriterReconnectIntervalMs`    |   `FailoverConnectionPlugin.FAILOVER_WRITER_RECONNECT_INTERVAL_MS`   |                 [FailoverPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheFailoverPlugin.md)                 |
+| `failureDetectionCount`                |       `HostMonitoringConnectionPlugin.FAILURE_DETECTION_COUNT`       |           [HostMonitoringPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md)           |
+| `failureDetectionEnabled`              |      `HostMonitoringConnectionPlugin.FAILURE_DETECTION_ENABLED`      |           [HostMonitoringPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md)           |
+| `failureDetectionInterval`             |     `HostMonitoringConnectionPlugin.FAILURE_DETECTION_INTERVAL`      |           [HostMonitoringPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md)           |
+| `failureDetectionTime`                 |       `HostMonitoringConnectionPlugin.FAILURE_DETECTION_TIME`        |           [HostMonitoringPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md)           |
+| `monitorDisposalTime`                  |            `MonitorServiceImpl.MONITOR_DISPOSAL_TIME_MS`             |           [HostMonitoringPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheHostMonitoringPlugin.md)           |
+| `iamDefaultPort`                       |              `IamAuthConnectionPlugin.IAM_DEFAULT_PORT`              |        [IamAuthenticationPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md)        |
+| `iamHost`                              |                  `IamAuthConnectionPlugin.IAM_HOST`                  |        [IamAuthenticationPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md)        |
+| `iamRegion`                            |                 `IamAuthConnectionPlugin.IAM_REGION`                 |        [IamAuthenticationPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md)        |
+| `iamExpiration`                        |               `IamAuthConnectionPlugin.IAM_EXPIRATION`               |        [IamAuthenticationPlugin](./docs/using-the-jdbc-driver/using-plugins/UsingTheIamAuthenticationPlugin.md)        |
+| `wrapperLogUnclosedConnections`        |            `PropertyDefinition.LOG_UNCLOSED_CONNECTIONS`             |                  [LogUnclosedConnections](./docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#logging)                  |
+| `wrapperLoggerLevel`                   |                  `PropertyDefinition.LOGGER_LEVEL`                   |                       [LoggingLevel](./docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#logging)                       |
+| `wrapperProfileName`                   |                  `PropertyDefinition.PROFILE_NAME`                   |           [ConfigurationProfiles](./docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#configuration-profiles)           |
+
+**A Secret ARN** has the following format: `arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters`
 ## Using the AWS JDBC Driver
 Please refer to the AWS JDBC Driver's [Documentation page](./docs/Documentation.md) for details about using the AWS JDBC Driver. 
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -46,7 +46,7 @@ You can use [Maven's dependency management](https://search.maven.org/search?q=g:
     <dependency>
         <groupId>software.amazon.jdbc</groupId>
         <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-        <version>2.2.2</version>
+        <version>LATEST</version>
     </dependency>
 </dependencies>
 ```

--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
@@ -12,10 +12,15 @@ The following properties are required for the AWS Secrets Manager Connection Plu
 
 > **Note:** To use this plugin, you will need to set the following AWS Secrets Manager specific parameters.
 
-| Parameter                | Value  |                                                                                     Required                                                                                      | Description                                             | Example     | Default Value |
-|--------------------------|:------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------|:------------|---------------|
-| `secretsManagerSecretId` | String |                                                                                        Yes                                                                                        | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
-| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN. A Secret ARN has the following format: `arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters` | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
+| Parameter                | Value  |                         Required                         | Description                                             | Example     | Default Value |
+|--------------------------|:------:|:--------------------------------------------------------:|:--------------------------------------------------------|:------------|---------------|
+| `secretsManagerSecretId` | String |                           Yes                            | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
+| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN. | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
+
+*NOTE* A Secret ARN has the following format: `arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters`
+
+## Secret Data
+The plugin assumes that the secret contains the following properties `username` and `password`
 
 ### Example
 [AwsSecretsManagerConnectionPluginPostgresqlExample.java](../../../examples/AWSDriverExample/src/main/java/software/amazon/AwsSecretsManagerConnectionPluginPostgresqlExample.java)

--- a/examples/AWSDriverExample/src/main/java/software/amazon/AwsSecretsManagerConnectionPluginPostgresqlExample.java
+++ b/examples/AWSDriverExample/src/main/java/software/amazon/AwsSecretsManagerConnectionPluginPostgresqlExample.java
@@ -22,7 +22,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
-import software.amazon.jdbc.PropertyDefinition;
+
+import static software.amazon.jdbc.PropertyDefinition.PLUGINS;
+import static software.amazon.jdbc.plugin.AwsSecretsManagerConnectionPlugin.REGION_PROPERTY;
+import static software.amazon.jdbc.plugin.AwsSecretsManagerConnectionPlugin.SECRET_ID_PROPERTY;
 
 public class AwsSecretsManagerConnectionPluginPostgresqlExample {
 
@@ -31,11 +34,11 @@ public class AwsSecretsManagerConnectionPluginPostgresqlExample {
   public static void main(String[] args) throws SQLException {
     // Set the AWS Secrets Manager Connection Plugin parameters and the JDBC Wrapper parameters.
     final Properties properties = new Properties();
-    properties.setProperty("secretsManagerRegion", "us-east-2");
-    properties.setProperty("secretsManagerSecretId", "secretId");
+    REGION_PROPERTY.set(properties, "us-east-2");
+    SECRET_ID_PROPERTY.set(properties, "secretId");
 
     // Enable the AWS Secrets Manager Connection Plugin.
-    properties.setProperty(PropertyDefinition.PLUGINS.name, "awsSecretsManager");
+    PLUGINS.set(properties, "awsSecretsManager");
 
     // Try and make a connection:
     try (final Connection conn = DriverManager.getConnection(CONNECTION_STRING, properties);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPlugin.java
@@ -59,10 +59,10 @@ public class AwsSecretsManagerConnectionPlugin extends AbstractConnectionPlugin 
         }
       });
 
-  protected static final AwsWrapperProperty SECRET_ID_PROPERTY = new AwsWrapperProperty(
+  public static final AwsWrapperProperty SECRET_ID_PROPERTY = new AwsWrapperProperty(
       "secretsManagerSecretId", null,
       "The name or the ARN of the secret to retrieve.");
-  protected static final AwsWrapperProperty REGION_PROPERTY = new AwsWrapperProperty(
+  public static final AwsWrapperProperty REGION_PROPERTY = new AwsWrapperProperty(
       "secretsManagerRegion", "us-east-1",
       "The region of the secret to retrieve.");
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorServiceImpl.java
@@ -37,7 +37,7 @@ public class MonitorServiceImpl implements MonitorService {
 
   private static final Logger LOGGER = Logger.getLogger(MonitorServiceImpl.class.getName());
 
-  protected static final AwsWrapperProperty MONITOR_DISPOSAL_TIME_MS =
+  public static final AwsWrapperProperty MONITOR_DISPOSAL_TIME_MS =
       new AwsWrapperProperty(
           "monitorDisposalTime",
           "60000",

--- a/wrapper/src/test/java/integration/container/tests/AdvancedPerformanceTest.java
+++ b/wrapper/src/test/java/integration/container/tests/AdvancedPerformanceTest.java
@@ -18,6 +18,11 @@ package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static software.amazon.jdbc.PropertyDefinition.PLUGINS;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_COUNT;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_INTERVAL;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_TIME;
+import static software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin.FAILOVER_TIMEOUT_MS;
 
 import integration.DriverHelper;
 import integration.TestEnvironmentFeatures;
@@ -77,7 +82,7 @@ public class AdvancedPerformanceTest {
 
   private static final int TIMEOUT_SEC = 5;
   private static final int CONNECT_TIMEOUT_SEC = 5;
-  private static final int FAILOVER_TIMEOUT_MS = 300000;
+  private static final int EFM_FAILOVER_TIMEOUT_MS = 300000;
   private static final int EFM_FAILURE_DETECTION_TIME_MS = 30000;
   private static final int EFM_FAILURE_DETECTION_INTERVAL_MS = 5000;
   private static final int EFM_FAILURE_DETECTION_COUNT = 3;
@@ -377,13 +382,10 @@ public class AdvancedPerformanceTest {
             DriverHelper.setMonitoringConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
             DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
             DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
-            props.setProperty(
-                "failureDetectionTime", Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
-            props.setProperty(
-                "failureDetectionInterval", Integer.toString(EFM_FAILURE_DETECTION_INTERVAL_MS));
-            props.setProperty(
-                "failureDetectionCount", Integer.toString(EFM_FAILURE_DETECTION_COUNT));
-            props.setProperty("wrapperPlugins", "efm");
+            FAILURE_DETECTION_TIME.set(props, Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
+            FAILURE_DETECTION_INTERVAL.set(props, Integer.toString(EFM_FAILURE_DETECTION_INTERVAL_MS));
+            FAILURE_DETECTION_COUNT.set(props, Integer.toString(EFM_FAILURE_DETECTION_COUNT));
+            PLUGINS.set(props, "efm");
 
             final Connection conn =
                 openConnectionWithRetry(
@@ -455,14 +457,11 @@ public class AdvancedPerformanceTest {
             DriverHelper.setMonitoringConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
             DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
             DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
-            props.setProperty(
-                "failureDetectionTime", Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
-            props.setProperty(
-                "failureDetectionInterval", Integer.toString(EFM_FAILURE_DETECTION_INTERVAL_MS));
-            props.setProperty(
-                "failureDetectionCount", Integer.toString(EFM_FAILURE_DETECTION_COUNT));
-            props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
-            props.setProperty("wrapperPlugins", "failover,efm");
+            FAILURE_DETECTION_TIME.set(props, Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
+            FAILURE_DETECTION_INTERVAL.set(props, Integer.toString(EFM_FAILURE_DETECTION_TIME_MS));
+            FAILURE_DETECTION_COUNT.set(props, Integer.toString(EFM_FAILURE_DETECTION_COUNT));
+            FAILOVER_TIMEOUT_MS.set(props, Integer.toString(EFM_FAILOVER_TIMEOUT_MS));
+            PLUGINS.set(props, "failover,efm");
 
             final Connection conn =
                 openConnectionWithRetry(

--- a/wrapper/src/test/java/integration/container/tests/HikariTests.java
+++ b/wrapper/src/test/java/integration/container/tests/HikariTests.java
@@ -19,6 +19,8 @@ package integration.container.tests;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static software.amazon.jdbc.PropertyDefinition.PLUGINS;
+import static software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin.FAILOVER_TIMEOUT_MS;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -81,7 +83,7 @@ public class HikariTests {
     dataSource.setJdbcUrl(url);
     dataSource.setUsername(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
     dataSource.setPassword(TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
-    dataSource.addDataSourceProperty(PropertyDefinition.PLUGINS.name, "");
+    dataSource.addDataSourceProperty(PLUGINS.name, "");
 
     final Connection conn = dataSource.getConnection();
 
@@ -124,7 +126,7 @@ public class HikariTests {
 
     // Configuring driver-specific DataSource:
     final Properties targetDataSourceProps = new Properties();
-    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "");
+    targetDataSourceProps.setProperty(PLUGINS.name, "");
 
     if (TestEnvironment.getCurrent().getCurrentDriver() == TestDriver.MARIADB
         && TestEnvironment.getCurrent().getInfo().getRequest().getDatabaseEngine()
@@ -158,8 +160,8 @@ public class HikariTests {
   @EnableOnNumOfInstances(min = 3)
   public void testFailoverLostConnection() throws SQLException {
     final Properties customProps = new Properties();
-    customProps.setProperty(PropertyDefinition.PLUGINS.name, "failover");
-    customProps.setProperty("failoverTimeoutMs", Integer.toString(1));
+    PLUGINS.set(customProps, "failover");
+    FAILOVER_TIMEOUT_MS.set(customProps, Integer.toString(1));
     DriverHelper.setSocketTimeout(customProps, 1, TimeUnit.SECONDS);
 
     final HikariDataSource dataSource = createDataSource(customProps);
@@ -278,7 +280,7 @@ public class HikariTests {
 
     final Properties targetDataSourceProps = new Properties();
 
-    targetDataSourceProps.setProperty(PropertyDefinition.PLUGINS.name, "failover,efm");
+    targetDataSourceProps.setProperty(PLUGINS.name, "failover,efm");
     targetDataSourceProps.setProperty(
         "clusterInstanceHostPattern",
         "?."

--- a/wrapper/src/test/java/integration/container/tests/PerformanceTest.java
+++ b/wrapper/src/test/java/integration/container/tests/PerformanceTest.java
@@ -17,6 +17,11 @@
 package integration.container.tests;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static software.amazon.jdbc.PropertyDefinition.PLUGINS;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_COUNT;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_INTERVAL;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_TIME;
+import static software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin.FAILOVER_TIMEOUT_MS;
 
 import integration.DriverHelper;
 import integration.TestEnvironmentFeatures;
@@ -69,7 +74,7 @@ public class PerformanceTest {
 
   private static final int TIMEOUT_SEC = 1;
   private static final int CONNECT_TIMEOUT_SEC = 3;
-  private static final int FAILOVER_TIMEOUT_MS = 120000;
+  private static final int PERF_FAILOVER_TIMEOUT_MS = 120000;
 
   private static final List<PerfStatMonitoring> enhancedFailureMonitoringPerfDataList =
       new ArrayList<>();
@@ -152,10 +157,10 @@ public class PerformanceTest {
     DriverHelper.setMonitoringSocketTimeout(props, TIMEOUT_SEC, TimeUnit.SECONDS);
     DriverHelper.setConnectTimeout(props, CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS);
     // this performance test measures efm failure detection time after disconnecting the network
-    props.setProperty("failureDetectionTime", Integer.toString(detectionTime));
-    props.setProperty("failureDetectionInterval", Integer.toString(detectionInterval));
-    props.setProperty("failureDetectionCount", Integer.toString(detectionCount));
-    props.setProperty("wrapperPlugins", "efm");
+    FAILURE_DETECTION_TIME.set(props, Integer.toString(detectionTime));
+    FAILURE_DETECTION_INTERVAL.set(props, Integer.toString(detectionInterval));
+    FAILURE_DETECTION_COUNT.set(props, Integer.toString(detectionCount));
+    PLUGINS.set(props, "efm");
 
     final PerfStatMonitoring data = new PerfStatMonitoring();
     doMeasurePerformance(sleepDelayMillis, REPEAT_TIMES, props, false, data);
@@ -207,11 +212,11 @@ public class PerformanceTest {
 
     // this performance test measures failover and efm failure detection time after disconnecting
     // the network
-    props.setProperty("failureDetectionTime", Integer.toString(detectionTime));
-    props.setProperty("failureDetectionInterval", Integer.toString(detectionInterval));
-    props.setProperty("failureDetectionCount", Integer.toString(detectionCount));
-    props.setProperty("wrapperPlugins", "failover,efm");
-    props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
+    FAILURE_DETECTION_TIME.set(props, Integer.toString(detectionTime));
+    FAILURE_DETECTION_INTERVAL.set(props, Integer.toString(detectionInterval));
+    FAILURE_DETECTION_COUNT.set(props, Integer.toString(detectionCount));
+    PLUGINS.set(props, "failover,efm");
+    FAILOVER_TIMEOUT_MS.set(props, Integer.toString(PERF_FAILOVER_TIMEOUT_MS));
     props.setProperty(
         "clusterInstanceHostPattern",
         "?."
@@ -273,7 +278,7 @@ public class PerformanceTest {
                 .getInfo()
                 .getProxyDatabaseInfo()
                 .getInstanceEndpointSuffix());
-    props.setProperty("failoverTimeoutMs", Integer.toString(FAILOVER_TIMEOUT_MS));
+    props.setProperty("failoverTimeoutMs", Integer.toString(PERF_FAILOVER_TIMEOUT_MS));
 
     final PerfStatSocketTimeout data = new PerfStatSocketTimeout();
     doMeasurePerformance(sleepDelayMillis, REPEAT_TIMES, props, true, data);

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/AwsSecretsManagerConnectionPluginTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.jdbc.plugin.AwsSecretsManagerConnectionPlugin.REGION_PROPERTY;
+import static software.amazon.jdbc.plugin.AwsSecretsManagerConnectionPlugin.SECRET_ID_PROPERTY;
 
 import com.mysql.cj.exceptions.CJException;
 import java.sql.Connection;
@@ -104,8 +106,8 @@ public class AwsSecretsManagerConnectionPluginTest {
   public void init() throws SQLException {
     closeable = MockitoAnnotations.openMocks(this);
 
-    TEST_PROPS.setProperty("secretsManagerRegion", TEST_REGION);
-    TEST_PROPS.setProperty("secretsManagerSecretId", TEST_SECRET_ID);
+    REGION_PROPERTY.set(TEST_PROPS, TEST_REGION);
+    SECRET_ID_PROPERTY.set(TEST_PROPS, TEST_SECRET_ID);
 
     this.plugin = new AwsSecretsManagerConnectionPlugin(
         mockService,
@@ -420,7 +422,8 @@ public class AwsSecretsManagerConnectionPluginTest {
   public void testConnectViaARN(final String arn, final Region expectedRegionParsedFromARN)
       throws SQLException {
     final Properties props = new Properties();
-    props.setProperty("secretsManagerSecretId", arn);
+
+    SECRET_ID_PROPERTY.set(props, arn);
 
     this.plugin = spy(new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, props, "url", TEST_PG_PROTOCOL),
@@ -439,8 +442,8 @@ public class AwsSecretsManagerConnectionPluginTest {
     final Region expectedRegion = Region.US_ISO_EAST_1;
 
     final Properties props = new Properties();
-    props.setProperty("secretsManagerSecretId", arn);
-    props.setProperty("secretsManagerRegion", expectedRegion.toString());
+    SECRET_ID_PROPERTY.set(props, arn);
+    REGION_PROPERTY.set(props, expectedRegion.toString());
 
     this.plugin = spy(new AwsSecretsManagerConnectionPlugin(
         new PluginServiceImpl(mockConnectionPluginManager, props, "url", TEST_PG_PROTOCOL),
@@ -473,10 +476,10 @@ public class AwsSecretsManagerConnectionPluginTest {
 
   private static Stream<Arguments> missingArguments() {
     final Properties missingId = new Properties();
-    missingId.setProperty("secretsManagerRegion", TEST_REGION);
+    REGION_PROPERTY.set(missingId, TEST_REGION);
 
     final Properties missingRegion = new Properties();
-    missingRegion.setProperty("secretsManagerSecretId", TEST_SECRET_ID);
+    SECRET_ID_PROPERTY.set(missingRegion, TEST_SECRET_ID);
 
     return Stream.of(
         Arguments.of(missingId),

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -16,6 +16,11 @@
 
 package software.amazon.jdbc.plugin.efm;
 
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_COUNT;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_INTERVAL;
+import static software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin.FAILURE_DETECTION_TIME;
+import static software.amazon.jdbc.plugin.efm.MonitorServiceImpl.MONITOR_DISPOSAL_TIME_MS;
+
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -107,10 +112,10 @@ public class ConcurrencyTests {
       executor.submit(() -> {
 
         final Properties properties = new Properties();
-        properties.put("monitorDisposalTime", "30000");
-        properties.put("failureDetectionTime", "10000");
-        properties.put("failureDetectionInterval", "1000");
-        properties.put("failureDetectionCount", "1");
+        MONITOR_DISPOSAL_TIME_MS.set(properties, "30000");
+        FAILURE_DETECTION_TIME.set(properties, "10000");
+        FAILURE_DETECTION_INTERVAL.set(properties, "1000");
+        FAILURE_DETECTION_COUNT.set(properties, "1");
 
         final JdbcCallable<ResultSet, SQLException> sqlFunction = () -> {
           try {
@@ -193,10 +198,10 @@ public class ConcurrencyTests {
     hostSpec.addAlias("test-host-alias-b");
 
     final Properties properties = new Properties();
-    properties.put("monitorDisposalTime", "30000");
-    properties.put("failureDetectionTime", "10000");
-    properties.put("failureDetectionInterval", "1000");
-    properties.put("failureDetectionCount", "1");
+    MONITOR_DISPOSAL_TIME_MS.set(properties, "30000");
+    FAILURE_DETECTION_TIME.set(properties, "10000");
+    FAILURE_DETECTION_INTERVAL.set(properties, "1000");
+    FAILURE_DETECTION_COUNT.set(properties, "1");
 
     final JdbcCallable<ResultSet, SQLException> sqlFunction = () -> {
       try {


### PR DESCRIPTION
This makes it easier to find where configuration parameters are used

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.