### PR TITLE
sort plugins by default

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginChainBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginChainBuilder.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.jdbc.plugin.AuroraConnectionTrackerPluginFactory;
+import software.amazon.jdbc.plugin.AuroraHostListConnectionPluginFactory;
+import software.amazon.jdbc.plugin.AwsSecretsManagerConnectionPluginFactory;
+import software.amazon.jdbc.plugin.ConnectTimeConnectionPluginFactory;
+import software.amazon.jdbc.plugin.DataCacheConnectionPluginFactory;
+import software.amazon.jdbc.plugin.DefaultConnectionPlugin;
+import software.amazon.jdbc.plugin.DriverMetaDataConnectionPluginFactory;
+import software.amazon.jdbc.plugin.ExecutionTimeConnectionPluginFactory;
+import software.amazon.jdbc.plugin.IamAuthConnectionPluginFactory;
+import software.amazon.jdbc.plugin.LogQueryConnectionPluginFactory;
+import software.amazon.jdbc.plugin.dev.DeveloperConnectionPluginFactory;
+import software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPluginFactory;
+import software.amazon.jdbc.plugin.failover.FailoverConnectionPluginFactory;
+import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingPluginFactory;
+import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsPluginFactory;
+import software.amazon.jdbc.profile.DriverConfigurationProfiles;
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.SqlState;
+import software.amazon.jdbc.util.StringUtils;
+import software.amazon.jdbc.util.WrapperUtils;
+
+public class ConnectionPluginChainBuilder {
+
+  private static final Logger LOGGER = Logger.getLogger(ConnectionPluginChainBuilder.class.getName());
+
+  private static final int STICK_TO_PRIOR_PLUGIN = -1;
+
+  protected static final Map<String, Class<? extends ConnectionPluginFactory>> pluginFactoriesByCode =
+      new HashMap<String, Class<? extends ConnectionPluginFactory>>() {
+        {
+          put("executionTime", ExecutionTimeConnectionPluginFactory.class);
+          put("auroraHostList", AuroraHostListConnectionPluginFactory.class);
+          put("logQuery", LogQueryConnectionPluginFactory.class);
+          put("dataCache", DataCacheConnectionPluginFactory.class);
+          put("efm", HostMonitoringConnectionPluginFactory.class);
+          put("failover", FailoverConnectionPluginFactory.class);
+          put("iam", IamAuthConnectionPluginFactory.class);
+          put("awsSecretsManager", AwsSecretsManagerConnectionPluginFactory.class);
+          put("auroraStaleDns", AuroraStaleDnsPluginFactory.class);
+          put("readWriteSplitting", ReadWriteSplittingPluginFactory.class);
+          put("auroraConnectionTracker", AuroraConnectionTrackerPluginFactory.class);
+          put("driverMetaData", DriverMetaDataConnectionPluginFactory.class);
+          put("connectTime", ConnectTimeConnectionPluginFactory.class);
+          put("dev", DeveloperConnectionPluginFactory.class);
+        }
+      };
+
+  /**
+   * Plugins are sorted by assigned weight ascending.
+   * The first plugin in the final sorted list has a minimal weight.
+   */
+  protected static final Map<Class<? extends ConnectionPluginFactory>, Integer> pluginWeightByPluginFactory =
+      new HashMap<Class<? extends ConnectionPluginFactory>, Integer>() {
+        {
+          put(DriverMetaDataConnectionPluginFactory.class, 100);
+          put(DataCacheConnectionPluginFactory.class, 200);
+          put(AuroraHostListConnectionPluginFactory.class, 300);
+          put(AuroraConnectionTrackerPluginFactory.class, 400);
+          put(AuroraStaleDnsPluginFactory.class, 500);
+          put(ReadWriteSplittingPluginFactory.class, 600);
+          put(FailoverConnectionPluginFactory.class, 700);
+          put(HostMonitoringConnectionPluginFactory.class, 800);
+          put(IamAuthConnectionPluginFactory.class, 900);
+          put(AwsSecretsManagerConnectionPluginFactory.class, 1000);
+          put(LogQueryConnectionPluginFactory.class, 1100);
+          put(ConnectTimeConnectionPluginFactory.class, STICK_TO_PRIOR_PLUGIN);
+          put(ExecutionTimeConnectionPluginFactory.class, STICK_TO_PRIOR_PLUGIN);
+          put(DeveloperConnectionPluginFactory.class, STICK_TO_PRIOR_PLUGIN);
+        }
+      };
+
+  protected static final String DEFAULT_PLUGINS = "auroraConnectionTracker,failover,efm";
+
+  private static class PluginFactoryInfo {
+    public Class<? extends ConnectionPluginFactory> factory;
+    public int weight;
+
+    public PluginFactoryInfo(final Class<? extends ConnectionPluginFactory> factory, final int weight) {
+      this.factory = factory;
+      this.weight = weight;
+    }
+  }
+
+  public List<ConnectionPlugin> getPlugins(
+      final PluginService pluginService,
+      final ConnectionProvider defaultConnProvider,
+      final PluginManagerService pluginManagerService,
+      final Properties props)
+      throws SQLException {
+
+    List<ConnectionPlugin> plugins;
+    List<Class<? extends ConnectionPluginFactory>> pluginFactories;
+
+    final String profileName = PropertyDefinition.PROFILE_NAME.getString(props);
+
+    if (profileName != null) {
+
+      if (!DriverConfigurationProfiles.contains(profileName)) {
+        throw new SQLException(
+            Messages.get(
+                "ConnectionPluginManager.configurationProfileNotFound",
+                new Object[] {profileName}));
+      }
+      pluginFactories = DriverConfigurationProfiles.getPluginFactories(profileName);
+
+    } else {
+
+      String pluginCodes = PropertyDefinition.PLUGINS.getString(props);
+
+      if (pluginCodes == null) {
+        pluginCodes = DEFAULT_PLUGINS;
+      }
+
+      final List<String> pluginCodeList = StringUtils.split(pluginCodes, ",", true);
+      pluginFactories = new ArrayList<>(pluginCodeList.size());
+
+      for (final String pluginCode : pluginCodeList) {
+        if (!pluginFactoriesByCode.containsKey(pluginCode)) {
+          throw new SQLException(
+              Messages.get(
+                  "ConnectionPluginManager.unknownPluginCode",
+                  new Object[] {pluginCode}));
+        }
+        pluginFactories.add(pluginFactoriesByCode.get(pluginCode));
+      }
+    }
+
+    if (!pluginFactories.isEmpty()) {
+
+      if (!PropertyDefinition.PRESERVE_PLUGINS_ORDER.getBoolean(props)) {
+        pluginFactories = this.sortPluginFactories(pluginFactories);
+
+        final List<Class<? extends ConnectionPluginFactory>> tempPluginFactories = pluginFactories;
+        LOGGER.finest(() ->
+            "Plugins order has been rearranged. The following order is in effect: "
+                + tempPluginFactories.stream()
+                  .map(Class::getSimpleName)
+                  .collect(Collectors.joining(", ")));
+      }
+
+      try {
+        final ConnectionPluginFactory[] factories =
+            WrapperUtils.loadClasses(
+                    pluginFactories,
+                    ConnectionPluginFactory.class,
+                    "ConnectionPluginManager.unableToLoadPlugin")
+                .toArray(new ConnectionPluginFactory[0]);
+
+        // make a chain of connection plugins
+
+        plugins = new ArrayList<>(factories.length + 1);
+
+        for (final ConnectionPluginFactory factory : factories) {
+          plugins.add(factory.getInstance(pluginService, props));
+        }
+
+      } catch (final InstantiationException instEx) {
+        throw new SQLException(instEx.getMessage(), SqlState.UNKNOWN_STATE.getState(), instEx);
+      }
+    } else {
+      plugins = new ArrayList<>(1); // one spot for default connection plugin
+    }
+
+    // add default connection plugin to the tail
+    final ConnectionPlugin defaultPlugin =
+        new DefaultConnectionPlugin(pluginService, defaultConnProvider, pluginManagerService);
+    plugins.add(defaultPlugin);
+
+    return plugins;
+  }
+
+  protected List<Class<? extends ConnectionPluginFactory>> sortPluginFactories(
+      final List<Class<? extends ConnectionPluginFactory>> unsortedPluginFactories) {
+
+    ArrayList<PluginFactoryInfo> weights = new ArrayList<>();
+    for (Class<? extends ConnectionPluginFactory> pluginFactory : unsortedPluginFactories) {
+      Integer pluginFactoryWeight = pluginWeightByPluginFactory.get(pluginFactory);
+      if (pluginFactoryWeight == null) {
+        // This plugin factory is unknown. It might be a user custom plugin factory.
+        // Let's keep this plugin factory original position.
+        pluginFactoryWeight = STICK_TO_PRIOR_PLUGIN;
+      }
+      weights.add(new PluginFactoryInfo(pluginFactory, pluginFactoryWeight));
+    }
+
+    // Determine weights for plugin factories with STICK_TO_PRIOR_PLUGIN
+    int lastWeight = 0;
+    for (PluginFactoryInfo info : weights) {
+      if (info.weight != STICK_TO_PRIOR_PLUGIN) {
+        lastWeight = info.weight;
+        continue;
+      }
+      lastWeight++;
+      info.weight = lastWeight;
+    }
+
+    return weights.stream()
+        .sorted(Comparator.comparingInt(o -> o.weight))
+        .map((info) -> info.factory)
+        .collect(Collectors.toList());
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
@@ -48,6 +48,12 @@ public class PropertyDefinition {
       new AwsWrapperProperty(
           "wrapperPlugins", null, "Comma separated list of connection plugin codes");
 
+  public static final AwsWrapperProperty PRESERVE_PLUGINS_ORDER =
+      new AwsWrapperProperty(
+          "preserveWrapperPluginsOrder",
+          "false",
+          "Allows to preserve plugin order provided by user.");
+
   public static final AwsWrapperProperty PROFILE_NAME =
       new AwsWrapperProperty(
           "wrapperProfileName", null, "Driver configuration profile name");

--- a/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PropertyDefinition.java
@@ -48,11 +48,12 @@ public class PropertyDefinition {
       new AwsWrapperProperty(
           "wrapperPlugins", null, "Comma separated list of connection plugin codes");
 
-  public static final AwsWrapperProperty PRESERVE_PLUGINS_ORDER =
+  public static final AwsWrapperProperty AUTO_SORT_PLUGIN_ORDER =
       new AwsWrapperProperty(
-          "preserveWrapperPluginsOrder",
-          "false",
-          "Allows to preserve plugin order provided by user.");
+          "autoSortWrapperPluginOrder",
+          "true",
+          "This flag is enabled by default, meaning that the plugins order will be automatically adjusted."
+          + " Disable it at your own risk or if you really need plugins to be executed in a particular order.");
 
   public static final AwsWrapperProperty PROFILE_NAME =
       new AwsWrapperProperty(

--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginChainBuilderTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginChainBuilderTests.java
@@ -76,7 +76,7 @@ public class ConnectionPluginChainBuilderTests {
     ConnectionPluginChainBuilder builder = new ConnectionPluginChainBuilder();
     Properties props = new Properties();
     props.put(PropertyDefinition.PLUGINS.name, "iam,efm,failover");
-    props.put(PropertyDefinition.PRESERVE_PLUGINS_ORDER.name, "true");
+    props.put(PropertyDefinition.AUTO_SORT_PLUGIN_ORDER.name, "false");
 
     List<ConnectionPlugin> result =
         builder.getPlugins(mockPluginService, mockConnectionProvider, mockPluginManagerService, props);

--- a/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginChainBuilderTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/ConnectionPluginChainBuilderTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.plugin.ConnectTimeConnectionPlugin;
+import software.amazon.jdbc.plugin.DefaultConnectionPlugin;
+import software.amazon.jdbc.plugin.ExecutionTimeConnectionPlugin;
+import software.amazon.jdbc.plugin.IamAuthConnectionPlugin;
+import software.amazon.jdbc.plugin.dev.DeveloperConnectionPlugin;
+import software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin;
+import software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin;
+
+public class ConnectionPluginChainBuilderTests {
+
+  @Mock ConnectionProvider mockConnectionProvider;
+  @Mock PluginService mockPluginService;
+  @Mock PluginManagerService mockPluginManagerService;
+
+  private AutoCloseable closeable;
+
+  @AfterEach
+  void afterEach() throws Exception {
+    closeable.close();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    closeable = MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testSortPlugins() throws SQLException {
+    ConnectionPluginChainBuilder builder = new ConnectionPluginChainBuilder();
+    Properties props = new Properties();
+    props.put(PropertyDefinition.PLUGINS.name, "iam,efm,failover");
+
+    List<ConnectionPlugin> result =
+        builder.getPlugins(mockPluginService, mockConnectionProvider, mockPluginManagerService, props);
+
+    assertNotNull(result);
+    assertEquals(4, result.size());
+    assertTrue(result.get(0) instanceof FailoverConnectionPlugin);
+    assertTrue(result.get(1) instanceof HostMonitoringConnectionPlugin);
+    assertTrue(result.get(2) instanceof IamAuthConnectionPlugin);
+    assertTrue(result.get(3) instanceof DefaultConnectionPlugin);
+  }
+
+  @Test
+  public void testPreservePluginOrder() throws SQLException {
+    ConnectionPluginChainBuilder builder = new ConnectionPluginChainBuilder();
+    Properties props = new Properties();
+    props.put(PropertyDefinition.PLUGINS.name, "iam,efm,failover");
+    props.put(PropertyDefinition.PRESERVE_PLUGINS_ORDER.name, "true");
+
+    List<ConnectionPlugin> result =
+        builder.getPlugins(mockPluginService, mockConnectionProvider, mockPluginManagerService, props);
+
+    assertNotNull(result);
+    assertEquals(4, result.size());
+    assertTrue(result.get(0) instanceof IamAuthConnectionPlugin);
+    assertTrue(result.get(1) instanceof HostMonitoringConnectionPlugin);
+    assertTrue(result.get(2) instanceof FailoverConnectionPlugin);
+    assertTrue(result.get(3) instanceof DefaultConnectionPlugin);
+  }
+
+  @Test
+  public void testSortPluginsWithStickToPrior() throws SQLException {
+    ConnectionPluginChainBuilder builder = new ConnectionPluginChainBuilder();
+    Properties props = new Properties();
+    props.put(PropertyDefinition.PLUGINS.name, "dev,iam,executionTime,connectTime,efm,failover");
+
+    List<ConnectionPlugin> result =
+        builder.getPlugins(mockPluginService, mockConnectionProvider, mockPluginManagerService, props);
+
+    assertNotNull(result);
+    assertEquals(7, result.size());
+    assertTrue(result.get(0) instanceof DeveloperConnectionPlugin);
+    assertTrue(result.get(1) instanceof FailoverConnectionPlugin);
+    assertTrue(result.get(2) instanceof HostMonitoringConnectionPlugin);
+    assertTrue(result.get(3) instanceof IamAuthConnectionPlugin);
+    assertTrue(result.get(4) instanceof ExecutionTimeConnectionPlugin);
+    assertTrue(result.get(5) instanceof ConnectTimeConnectionPlugin);
+    assertTrue(result.get(6) instanceof DefaultConnectionPlugin);
+  }
+}


### PR DESCRIPTION
### Summary

Sort plugins by default to prevent plugin misconfiguration. Allows a user to provide a custom plugin order if needed.

### Description

Plugin chain initialization has been separated to `ConnectionPluginChainBuilder `class. Depending on user settings, a plugin factory list is sorted based on plugin assigned weights. 

### Additional Reviewers

@karenc-bq @aaron-congo @aaronchung-bitquill @crystall-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.