### PR TITLE
Propagate Connection.clearWarnings() to writer and reader connection

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -52,10 +52,12 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
           add("initHostProvider");
           add("connect");
           add("notifyConnectionChanged");
-          add("Connection.setReadOnly");
+          add(METHOD_SET_READ_ONLY);
+          add(METHOD_CLEAR_WARNINGS);
         }
       });
   static final String METHOD_SET_READ_ONLY = "Connection.setReadOnly";
+  static final String METHOD_CLEAR_WARNINGS = "Connection.clearWarnings";
 
   private final PluginService pluginService;
   private final Properties properties;
@@ -197,6 +199,19 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
           () -> Messages.get("ReadWriteSplittingPlugin.executingAgainstOldConnection",
               new Object[] {methodInvokeOn}));
       return jdbcMethodFunc.call();
+    }
+
+    if (methodName.equals(METHOD_CLEAR_WARNINGS)) {
+      try {
+        if (this.writerConnection != null && !this.writerConnection.isClosed()) {
+          this.writerConnection.clearWarnings();
+        }
+        if (this.readerConnection != null && !this.readerConnection.isClosed()) {
+          this.readerConnection.clearWarnings();
+        }
+      } catch (final SQLException e) {
+        throw WrapperUtils.wrapExceptionIfNeeded(exceptionClass, e);
+      }
     }
 
     if (methodName.equals(METHOD_SET_READ_ONLY) && args != null && args.length > 0) {

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPluginTest.java
@@ -17,6 +17,7 @@
 package software.amazon.jdbc.plugin.readwritesplitting;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.AdditionalMatchers.not;
@@ -529,13 +530,16 @@ public class ReadWriteSplittingPluginTest {
             null,
             null);
 
-    plugin.execute(
-            ResultSet.class,
-            SQLException.class,
-            mockStatement,
-            "Connection.clearWarnings",
-            mockSqlFunction,
-            new Object[] {}
-    );
+    // calling clearWarnings() on nullified connection would throw an exception
+    assertDoesNotThrow(() -> {
+      plugin.execute(
+              ResultSet.class,
+              SQLException.class,
+              mockStatement,
+              "Connection.clearWarnings",
+              mockSqlFunction,
+              new Object[] {}
+      );
+    });
   }
 }


### PR DESCRIPTION
### Summary

Propagate `Connection.clearWarnings()` to writer and reader connection

### Description

`ReadWriteSplittingPlugin` does not propagate `Connection.clearWarnings()` calls to the underlying reader connection, hence the connection object may accumulate warning messages, and in effect cause a memory leak in the application.

This PR fixes the memory leak problem described in https://github.com/awslabs/aws-advanced-jdbc-wrapper/issues/547

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.