### PR TITLE
fix: update topology for specific methods

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SubscribedMethodHelper.java
@@ -50,4 +50,31 @@ public class SubscribedMethodHelper {
       "CallableStatement.executeUpdate",
       "CallableStatement.executeWithFlags"
   );
+
+  public static final List<String> METHODS_REQUIRING_UPDATED_TOPOLOGY = Arrays.asList(
+      "Connection.commit",
+      "Connection.connect",
+      "Connection.isValid",
+      "Connection.setAutoCommit",
+      "Connection.setReadOnly",
+      "Statement.execute",
+      "Statement.executeBatch",
+      "Statement.executeLargeBatch",
+      "Statement.executeLargeUpdate",
+      "Statement.executeQuery",
+      "Statement.executeUpdate",
+      "Statement.executeWithFlags",
+      "PreparedStatement.execute",
+      "PreparedStatement.executeBatch",
+      "PreparedStatement.executeLargeUpdate",
+      "PreparedStatement.executeQuery",
+      "PreparedStatement.executeUpdate",
+      "PreparedStatement.executeWithFlags",
+      "PreparedStatement.getParameterMetaData",
+      "CallableStatement.execute",
+      "CallableStatement.executeLargeUpdate",
+      "CallableStatement.executeQuery",
+      "CallableStatement.executeUpdate",
+      "CallableStatement.executeWithFlags"
+  );
 }


### PR DESCRIPTION
### Summary

Update topology for specific methods

### Description

Specify a list of methods where it's safe to update the topology before executing to prevent error where connection objects have more than one streaming result set open at the same time.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.