### PR TITLE
Upgrade org.springframework.boot:spring-boot-starter-jdbc from 2.7.+ to 3.1.1

### DIFF
--- a/examples/AWSDriverExample/build.gradle.kts
+++ b/examples/AWSDriverExample/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.+")
+    implementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
     implementation("org.postgresql:postgresql:42.5.4")
     implementation("mysql:mysql-connector-java:8.0.31")
     implementation("software.amazon.awssdk:rds:2.20.49")

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     testImplementation("mysql:mysql-connector-java:8.0.31")
     testImplementation("org.mariadb.jdbc:mariadb-java-client:3.1.4")
     testImplementation("com.zaxxer:HikariCP:4.0.3") // Version 4.+ is compatible with Java 8
-    testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.4")
+    testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
     testImplementation("org.mockito:mockito-inline:4.8.0")
     testImplementation("software.amazon.awssdk:rds:2.20.49")
     testImplementation("software.amazon.awssdk:ec2:2.20.61")

--- a/wrapper/src/test/build.gradle.kts
+++ b/wrapper/src/test/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     testImplementation("mysql:mysql-connector-java:8.0.30")
     testImplementation("org.mariadb.jdbc:mariadb-java-client:3.1.0")
     testImplementation("com.zaxxer:HikariCP:4.+") // version 4.+ is compatible with Java 8
-    testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.+")
+    testImplementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
     testImplementation("org.mockito:mockito-inline:4.8.0")
     testImplementation("software.amazon.awssdk:rds:2.20.49")
     testImplementation("software.amazon.awssdk:ec2:2.20.49")


### PR DESCRIPTION
### Summary

Upgrade org.springframework.boot:spring-boot-starter-jdbc from 2.7.+ to 3.1.1

### Additional Reviewers

@karenc-bq 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.