### PR TITLE
docs: add known limitations to main readme and fix example url

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Technical documentation regarding the functionality of the AWS JDBC Driver will 
 ### Using the AWS JDBC Driver
 To find all the documentation and concrete examples on how to use the AWS JDBC Driver, please refer to the [AWS JDBC Driver Documentation](./docs/Documentation.md) page.
 
+### Known Limitations
+
+#### Amazon RDS Blue/Green Deployments
+
+This driver currently does not support switchover in Amazon RDS Blue/Green Deployments. If you do execute a Blue/Green deployment with the driver, please ensure your application is coded to retry the database connection. Retry will allow the driver to re-establish a connection to an available database instance. Without a retry, the driver would not be able to identify an available database instance, after a switchover has happened between the blue and green environments. However, please note that even with your application coded to retry the database connection, you may still encounter other unexpected errors. Support for Amazon RDS Blue/Green Deployments is in the backlog, but we cannot comment on a timeline right now.
+
 ## Examples
 
 | Description                                                                                                                                                                                                              |                                                                                                                                                                    Examples                                                                                                                                                                    |

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -31,4 +31,3 @@
     - [Plugin Service](./development-guide/PluginService.md)
     - [Pipelines](./development-guide/Pipelines.md)
     - [Read-Write Splitting Plugin Performance Results](./development-guide/ReadWriteSplittingPluginPerformanceResults.md)
-- [Known Limitations](./KnownLimitations.md)

--- a/docs/KnownLimitations.md
+++ b/docs/KnownLimitations.md
@@ -1,5 +1,0 @@
-# Known Limitations
-
-## Amazon RDS Blue/Green Deployments
-
-This driver currently does not support switchover in Amazon RDS Blue/Green Deployments. In order to execute a Blue/Green deployment with the driver, please ensure your application is coded to retry the database connection. Retry will allow the driver to re-establish a connection to an available database instance. Without a retry, the driver would not be able to identify an available database instance, after a switchover has happened between the blue and green environments. 

--- a/examples/VertxExample/src/main/java/com/example/starter/MainVerticle.java
+++ b/examples/VertxExample/src/main/java/com/example/starter/MainVerticle.java
@@ -37,7 +37,7 @@ public class MainVerticle extends AbstractVerticle {
   public static final String INSERT = "INSERT INTO example (status, id) VALUES (?, ?)";
 
   final JsonObject writeConfig = new JsonObject()
-    .put("url", "jdbc:aws-wrapper:postgresql://db-identifier.cluster-ro-XYZ.us-east-2.rds.amazonaws.com:5432/postgres")
+    .put("url", "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres")
     .put("driverClass", "software.amazon.jdbc.Driver")
     .put("user", "username")
     .put("password", "password")


### PR DESCRIPTION
### Summary

Minor documentation updates

### Description

- Moved the known limitations to the main read me
- Changed the wording on the blue/green deployments limitation
- Change a url from reader cluster to cluster in VertX example

Related to #678 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.