### PR TITLE
Fix Maven coordinates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can find our driver by searching in The Central Repository with GroupId and 
 <!-- replacing LATEST with the specific version as required -->
 
 <dependency>
-  <groupId>software.amazon</groupId>
+  <groupId>software.amazon.jdbc</groupId>
   <artifactId>aws-advanced-jdbc-wrapper</artifactId>
   <version>LATEST</version>
 </dependency>


### PR DESCRIPTION
### Summary

Fix Maven coordinates in README

### Description

As per the link above the text blob in `README.md`, https://search.maven.org/search?q=g:software.amazon.jdbc, the group ID is `software.amazon.jdbc`.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.