### PR TITLE
feat: allow endpoint override for secrets manager plugin

### DIFF
--- a/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
+++ b/docs/using-the-jdbc-driver/using-plugins/UsingTheAwsSecretsManagerPlugin.md
@@ -12,10 +12,11 @@ The following properties are required for the AWS Secrets Manager Connection Plu
 
 > **Note:** To use this plugin, you will need to set the following AWS Secrets Manager specific parameters.
 
-| Parameter                | Value  |                         Required                         | Description                                             | Example     | Default Value |
-|--------------------------|:------:|:--------------------------------------------------------:|:--------------------------------------------------------|:------------|---------------|
-| `secretsManagerSecretId` | String |                           Yes                            | Set this value to be the secret name or the secret ARN. | `secretId`  | `null`        |
-| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN. | Set this value to be the region your secret is in.      | `us-east-2` | `us-east-1`   |
+| Parameter                | Value  |                         Required                         | Description                                                                                                                                                                                                                      | Example                 | Default Value |
+|--------------------------|:------:|:--------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------|---------------|
+| `secretsManagerSecretId` | String |                           Yes                            | Set this value to be the secret name or the secret ARN.                                                                                                                                                                          | `secretId`              | `null`        |
+| `secretsManagerRegion`   | String | Yes unless the `secretsManagerSecretId` is a Secret ARN. | Set this value to be the region your secret is in.                                                                                                                                                                               | `us-east-2`             | `us-east-1`   |
+| `secretsManagerEndpoint` | String |                            No                            | Set this value to be the endpoint override to retrieve your secret from. This parameter value should be in the form of a URL, with a valid protocol (ex. `http://`) and domain (ex. `localhost`). A port number is not required. | `http://localhost:1234` | `null`        |
 
 *NOTE* A Secret ARN has the following format: `arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters`
 

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -36,11 +36,12 @@ AwsCredentialsManager.nullProvider=The configured AwsCredentialsProvider was nul
 AwsSdk.unsupportedRegion=Unsupported AWS region ''{0}''. For supported regions please read https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html
 
 # AWS Secrets Manager Connection Plugin
+AwsSecretsManagerConnectionPlugin.endpointOverrideMisconfigured=The provided endpoint is invalid and could not be used to create a URI: `{0}`.
+AwsSecretsManagerConnectionPlugin.endpointOverrideInvalidConnection=A connection to the provided endpoint could not be established: `{0}`.
 AwsSecretsManagerConnectionPlugin.javaSdkNotInClasspath=Required dependency 'AWS Java SDK for AWS Secrets Manager' is not on the classpath.
 AwsSecretsManagerConnectionPlugin.jacksonDatabindNotInClasspath=Required dependency 'Jackson Databind' is not on the classpath.
 AwsSecretsManagerConnectionPlugin.failedToFetchDbCredentials=Was not able to either fetch or read the database credentials from AWS Secrets Manager. Ensure the correct secretId and region properties have been provided.
 AwsSecretsManagerConnectionPlugin.missingRequiredConfigParameter=Configuration parameter ''{0}'' is required.
-AwsSecretsManagerConnectionPlugin.failedLogin=Login failed. SQLState=''{0}''
 AwsSecretsManagerConnectionPlugin.unhandledException=Unhandled exception: ''{0}''
 
 # AWS Wrapper Data Source


### PR DESCRIPTION
### Summary

Allow endpoint override for secrets manager plugin

### Description

- adds the configuration parameter `secretsManagerEndpoint` to allow users to set the endpoint override for secret retrieval in the secrets manager plugin

Addresses #630 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.