### PR TITLE
Refactor: Rename class AuroraStaleDns to RdsStaleDns

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -45,7 +45,7 @@ import software.amazon.jdbc.plugin.dev.DeveloperConnectionPluginFactory;
 import software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPluginFactory;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPluginFactory;
 import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingPluginFactory;
-import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsPluginFactory;
+import software.amazon.jdbc.plugin.staledns.RdsStaleDnsPluginFactory;
 import software.amazon.jdbc.profile.DriverConfigurationProfiles;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.SqlMethodAnalyzer;
@@ -73,7 +73,7 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper {
           put("failover", FailoverConnectionPluginFactory.class);
           put("iam", IamAuthConnectionPluginFactory.class);
           put("awsSecretsManager", AwsSecretsManagerConnectionPluginFactory.class);
-          put("auroraStaleDns", AuroraStaleDnsPluginFactory.class);
+          put("auroraStaleDns", RdsStaleDnsPluginFactory.class);
           put("readWriteSplitting", ReadWriteSplittingPluginFactory.class);
           put("auroraConnectionTracker", AuroraConnectionTrackerPluginFactory.class);
           put("driverMetaData", DriverMetaDataConnectionPluginFactory.class);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -43,7 +43,7 @@ import software.amazon.jdbc.PluginService;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.hostlistprovider.AuroraHostListProvider;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
-import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsHelper;
+import software.amazon.jdbc.plugin.staledns.RdsStaleDnsHelper;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.RdsUrlType;
 import software.amazon.jdbc.util.RdsUtils;
@@ -98,7 +98,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
   private boolean isInTransaction = false;
   private RdsUrlType rdsUrlType;
   private HostListProviderService hostListProviderService;
-  private final AuroraStaleDnsHelper staleDnsHelper;
+  private final RdsStaleDnsHelper staleDnsHelper;
 
   public static final AwsWrapperProperty FAILOVER_CLUSTER_TOPOLOGY_REFRESH_RATE_MS =
       new AwsWrapperProperty(
@@ -160,7 +160,7 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
 
     initSettings();
 
-    this.staleDnsHelper = new AuroraStaleDnsHelper(this.pluginService);
+    this.staleDnsHelper = new RdsStaleDnsHelper(this.pluginService);
   }
 
   @Override

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/staledns/RdsStaleDnsHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/staledns/RdsStaleDnsHelper.java
@@ -38,9 +38,9 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.RdsUtils;
 import software.amazon.jdbc.util.Utils;
 
-public class AuroraStaleDnsHelper {
+public class RdsStaleDnsHelper {
 
-  private static final Logger LOGGER = Logger.getLogger(AuroraStaleDnsHelper.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(RdsStaleDnsHelper.class.getName());
 
   private final PluginService pluginService;
   private final RdsUtils rdsUtils = new RdsUtils();
@@ -50,7 +50,7 @@ public class AuroraStaleDnsHelper {
 
   private static final int RETRIES = 3;
 
-  public AuroraStaleDnsHelper(final PluginService pluginService) {
+  public RdsStaleDnsHelper(final PluginService pluginService) {
     this.pluginService = pluginService;
   }
 
@@ -76,7 +76,7 @@ public class AuroraStaleDnsHelper {
     }
 
     final String hostInetAddress = clusterInetAddress;
-    LOGGER.finest(() -> Messages.get("AuroraStaleDnsHelper.clusterEndpointDns",
+    LOGGER.finest(() -> Messages.get("RdsStaleDnsHelper.clusterEndpointDns",
         new Object[]{hostInetAddress}));
 
     if (clusterInetAddress == null) {
@@ -106,7 +106,7 @@ public class AuroraStaleDnsHelper {
       this.writerHostSpec = writerCandidate;
     }
 
-    LOGGER.finest(() -> Messages.get("AuroraStaleDnsHelper.writerHostSpec",
+    LOGGER.finest(() -> Messages.get("RdsStaleDnsHelper.writerHostSpec",
         new Object[]{this.writerHostSpec}));
 
     if (this.writerHostSpec == null) {
@@ -121,7 +121,7 @@ public class AuroraStaleDnsHelper {
       }
     }
 
-    LOGGER.finest(() -> Messages.get("AuroraStaleDnsHelper.writerInetAddress",
+    LOGGER.finest(() -> Messages.get("RdsStaleDnsHelper.writerInetAddress",
         new Object[]{this.writerHostAddress}));
 
     if (this.writerHostAddress == null) {
@@ -132,7 +132,7 @@ public class AuroraStaleDnsHelper {
       // DNS resolves a cluster endpoint to a wrong writer
       // opens a connection to a proper writer node
 
-      LOGGER.fine(() -> Messages.get("AuroraStaleDnsHelper.staleDnsDetected",
+      LOGGER.fine(() -> Messages.get("RdsStaleDnsHelper.staleDnsDetected",
           new Object[]{this.writerHostSpec}));
 
       final Connection writerConn = this.pluginService.connect(this.writerHostSpec, props);
@@ -162,7 +162,7 @@ public class AuroraStaleDnsHelper {
       LOGGER.finest(() -> String.format("[%s]: %s", entry.getKey(), entry.getValue()));
       if (entry.getKey().equals(this.writerHostSpec.getUrl())
           && entry.getValue().contains(NodeChangeOptions.PROMOTED_TO_READER)) {
-        LOGGER.finest(() -> Messages.get("AuroraStaleDnsHelper.reset"));
+        LOGGER.finest(() -> Messages.get("RdsStaleDnsHelper.reset"));
         this.writerHostSpec = null;
         this.writerHostAddress = null;
       }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/staledns/RdsStaleDnsPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/staledns/RdsStaleDnsPlugin.java
@@ -35,7 +35,7 @@ import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.SubscribedMethodHelper;
 
 /**
- * After Aurora DB cluster fail over is completed and a cluster has elected a new writer node, the corresponding
+ * After RDS DB cluster fail over is completed and a cluster has elected a new writer node, the corresponding
  * cluster (writer) endpoint contains stale data and points to an old writer node. That old writer node plays
  * a reader role after fail over and connecting with the cluster endpoint connects to it. In such case a user
  * application expects a writer connection but practically gets connected to a reader. Any DML statements fail
@@ -47,9 +47,9 @@ import software.amazon.jdbc.util.SubscribedMethodHelper;
  * <p>This plugin tries to recognize such a wrong connection to a reader when a writer connection is expected, and to
  * mitigate it by reconnecting a proper new writer.
  */
-public class AuroraStaleDnsPlugin extends AbstractConnectionPlugin {
+public class RdsStaleDnsPlugin extends AbstractConnectionPlugin {
 
-  private static final Logger LOGGER = Logger.getLogger(AuroraStaleDnsPlugin.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(RdsStaleDnsPlugin.class.getName());
 
   private static final Set<String> subscribedMethods =
       Collections.unmodifiableSet(new HashSet<String>() {
@@ -63,12 +63,12 @@ public class AuroraStaleDnsPlugin extends AbstractConnectionPlugin {
       });
 
   private final PluginService pluginService;
-  private final AuroraStaleDnsHelper helper;
+  private final RdsStaleDnsHelper helper;
   private HostListProviderService hostListProviderService;
 
-  public AuroraStaleDnsPlugin(final PluginService pluginService, final Properties properties) {
+  public RdsStaleDnsPlugin(final PluginService pluginService, final Properties properties) {
     this.pluginService = pluginService;
-    this.helper = new AuroraStaleDnsHelper(this.pluginService);
+    this.helper = new RdsStaleDnsHelper(this.pluginService);
   }
 
   @Override
@@ -109,7 +109,7 @@ public class AuroraStaleDnsPlugin extends AbstractConnectionPlugin {
       final JdbcCallable<Void, SQLException> initHostProviderFunc) throws SQLException {
     this.hostListProviderService = hostListProviderService;
     if (hostListProviderService.isStaticHostListProvider()) {
-      throw new SQLException(Messages.get("AuroraStaleDnsPlugin.requireDynamicProvider"));
+      throw new SQLException(Messages.get("RdsStaleDnsPlugin.requireDynamicProvider"));
     }
     initHostProviderFunc.call();
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/staledns/RdsStaleDnsPluginFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/staledns/RdsStaleDnsPluginFactory.java
@@ -21,10 +21,10 @@ import software.amazon.jdbc.ConnectionPlugin;
 import software.amazon.jdbc.ConnectionPluginFactory;
 import software.amazon.jdbc.PluginService;
 
-public class AuroraStaleDnsPluginFactory implements ConnectionPluginFactory  {
+public class RdsStaleDnsPluginFactory implements ConnectionPluginFactory  {
 
   @Override
   public ConnectionPlugin getInstance(final PluginService pluginService, final Properties props) {
-    return new AuroraStaleDnsPlugin(pluginService, props);
+    return new RdsStaleDnsPlugin(pluginService, props);
   }
 }


### PR DESCRIPTION
Renaming class `AuroraStaleDns` to `RdsStaleDns` because the plugin supports both RDS Aurora and RDS Multi-AZ DB Cluster.

We'll keep the plugin code "auroraStaleDns" for now for backward compatibility.
