### PR TITLE
fix: condition setting delayMillis

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/MonitorImpl.java
@@ -202,7 +202,7 @@ public class MonitorImpl implements Monitor {
           } else {
             delayMillis -= status.elapsedTimeNano;
             // Check for min delay between node health check
-            if (delayMillis < MIN_CONNECTION_CHECK_TIMEOUT_MILLIS) {
+            if (delayMillis <= 0) {
               delayMillis = MIN_CONNECTION_CHECK_TIMEOUT_MILLIS;
             }
             // Use this delay as node checkout timeout since it corresponds to min interval for all active contexts


### PR DESCRIPTION
### Summary

The original condition is to prevent passing a negative value to `sleep`. However min check time is 3 seconds. Setting the delays to 3 seconds when the delay is nonnegative has negative performance impacts.

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.