### PR TITLE
test: Update container helper to create proxies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,7 +21,7 @@ ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
 ij_kotlin_name_count_to_use_star_import = 99
 ij_kotlin_name_count_to_use_star_import_for_members = 99
 ij_java_use_single_class_imports = true
-max_line_length = 100
+max_line_length = 120
 ij_any_wrap_long_lines = true
 
 [*.java]
@@ -30,7 +30,7 @@ ij_any_wrap_long_lines = true
 ij_java_imports_layout = $*,|,*
 indent_size = 2
 tab_width = 2
-max_line_length = 100
+max_line_length = 120
 ij_any_spaces_around_additive_operators = true
 ij_any_spaces_around_assignment_operators = true
 ij_any_spaces_around_bitwise_operators = true

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     testImplementation("org.testcontainers:mariadb:1.18.3")
     testImplementation("org.testcontainers:junit-jupiter:1.17.4")
     testImplementation("org.testcontainers:toxiproxy:1.18.3")
+    testImplementation("eu.rekawek.toxiproxy:toxiproxy-java:2.1.7")
     testImplementation("org.apache.poi:poi-ooxml:5.2.2")
     testImplementation("org.slf4j:slf4j-simple:2.0.7")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -55,7 +55,7 @@ public class ContainerHelper {
   private static final DockerImageName TOXIPROXY_IMAGE =
       DockerImageName.parse("shopify/toxiproxy:2.1.4");
 
-  private final static int proxyPort = 8666;
+  private static final int proxyPort = 8666;
 
   public Long runCmd(GenericContainer<?> container, String... cmd)
       throws IOException, InterruptedException {

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -23,8 +23,10 @@ import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.DockerException;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
 import integration.TestInstanceInfo;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.testcontainers.DockerClientFactory;
@@ -53,13 +55,7 @@ public class ContainerHelper {
   private static final DockerImageName TOXIPROXY_IMAGE =
       DockerImageName.parse("shopify/toxiproxy:2.1.4");
 
-  private static final String RETRIEVE_TOPOLOGY_SQL_POSTGRES =
-      "SELECT SERVER_ID, SESSION_ID FROM aurora_replica_status() "
-          + "ORDER BY CASE WHEN SESSION_ID = 'MASTER_SESSION_ID' THEN 0 ELSE 1 END";
-  private static final String RETRIEVE_TOPOLOGY_SQL_MYSQL =
-      "SELECT SERVER_ID, SESSION_ID FROM information_schema.replica_host_status "
-          + "ORDER BY IF(SESSION_ID = 'MASTER_SESSION_ID', 0, 1)";
-  private static final String SERVER_ID = "SERVER_ID";
+  private final static int proxyPort = 8666;
 
   public Long runCmd(GenericContainer<?> container, String... cmd)
       throws IOException, InterruptedException {
@@ -285,19 +281,23 @@ public class ContainerHelper {
       String networkAlias,
       String networkUrl,
       String hostname,
-      int port,
-      int expectedProxyPort) {
+      int port) throws IOException {
     final ToxiproxyContainer container =
         new ToxiproxyContainer(TOXIPROXY_IMAGE)
             .withNetwork(network)
             .withNetworkAliases(networkAlias, networkUrl);
     container.start();
-    ToxiproxyContainer.ContainerProxy proxy = container.getProxy(hostname, port);
-    assertEquals(
-        expectedProxyPort,
-        proxy.getOriginalProxyPort(),
-        "Proxy port for " + hostname + " should be " + expectedProxyPort);
+    final ToxiproxyClient toxiproxyClient = new ToxiproxyClient(container.getHost(), container.getMappedPort(8474));
+    this.createProxy(toxiproxyClient, hostname, port);
     return container;
+  }
+
+  public void createProxy(final ToxiproxyClient client, String hostname, int port)
+      throws IOException {
+    client.createProxy(
+        hostname + ":" + port,
+        "0.0.0.0:" + proxyPort,
+        hostname + ":" + port);
   }
 
   public ToxiproxyContainer createProxyContainer(

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -26,7 +26,6 @@ import com.github.dockerjava.api.exception.DockerException;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import integration.TestInstanceInfo;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.testcontainers.DockerClientFactory;
@@ -55,7 +54,8 @@ public class ContainerHelper {
   private static final DockerImageName TOXIPROXY_IMAGE =
       DockerImageName.parse("shopify/toxiproxy:2.1.4");
 
-  private static final int proxyPort = 8666;
+  private static final int PROXY_CONTROL_PORT = 8474;
+  private static final int PROXY_PORT = 8666;
 
   public Long runCmd(GenericContainer<?> container, String... cmd)
       throws IOException, InterruptedException {
@@ -287,7 +287,9 @@ public class ContainerHelper {
             .withNetwork(network)
             .withNetworkAliases(networkAlias, networkUrl);
     container.start();
-    final ToxiproxyClient toxiproxyClient = new ToxiproxyClient(container.getHost(), container.getMappedPort(8474));
+    final ToxiproxyClient toxiproxyClient = new ToxiproxyClient(
+        container.getHost(),
+        container.getMappedPort(PROXY_CONTROL_PORT));
     this.createProxy(toxiproxyClient, hostname, port);
     return container;
   }
@@ -296,7 +298,7 @@ public class ContainerHelper {
       throws IOException {
     client.createProxy(
         hostname + ":" + port,
-        "0.0.0.0:" + proxyPort,
+        "0.0.0.0:" + PROXY_PORT,
         hostname + ":" + port);
   }
 


### PR DESCRIPTION
### Summary

ToxiproxyContainer used to handle the creation of the Toxiproxy client and the proxies. This was recently [deprecated](https://github.com/testcontainers/testcontainers-java/pull/6065) and user applications are encouraged to create their own client.

This PR updates the container helper to create and handle the toxiproxy client for each proxy container instead of relying on the `getProxy` method.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.