### PR TITLE
fix: expand ReentrantLock scope in MonitorThreadContainer for better …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### :magic_wand: Added
 - Host Availability Strategy to help keep host health status up to date ([PR #530](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/530)).
 
+### :bug: Fixed
+- Race condition issues between `MonitorThreadContainer#getInstance()` and `MonitorThreadContainer#releaseInstance()` ([PR #601](https://github.com/awslabs/aws-advanced-jdbc-wrapper/pull/601)).
+
 ### :crab: Changed
 - Dynamically sets the default host list provider based on the dialect used. User applications no longer need to manually set the AuroraHostListProvider when connecting to Aurora Postgres or Aurora MySQL databases.
 - Deprecated AuroraHostListConnectionPlugin. 

--- a/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/MultiThreadedMonitorThreadContainerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/plugin/efm/MultiThreadedMonitorThreadContainerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.efm;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class MultiThreadedMonitorThreadContainerTest {
+
+  @Mock ExecutorServiceInitializer mockExecutorServiceInitializer;
+  @Mock ExecutorService mockExecutorService;
+
+  private AutoCloseable closeable;
+
+  @BeforeEach
+  void init() {
+    closeable = MockitoAnnotations.openMocks(this);
+    when(mockExecutorServiceInitializer.createExecutorService()).thenReturn(mockExecutorService);
+  }
+
+  @AfterEach
+  void cleanup() throws Exception {
+    closeable.close();
+    MonitorThreadContainer.releaseInstance();
+  }
+
+  @RepeatedTest(value = 1000, name = "MonitorThreadContainer ThreadPoolExecutor is not closed prematurely")
+  void testThreadPoolExecutorNotClosedPrematurely() throws InterruptedException {
+    MonitorThreadContainer.getInstance(mockExecutorServiceInitializer);
+
+    ExecutorService executorService = Executors.newCachedThreadPool();
+    executorService.execute(() -> MonitorThreadContainer.getInstance(mockExecutorServiceInitializer));
+    Thread.sleep(3);
+    executorService.execute(MonitorThreadContainer::releaseInstance);
+    executorService.shutdown();
+
+    verify(mockExecutorService, times(0)).shutdownNow();
+  }
+}


### PR DESCRIPTION
…thread safety

### Summary
Remove race condition in `MonitorThreadContainer` between `getInstance()` and `releaseInstance()` methods.

### Description

In the `MonitorThreadContainer`, there are possible race conditions between the `getInstance()` and `releaseInstance()` methods. 

In one of the race conditions is in the `getInstance()`. 
```
...
      } finally {
        LOCK_OBJECT.unlock();
      }
    }
    CLASS_USAGE_COUNT.getAndIncrement();
    return singleton;
  }
```
Just after the lock object is unlocked, is an opportunity for a race condition with another thread in the `releaseInstance()` method. 
```
...
    if (CLASS_USAGE_COUNT.decrementAndGet() <= 0) {
      LOCK_OBJECT.lock();
      try {
        if (singleton != null) {
          singleton.releaseResources();
          singleton = null;
          CLASS_USAGE_COUNT.set(0);
...
```
If the locked block is entered, a race condition may result.  `getInstance()` may  return a null `singleton` which will be followed by a NPE. Or another scenario is that a non-null singleton will be returned, but `singleton.releaseResources()` is called so the `MonitorThreadContainer`'s `threadPool` will be shutdown and subsequent usage of the threadPool will result in a `RejectedExecutionException`.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.