### PR TITLE
docs: update HikariCP example to include configuring the datasource with a JDBC URL

### DIFF
--- a/docs/using-the-jdbc-driver/DataSource.md
+++ b/docs/using-the-jdbc-driver/DataSource.md
@@ -64,6 +64,9 @@ To use the AWS JDBC Driver with a connection pool, you must:
    ds.addDataSourceProperty("serverName", "db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com");
    ds.addDataSourceProperty("serverPort", "5432");
    ds.addDataSourceProperty("database", "postgres");
+   
+   // Alternatively, the AwsWrapperDataSource can be configured with a JDBC URL instead of individual properties as seen above.
+   ds.addDataSourceProperty("jdbcUrl", "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres");
    ```
 
 4. Set the driver-specific datasource:
@@ -79,7 +82,7 @@ To use the AWS JDBC Driver with a connection pool, you must:
    ds.addDataSourceProperty("targetDataSourceProperties", targetDataSourceProps);
    ```
 
-> **:warning:Note:** HikariCP supports either DataSource-based configuration or DriverManager-based configuration by specifying the `dataSourceClassName` or the `jdbcUrl`. When using the `AwsWrapperDataSource` you must specify the `dataSourceClassName`, therefore `HikariDataSource.setJdbcUrl` is not supported. For more information see HikariCP's [documentation](https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby).
+> **:warning:Note:** HikariCP supports either DataSource-based configuration or DriverManager-based configuration by specifying the `dataSourceClassName` or the `jdbcUrl`. When using the `AwsWrapperDataSource` you must specify the `dataSourceClassName`, and the  `HikariDataSource.setJdbcUrl` method should not be used. For more information see HikariCP's [documentation](https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby).
 
 ### Examples
 See [here](../../examples/AWSDriverExample/src/main/java/software/amazon/DatasourceExample.java) for a simple AWS Driver Datasource example.

--- a/examples/HikariExample/src/main/java/software/amazon/HikariExample.java
+++ b/examples/HikariExample/src/main/java/software/amazon/HikariExample.java
@@ -47,6 +47,12 @@ public class HikariExample {
       ds.addDataSourceProperty("serverPort", "5432");
       ds.addDataSourceProperty("serverName", ENDPOINT);
 
+      // Alternatively, the AwsWrapperDataSource can be configured with a JDBC URL instead of individual properties as
+      // seen above.
+      ds.addDataSourceProperty(
+          "jdbcUrl",
+          "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres");
+
       // Specify the driver-specific data source for AwsWrapperDataSource:
       ds.addDataSourceProperty("targetDataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
 

--- a/examples/HikariExample/src/main/java/software/amazon/HikariFailoverExample.java
+++ b/examples/HikariExample/src/main/java/software/amazon/HikariFailoverExample.java
@@ -50,6 +50,12 @@ public class HikariFailoverExample {
       ds.addDataSourceProperty("serverPort", "5432");
       ds.addDataSourceProperty("database", DATABASE_NAME);
 
+      // Alternatively, the AwsWrapperDataSource can be configured with a JDBC URL instead of individual properties as
+      // seen above.
+      ds.addDataSourceProperty(
+          "jdbcUrl",
+          "jdbc:aws-wrapper:postgresql://db-identifier.cluster-XYZ.us-east-2.rds.amazonaws.com:5432/postgres");
+
       // The failover plugin throws failover-related exceptions that need to be handled explicitly by HikariCP,
       // otherwise connections will be closed immediately after failover. Set `ExceptionOverrideClassName` to provide
       // a custom exception class.


### PR DESCRIPTION
### Summary

Update HikariCP example to include configuring the datasource with a JDBC URL

### Description

The existing example only uses the individual data source properties. This PR includes the option of using a URL in the example and clarifies that it is possible to use URLs.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.