### PR TITLE
chore: update error message for when target drivers are not found

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -97,20 +97,19 @@ public class Driver implements java.sql.Driver {
 
     final String driverUrl = url.replaceFirst(PROTOCOL_PREFIX, "jdbc:");
 
-    final String message = Messages.get(
-        "Driver.missingDriver",
-        new Object[] {driverUrl, Collections.list(DriverManager.getDrivers())});
-
     java.sql.Driver driver;
     try {
       driver = DriverManager.getDriver(driverUrl);
     } catch (SQLException e) {
-      LOGGER.warning(() -> message);
-      throw new SQLException(message, e);
+      throw new SQLException(Messages.get(
+          "Driver.missingDriver",
+          new Object[] {driverUrl, Collections.list(DriverManager.getDrivers())}), e);
     }
 
     if (driver == null) {
-      LOGGER.warning(() -> message);
+      LOGGER.severe(() -> Messages.get(
+          "Driver.missingDriver",
+          new Object[] {driverUrl, Collections.list(DriverManager.getDrivers())}));
       return null;
     }
     final String databaseName = ConnectionUrlParser.parseDatabaseFromUrl(url);

--- a/wrapper/src/main/java/software/amazon/jdbc/Driver.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/Driver.java
@@ -96,10 +96,21 @@ public class Driver implements java.sql.Driver {
     LOGGER.finest("Opening connection to " + url);
 
     final String driverUrl = url.replaceFirst(PROTOCOL_PREFIX, "jdbc:");
-    final java.sql.Driver driver = DriverManager.getDriver(driverUrl);
+
+    final String message = Messages.get(
+        "Driver.missingDriver",
+        new Object[] {driverUrl, Collections.list(DriverManager.getDrivers())});
+
+    java.sql.Driver driver;
+    try {
+      driver = DriverManager.getDriver(driverUrl);
+    } catch (SQLException e) {
+      LOGGER.warning(() -> message);
+      throw new SQLException(message, e);
+    }
 
     if (driver == null) {
-      LOGGER.warning(() -> Messages.get("Driver.missingDriver", new Object[] {driverUrl}));
+      LOGGER.warning(() -> message);
       return null;
     }
     final String databaseName = ConnectionUrlParser.parseDatabaseFromUrl(url);

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -120,7 +120,7 @@ DefaultConnectionPlugin.unknownRoleRequested=A HostSpec with a role of HostRole.
 # Driver
 Driver.nullUrl=Url is null.
 Driver.alreadyRegistered=Driver is already registered. It can only be registered once.
-Driver.missingDriver=Can''t find the target driver for ''{0}''. Please ensure the target driver is on the classpath. Here is the list of registered drivers on the classpath: [{1}]
+Driver.missingDriver=Can''t find the target driver for ''{0}''. Please ensure the target driver is in the classpath. Here is the list of registered drivers in the classpath: {1}
 Driver.notRegistered=Driver is not registered (or it has not been registered using Driver.register() method).
 Driver.urlParsingFailed=Url [{0}] parsing failed with error: [{1}]
 

--- a/wrapper/src/main/resources/messages.properties
+++ b/wrapper/src/main/resources/messages.properties
@@ -120,7 +120,7 @@ DefaultConnectionPlugin.unknownRoleRequested=A HostSpec with a role of HostRole.
 # Driver
 Driver.nullUrl=Url is null.
 Driver.alreadyRegistered=Driver is already registered. It can only be registered once.
-Driver.missingDriver=Can''t find a suitable driver for ''{0}''.
+Driver.missingDriver=Can''t find the target driver for ''{0}''. Please ensure the target driver is on the classpath. Here is the list of registered drivers on the classpath: [{1}]
 Driver.notRegistered=Driver is not registered (or it has not been registered using Driver.register() method).
 Driver.urlParsingFailed=Url [{0}] parsing failed with error: [{1}]
 


### PR DESCRIPTION
### Summary

Update the error message so the stacktrace provides more information when DriverManger throws an exception regarding no suitable drivers.

New message:
```
Exception in thread "main" java.sql.SQLException: Can't find the target driver for 'jdbc:postgresql://database-pg.cluster-xyz.us-east-2.rds.amazonaws.com/postgres'. Please ensure the target driver is on the classpath. Here is the list of registered drivers on the classpath: [[software.amazon.jdbc.Driver@736e9adb, com.mysql.cj.jdbc.Driver@deb6432]]
	at software.amazon.jdbc.Driver.connect(Driver.java:108)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:681)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:190)
	at software.amazon.PGSimple.main(PGSimple.java:40)
Caused by: java.sql.SQLException: No suitable driver
	at java.sql/java.sql.DriverManager.getDriver(DriverManager.java:299)
	at software.amazon.jdbc.Driver.connect(Driver.java:105)
	... 3 more
```

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.