### PR TITLE
fix: update aurora pg topology query to also return instances with null last_update_timestamp

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/AuroraPgDialect.java
@@ -42,7 +42,8 @@ public class AuroraPgDialect extends PgDialect {
           + "CPU, COALESCE(REPLICA_LAG_IN_MSEC, 0), LAST_UPDATE_TIMESTAMP "
           + "FROM aurora_replica_status() "
           // filter out nodes that haven't been updated in the last 5 minutes
-          + "WHERE EXTRACT(EPOCH FROM(NOW() - LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID' ";
+          + "WHERE EXTRACT(EPOCH FROM(NOW() - LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID' "
+          + "OR LAST_UPDATE_TIMESTAMP IS NULL";
 
   private static final String NODE_ID_QUERY = "SELECT aurora_db_instance_identifier()";
   private static final String IS_READER_QUERY = "SELECT pg_is_in_recovery()";

--- a/wrapper/src/test/java/integration/container/tests/AuroraConnectivityTests.java
+++ b/wrapper/src/test/java/integration/container/tests/AuroraConnectivityTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.container.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import integration.DatabaseEngineDeployment;
+import integration.DriverHelper;
+import integration.TestEnvironmentFeatures;
+import integration.container.ConnectionStringHelper;
+import integration.container.TestDriver;
+import integration.container.TestDriverProvider;
+import integration.container.TestEnvironment;
+import integration.container.condition.DisableOnTestFeature;
+import integration.container.condition.EnableOnDatabaseEngineDeployment;
+import integration.container.condition.EnableOnNumOfInstances;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.jdbc.PropertyDefinition;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+@ExtendWith(TestDriverProvider.class)
+@EnableOnNumOfInstances(min = 2)
+@EnableOnDatabaseEngineDeployment(DatabaseEngineDeployment.AURORA)
+@DisableOnTestFeature({
+    TestEnvironmentFeatures.PERFORMANCE,
+    TestEnvironmentFeatures.RUN_HIBERNATE_TESTS_ONLY,
+    TestEnvironmentFeatures.RUN_AUTOSCALING_TESTS_ONLY})
+public class AuroraConnectivityTests {
+
+  private static final Logger LOGGER = Logger.getLogger(AuroraConnectivityTests.class.getName());
+
+  @TestTemplate
+  @ExtendWith(TestDriverProvider.class)
+  public void test_WrapperConnectionReaderClusterWithEfmEnabled(TestDriver testDriver) throws SQLException {
+    LOGGER.info(testDriver.toString());
+
+    final Properties props = new Properties();
+    props.setProperty(
+        PropertyDefinition.USER.name,
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getUsername());
+    props.setProperty(
+        PropertyDefinition.PASSWORD.name,
+        TestEnvironment.getCurrent().getInfo().getDatabaseInfo().getPassword());
+    DriverHelper.setConnectTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    DriverHelper.setSocketTimeout(testDriver, props, 10, TimeUnit.SECONDS);
+    props.setProperty(PropertyDefinition.PLUGINS.name, "efm");
+
+    String url = ConnectionStringHelper.getWrapperReaderClusterUrl();
+    LOGGER.finest("Connecting to " + url);
+
+    try (final Connection conn = DriverManager.getConnection(url, props)) {
+      assertTrue(conn.isValid(5));
+
+      Statement stmt = conn.createStatement();
+      stmt.executeQuery("SELECT 1");
+      ResultSet rs = stmt.getResultSet();
+      rs.next();
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+}

--- a/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
+++ b/wrapper/src/test/java/integration/container/tests/ReadWriteSplittingTests.java
@@ -65,7 +65,6 @@ import software.amazon.jdbc.HikariPoolConfigurator;
 import software.amazon.jdbc.HikariPooledConnectionProvider;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.hostlistprovider.AuroraHostListProvider;
-import software.amazon.jdbc.hostlistprovider.ConnectionStringHostListProvider;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin;
 import software.amazon.jdbc.plugin.failover.FailoverFailedSQLException;
 import software.amazon.jdbc.plugin.failover.FailoverSuccessSQLException;

--- a/wrapper/src/test/java/integration/util/AuroraTestUtility.java
+++ b/wrapper/src/test/java/integration/util/AuroraTestUtility.java
@@ -92,7 +92,7 @@ public class AuroraTestUtility {
   private String dbName = "test";
   private String dbIdentifier = "test-identifier";
   private String dbEngine = "aurora-postgresql";
-  private String dbEngineVersion = "13.7";
+  private String dbEngineVersion = "13.9";
   private String dbInstanceClass = "db.r5.large";
   private final Region dbRegion;
   private final String dbSecGroup = "default";


### PR DESCRIPTION
### Summary

Update aurora pg topology query to also return instances with null last_update_timestamp

### Description

In Aurora PostgreSQL versions 13.9 and above, the instance a user is currently connected to will not include a `last_update_timestamp` when retrieved from `aurora_replica_status()`.  This PR adjusts the topology query to account for the change. 

For example, querying the `last_update_timestamp` for all instance from `aurora_replica_status()` while connecting through the reader cluster url will result in this:
```
          server_id          | case |  last_update_timestamp  
-----------------------------+------+------------------------
 database-instance-1         | t    | 2023-08-15 00:29:11+00
 database-instance-2         | f    | 

```

This PR also bumps the integration test engine version to 13.9

Addresses #593.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.