### PR TITLE
introduce Dialect.prepareConnectProperties

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DataSourceConnectionProvider.java
@@ -120,6 +120,7 @@ public class DataSourceConnectionProvider implements ConnectionProvider {
       throws SQLException {
 
     final Properties copy = PropertyUtils.copyProperties(props);
+    dialect.prepareConnectProperties(copy, protocol, hostSpec);
 
     Connection conn;
 

--- a/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/DriverConnectionProvider.java
@@ -115,8 +115,8 @@ public class DriverConnectionProvider implements ConnectionProvider {
       throws SQLException {
 
     final Properties copy = PropertyUtils.copyProperties(props);
-    final ConnectInfo connectInfo =
-        this.targetDriverDialect.prepareConnectInfo(protocol, hostSpec, copy);
+    dialect.prepareConnectProperties(copy, protocol, hostSpec);
+    final ConnectInfo connectInfo = this.targetDriverDialect.prepareConnectInfo(protocol, hostSpec, copy);
 
     LOGGER.finest(() -> "Connecting to " + connectInfo.url
         + PropertyUtils.logProperties(connectInfo.props, "\nwith properties: \n"));

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/Dialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/Dialect.java
@@ -18,6 +18,9 @@ package software.amazon.jdbc.dialect;
 
 import java.sql.Connection;
 import java.util.List;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
 
 public interface Dialect {
@@ -34,4 +37,7 @@ public interface Dialect {
   List</* dialect code */ String> getDialectUpdateCandidates();
 
   HostListProviderSupplier getHostListProvider();
+
+  void prepareConnectProperties(
+      final @NonNull Properties connectProperties, final @NonNull String protocol, final @NonNull HostSpec hostSpec);
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MariaDbDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MariaDbDialect.java
@@ -21,6 +21,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
 import software.amazon.jdbc.exceptions.MariaDBExceptionHandler;
 import software.amazon.jdbc.hostlistprovider.ConnectionStringHostListProvider;
@@ -75,5 +78,11 @@ public class MariaDbDialect implements Dialect {
 
   public HostListProviderSupplier getHostListProvider() {
     return ConnectionStringHostListProvider::new;
+  }
+
+  @Override
+  public void prepareConnectProperties(
+      final @NonNull Properties connectProperties, final @NonNull String protocol, final @NonNull HostSpec hostSpec) {
+    // do nothing
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MysqlDialect.java
@@ -22,6 +22,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
 import software.amazon.jdbc.exceptions.MySQLExceptionHandler;
 import software.amazon.jdbc.hostlistprovider.ConnectionStringHostListProvider;
@@ -81,5 +84,11 @@ public class MysqlDialect implements Dialect {
 
   public HostListProviderSupplier getHostListProvider() {
     return ConnectionStringHostListProvider::new;
+  }
+
+  @Override
+  public void prepareConnectProperties(
+      final @NonNull Properties connectProperties, final @NonNull String protocol, final @NonNull HostSpec hostSpec) {
+    // do nothing
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/PgDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/PgDialect.java
@@ -22,6 +22,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
 import software.amazon.jdbc.exceptions.PgExceptionHandler;
 import software.amazon.jdbc.hostlistprovider.ConnectionStringHostListProvider;
@@ -82,5 +85,11 @@ public class PgDialect implements Dialect {
   @Override
   public HostListProviderSupplier getHostListProvider() {
     return ConnectionStringHostListProvider::new;
+  }
+
+  @Override
+  public void prepareConnectProperties(
+      final @NonNull Properties connectProperties, final @NonNull String protocol, final @NonNull HostSpec hostSpec) {
+    // do nothing
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/UnknownDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/UnknownDialect.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import software.amazon.jdbc.HostListProviderService;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.exceptions.ExceptionHandler;
 import software.amazon.jdbc.exceptions.GenericExceptionHandler;
@@ -77,5 +76,11 @@ public class UnknownDialect implements Dialect {
   @Override
   public HostListProviderSupplier getHostListProvider() {
     return ConnectionStringHostListProvider::new;
+  }
+
+  @Override
+  public void prepareConnectProperties(
+      final @NonNull Properties connectProperties, final @NonNull String protocol, final @NonNull HostSpec hostSpec) {
+    // do nothing
   }
 }


### PR DESCRIPTION
### Summary

Allow dialect classes to modify properties while opening a new connection.

### Description

Dialect interface is extended with prepareConnectProperties(). It's called by connection provider before target driver dialect gets a chance to do similar preparation.

### Additional Reviewers

@karenc-bq 
@brunos-bq 
@crystall-bitquill 
@aaronchung-bitquill 
@hsuamz 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.