### PR TITLE
Allow user to set up a lambda to initialize new connections

### DIFF
--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -105,7 +105,7 @@ In some cases it's necessary to configure a connection before a user application
 
 AWS JDBC Driver allows to specify a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. `resetConnectionInitFunc` method is also available. 
 
-The initialization function is called for all connections, including pre-opened connections provided by internal connection pool (see [Using Read Write Splitting Plugin Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)), and, thus, helping a user application to clean up connection session "contaminated" by previous use.
+The initialization function is called for all connections, including pre-opened connections provided by internal connection pools (see [Using Read Write Splitting Plugin and Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)). This helps user applications clean up connection sessions that have been altered by previous operation, as returning a connection to a pool will reset the state and retrieving it will call the initialization function again.
 
 > :warning: Executing CPU and network intensive code in the initialization function may have a significant impact in the wrapper performance overall.
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -101,7 +101,7 @@ DriverConfigurationProfiles.addOrReplaceProfile(
 ```
 
 ### Executing Custom Code When Initializing a Connection
-In some cases it's necessary to configure a connection before a user application can use it. Some target drivers provides such functionality and allow to specify a configuration parameter with SQL statements that are executed when connection is established. However, not all drivers supports such functionality. Also, in some cases, additional conditions should be checked in order to identify what initialization is required for a particular connection.
+Users may need to define a specific configuration for a connection that has just been opened by the driver before an application can use it. Not all target drivers provide this functionality, but some allow specifying a configuration parameter with SQL statements that are executed when a connection is established. Some cases may also require that additional conditions are checked in order to identify what initialization configuration is required for a particular connection.
 
 AWS JDBC Driver allows to specify a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. `resetConnectionInitFunc` method is also available. 
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -107,7 +107,7 @@ In some use cases you may need to define a specific configuration for a new driv
 
 The AWS JDBC Driver allows specifying a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. The `resetConnectionInitFunc` method is also available to remove the function.
 
-The initialization function is called for all connections, including pre-opened connections provided by internal connection pools (see [Using Read Write Splitting Plugin and Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)). This helps user applications clean up connection sessions that have been altered by previous operation, as returning a connection to a pool will reset the state and retrieving it will call the initialization function again.
+The initialization function is called for all connections, including connections opened by the internal connection pools (see [Using Read Write Splitting Plugin and Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)). This helps user applications clean up connection sessions that have been altered by previous operations, as returning a connection to a pool will reset the state and retrieving it will call the initialization function again.
 
 > :warning: Executing CPU and network intensive code in the initialization function may have a significant impact in the wrapper performance overall.
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -101,7 +101,9 @@ DriverConfigurationProfiles.addOrReplaceProfile(
 ```
 
 ### Executing Custom Code When Initializing a Connection
-Users may need to define a specific configuration for a connection that has just been opened by the driver before an application can use it. Not all target drivers provide this functionality, but some allow specifying a configuration parameter with SQL statements that are executed when a connection is established. Some cases may also require that additional conditions are checked in order to identify what initialization configuration is required for a particular connection.
+In some use cases you may need to define a specific configuration for a new driver connection before your application can use it. For instance:
+- you might need to run some initial SQL queries when a connection is established, or;
+- you might need to check for some additional conditions to determine the initialization configuration required for a particular connection.
 
 The AWS JDBC Driver allows specifying a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. The `resetConnectionInitFunc` method is also available to remove the function.
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -100,6 +100,25 @@ DriverConfigurationProfiles.addOrReplaceProfile(
         CustomConnectionPluginFactory.class));
 ```
 
+### Connection Initialization
+In some cases it's necessary to configure a connection before a user application can use it. Some target drivers provides such functionality and allow to specify a configuration parameter with SQL statements that are executed when connection is established. However, not all drivers supports such functionality. Also, in some cases, additional conditions should be checked in order to identify what initialization is required for a particular connection.
+
+AWS JDBC Driver allows to specify a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. `resetConnectionInitFunc` method is also available. 
+
+The initialization function is called for all connections, including pre-opened connections provided by internal connection pool (see [Using Read Write Splitting Plugin Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)), and, thus, helping a user application to clean up connection session "contaminated" by previous use.
+
+> :warning: Executing CPU and network intensive code in the initialization function may cause significant performance degradation.
+
+```java
+ConnectionProviderManager.setConnectionInitFunc((connection, protocol, hostSpec, props) -> {
+    // Set custom schema for connections to a test-database  
+    if ("test-database".equals(props.getProperty("database"))) {
+        connection.setSchema("test-database-schema");
+    }
+});
+```
+
+
 ### List of Available Plugins
 The AWS JDBC Driver has several built-in plugins that are available to use. Please visit the individual plugin page for more details.
 

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -109,7 +109,8 @@ The AWS JDBC Driver allows specifying a special function that can initialize a c
 
 The initialization function is called for all connections, including connections opened by the internal connection pools (see [Using Read Write Splitting Plugin and Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)). This helps user applications clean up connection sessions that have been altered by previous operations, as returning a connection to a pool will reset the state and retrieving it will call the initialization function again.
 
-> :warning: Executing CPU and network intensive code in the initialization function may have a significant impact in the wrapper performance overall.
+> [!WARNING]\
+> Executing CPU and network intensive code in the initialization function may significantly impact the AWS JDBC Driver's overall performance.
 
 ```java
 ConnectionProviderManager.setConnectionInitFunc((connection, protocol, hostSpec, props) -> {

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -100,14 +100,14 @@ DriverConfigurationProfiles.addOrReplaceProfile(
         CustomConnectionPluginFactory.class));
 ```
 
-### Connection Initialization
+### Executing Custom Code When Initializing a Connection
 In some cases it's necessary to configure a connection before a user application can use it. Some target drivers provides such functionality and allow to specify a configuration parameter with SQL statements that are executed when connection is established. However, not all drivers supports such functionality. Also, in some cases, additional conditions should be checked in order to identify what initialization is required for a particular connection.
 
 AWS JDBC Driver allows to specify a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. `resetConnectionInitFunc` method is also available. 
 
 The initialization function is called for all connections, including pre-opened connections provided by internal connection pool (see [Using Read Write Splitting Plugin Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)), and, thus, helping a user application to clean up connection session "contaminated" by previous use.
 
-> :warning: Executing CPU and network intensive code in the initialization function may cause significant performance degradation.
+> :warning: Executing CPU and network intensive code in the initialization function may have a significant impact in the wrapper performance overall.
 
 ```java
 ConnectionProviderManager.setConnectionInitFunc((connection, protocol, hostSpec, props) -> {

--- a/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
+++ b/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md
@@ -103,7 +103,7 @@ DriverConfigurationProfiles.addOrReplaceProfile(
 ### Executing Custom Code When Initializing a Connection
 Users may need to define a specific configuration for a connection that has just been opened by the driver before an application can use it. Not all target drivers provide this functionality, but some allow specifying a configuration parameter with SQL statements that are executed when a connection is established. Some cases may also require that additional conditions are checked in order to identify what initialization configuration is required for a particular connection.
 
-AWS JDBC Driver allows to specify a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. `resetConnectionInitFunc` method is also available. 
+The AWS JDBC Driver allows specifying a special function that can initialize a connection. It can be done with `ConnectionProviderManager.setConnectionInitFunc` method. The `resetConnectionInitFunc` method is also available to remove the function.
 
 The initialization function is called for all connections, including pre-opened connections provided by internal connection pools (see [Using Read Write Splitting Plugin and Internal Connection Pooling](./using-plugins/UsingTheReadWriteSplittingPlugin.md#internal-connection-pooling)). This helps user applications clean up connection sessions that have been altered by previous operation, as returning a connection to a pool will reset the state and retrieving it will call the initialization function again.
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -173,6 +173,8 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
       telemetryContext.closeContext();
     }
 
+    this.connProviderManager.initConnection(conn, driverProtocol, hostSpec, props);
+
     this.pluginService.setAvailability(hostSpec.asAliases(), HostAvailability.AVAILABLE);
     this.pluginService.updateDialect(conn);
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/DefaultConnectionPlugin.java
@@ -67,6 +67,18 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
       final PluginService pluginService,
       final ConnectionProvider defaultConnProvider,
       final PluginManagerService pluginManagerService) {
+    this(pluginService,
+        defaultConnProvider,
+        pluginManagerService,
+        new ConnectionProviderManager(defaultConnProvider));
+  }
+
+  public DefaultConnectionPlugin(
+      final PluginService pluginService,
+      final ConnectionProvider defaultConnProvider,
+      final PluginManagerService pluginManagerService,
+      final ConnectionProviderManager connProviderManager) {
+
     if (pluginService == null) {
       throw new IllegalArgumentException("pluginService");
     }
@@ -79,7 +91,7 @@ public final class DefaultConnectionPlugin implements ConnectionPlugin {
 
     this.pluginService = pluginService;
     this.pluginManagerService = pluginManagerService;
-    this.connProviderManager = new ConnectionProviderManager(defaultConnProvider);
+    this.connProviderManager = connProviderManager;
   }
 
   @Override


### PR DESCRIPTION
### Summary

Allow user to set up a lambda to initialize new connections.

### Description

User needs to set an connection initialization function with ConnectionProviderManager.setConnectionInitFunc()
Related to https://github.com/awslabs/aws-advanced-jdbc-wrapper/issues/679

### Additional Reviewers

@karenc-bq 
@crystall-bitquill 
@brunos-bq 
@aaronchung-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.