### PR TITLE
fix: close underlying connections after setReadOnly when using internal connection pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [2.2.x] - ???
 ### :magic_wand: Added
-- Host Availability Strategy to help keep host health status up to date ([PR #530](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/530)).   
+- Host Availability Strategy to help keep host health status up to date ([PR #530](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/530)).
 
 ### :crab: Changed
 - Dynamically sets the default host list provider based on the dialect used. User applications no longer need to manually set the AuroraHostListProvider when connecting to Aurora Postgres or Aurora MySQL databases.
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - As an enhancement, the wrapper is now able to automatically set the Aurora host list provider for connections to Aurora MySQL and Aurora PostgreSQL databases.
     Aurora Host List Connection Plugin is deprecated. If you were using the `AuroraHostListConnectionPlugin`, you can simply remove the plugin from the `wrapperPlugins` parameter.
     However, if you choose to, you can ensure the provider is used by specifying a topology-aware dialect, for more information, see [Database Dialects](docs/using-the-jdbc-driver/DatabaseDialects.md).
+- Close underlying connections in the Read Write Splitting Plugin after switching to read-write or read-only depending on whether internal connection pooling is used ([PR #583](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/583)).
 
 ## [2.2.3] - 2023-07-28
 ### :magic_wand: Added

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginService.java
@@ -158,4 +158,8 @@ public interface PluginService extends ExceptionHandler {
   void fillAliases(final Connection connection, final HostSpec hostSpec) throws SQLException;
 
   HostSpecBuilder getHostSpecBuilder();
+
+  ConnectionProvider getConnectionProvider();
+
+  String getDriverProtocol();
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/PluginServiceImpl.java
@@ -154,6 +154,16 @@ public class PluginServiceImpl implements PluginService, CanReleaseResources,
   }
 
   @Override
+  public ConnectionProvider getConnectionProvider() {
+    return this.pluginManager.defaultConnProvider;
+  }
+
+  @Override
+  public String getDriverProtocol() {
+    return this.driverProtocol;
+  }
+
+  @Override
   public void setCurrentConnection(
       final @NonNull Connection connection, final @NonNull HostSpec hostSpec) throws SQLException {
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/readwritesplitting/ReadWriteSplittingPlugin.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.AwsWrapperProperty;
+import software.amazon.jdbc.ConnectionProviderManager;
 import software.amazon.jdbc.HostListProviderService;
 import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
@@ -34,6 +35,7 @@ import software.amazon.jdbc.JdbcCallable;
 import software.amazon.jdbc.NodeChangeOptions;
 import software.amazon.jdbc.OldConnectionSuggestedAction;
 import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.PooledConnectionProvider;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.cleanup.CanReleaseResources;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
@@ -62,11 +64,14 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
   private final PluginService pluginService;
   private final Properties properties;
   private final String readerSelectorStrategy;
+  private final ConnectionProviderManager connProviderManager;
   private volatile boolean inReadWriteSplit = false;
   private HostListProviderService hostListProviderService;
   private Connection writerConnection;
   private Connection readerConnection;
   private HostSpec readerHostSpec;
+  private boolean isReaderConnFromInternalPool;
+  private boolean isWriterConnFromInternalPool;
 
   public static final AwsWrapperProperty READER_HOST_SELECTOR_STRATEGY =
       new AwsWrapperProperty(
@@ -82,6 +87,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
     this.pluginService = pluginService;
     this.properties = properties;
     this.readerSelectorStrategy = READER_HOST_SELECTOR_STRATEGY.getString(properties);
+    this.connProviderManager = new ConnectionProviderManager(pluginService.getConnectionProvider());
   }
 
   /**
@@ -131,6 +137,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
           Messages.get("ReadWriteSplittingPlugin.unsupportedHostSpecSelectorStrategy",
               new Object[] { this.readerSelectorStrategy }));
     }
+
     return connectInternal(isInitialConnection, connectFunc);
   }
 
@@ -263,6 +270,11 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
 
   private void getNewWriterConnection(final HostSpec writerHostSpec) throws SQLException {
     final Connection conn = this.pluginService.connect(writerHostSpec, this.properties);
+    this.isWriterConnFromInternalPool = this.connProviderManager.getConnectionProvider(
+        this.pluginService.getDriverProtocol(),
+        writerHostSpec,
+        this.properties)
+        instanceof PooledConnectionProvider;
     setWriterConnection(conn, writerHostSpec);
     switchCurrentConnectionTo(this.writerConnection, writerHostSpec);
   }
@@ -379,6 +391,10 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
       switchCurrentConnectionTo(this.writerConnection, writerHost);
     }
 
+    if (this.isReaderConnFromInternalPool) {
+      this.closeConnectionIfIdle(this.readerConnection);
+    }
+
     LOGGER.finer(() -> Messages.get("ReadWriteSplittingPlugin.switchedFromReaderToWriter",
         new Object[] {writerHost.getUrl()}));
   }
@@ -452,6 +468,10 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
         initializeReaderConnection(hosts);
       }
     }
+
+    if (this.isWriterConnFromInternalPool) {
+      this.closeConnectionIfIdle(this.writerConnection);
+    }
   }
 
   private void initializeReaderConnection(final @NonNull List<HostSpec> hosts) throws SQLException {
@@ -494,6 +514,11 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
       HostSpec hostSpec = this.pluginService.getHostSpecByStrategy(HostRole.READER, this.readerSelectorStrategy);
       try {
         conn = this.pluginService.connect(hostSpec, this.properties);
+        this.isReaderConnFromInternalPool = this.connProviderManager.getConnectionProvider(
+            this.pluginService.getDriverProtocol(),
+            hostSpec,
+            this.properties)
+            instanceof PooledConnectionProvider;
         readerHost = hostSpec;
         break;
       } catch (final SQLException e) {
@@ -534,7 +559,7 @@ public class ReadWriteSplittingPlugin extends AbstractConnectionPlugin
     closeConnectionIfIdle(this.writerConnection);
   }
 
-  private void closeConnectionIfIdle(final Connection internalConnection) {
+  void closeConnectionIfIdle(final Connection internalConnection) {
     final Connection currentConnection = this.pluginService.getCurrentConnection();
     try {
       if (internalConnection != null

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/ConcurrencyTests.java
@@ -57,6 +57,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.jdbc.ConnectionPlugin;
+import software.amazon.jdbc.ConnectionProvider;
 import software.amazon.jdbc.HostListProvider;
 import software.amazon.jdbc.HostRole;
 import software.amazon.jdbc.HostSpec;
@@ -313,7 +314,6 @@ public class ConcurrencyTests {
 
     @Override
     public void setAvailability(Set<String> hostAliases, HostAvailability availability) {
-
     }
 
     @Override
@@ -403,6 +403,16 @@ public class ConcurrencyTests {
     @Override
     public HostSpecBuilder getHostSpecBuilder() {
       return new HostSpecBuilder(new SimpleHostAvailabilityStrategy());
+    }
+
+    @Override
+    public ConnectionProvider getConnectionProvider() {
+      return null;
+    }
+
+    @Override
+    public String getDriverProtocol() {
+      return null;
     }
   }
 


### PR DESCRIPTION
### Summary

Close underlying connections after setReadOnly when using internal connection pooling

### Description

From a discussion in PR #548, related to issue #547.

It was determined the underlying reader or writer connections in the Read Write Splitting Plugin should be returned to their connection pools if internal connection pooling is used. This PR will detect if internal connection pooling is used with flags and close connections when appropriate.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.