### PR TITLE
fix: continue monitoring if unhandled Exception is thrown

### DIFF
--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -188,6 +188,10 @@ MonitorThreadContainer.emptyNodeKeys=Provided node keys are empty.
 
 # Monitor Impl
 MonitorImpl.contextNullWarning=Parameter 'context' should not be null.
+MonitorImpl.interruptedExceptionDuringMonitoring=Monitoring thread for node {0} was interrupted: {1}
+MonitorImpl.exceptionDuringMonitoringContinue=Continuing monitoring after unhandled exception was thrown in monitoring thread for node {0}: {1}
+MonitorImpl.exceptionDuringMonitoringStop=Stopping monitoring after unhandled exception was thrown in monitoring thread for node {0}: {1}
+MonitorImpl.monitorIsStopped=Monitoring was already stopped for node {0}.
 
 # Monitor Service Impl
 MonitorServiceImpl.nullMonitorParam=Parameter 'monitor' should not be null.


### PR DESCRIPTION
### Summary

Add additional logging for efm

### Description

- Adds additional logging in the `MonitorImpl` class for previously unhandled exceptions and for scenarios where monitoring has stopped but the `startMonitoring` method was called again.
- Changes the monitoring loop to continue running unless an InterruptedException is thrown.

Related to #675 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.