### PR TITLE
Handle empty string sql query

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -16,10 +16,13 @@
 
 package software.amazon.jdbc.util;
 
+import static java.util.Collections.singletonList;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,14 +58,14 @@ public class SqlMethodAnalyzer {
 
   private List<String> parseMultiStatementQueries(String query) {
     if (StringUtils.isNullOrEmpty(query)) {
-      return new ArrayList<>();
+      return singletonList("");
     }
 
     query = query.replaceAll("\\s+", " ");
 
     // Check to see if string only has blank spaces.
     if (query.trim().isEmpty()) {
-      return new ArrayList<>();
+      return singletonList("");
     }
 
     return Arrays.stream(query.split(";")).collect(Collectors.toList());

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -16,6 +16,8 @@
 
 package software.amazon.jdbc.util;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -142,6 +144,20 @@ class SqlMethodAnalyzerTest {
   void testIsMethodClosingSqlObject(final String methodName, final boolean expected) {
     final boolean actual = sqlMethodAnalyzer.isMethodClosingSqlObject(methodName);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void testEmptySqlQueryDoesNotThrowIndexOutOfBoundsException() {
+    assertAll(
+        () -> assertDoesNotThrow(() -> sqlMethodAnalyzer.doesOpenTransaction(conn, "execute", new String[]{""}),
+            "doesOpenTransaction should handle an empty SQL query"),
+        () -> assertDoesNotThrow(() -> sqlMethodAnalyzer.doesCloseTransaction(conn, "execute", new String[]{""}),
+            "doesCloseTransaction should handle an empty SQL query"),
+        () -> assertDoesNotThrow(() -> sqlMethodAnalyzer.isStatementSettingAutoCommit("execute", new String[]{""}),
+            "isStatementSettingAutoCommit should handle an empty SQL query"),
+        () -> assertDoesNotThrow(() -> sqlMethodAnalyzer.getAutoCommitValueFromSqlStatement(new String[]{""}),
+            "getAutoCommitValueFromSqlStatement should handle an empty SQL query")
+    );
   }
 
   private static Stream<Arguments> openTransactionQueries() {


### PR DESCRIPTION
Don't throw  IndexOutOfBoundsException in SqlMethodAnalyzer when executing empty sql query

### Summary

<!--- General summary / title -->
As mentioned in [the discussion about JBoss EAP datasource migration](https://github.com/awslabs/aws-advanced-jdbc-wrapper/discussions/217#discussioncomment-7661887), the [PostgreSQLValidConnectionChecker](https://github.com/oloake/IronJacamar/blob/master/adapters/src/main/java/org/jboss/jca/adapters/jdbc/extensions/postgres/PostgreSQLValidConnectionChecker.java#L61C10-L61C27) tries to execute an empty string statement. This results in an IndexOutOfBoundsException.

### Description

When given an empty SQL statement, I've made `SqlMethodAnalyzer#getFirstSqlStatement` return an empty string in a singleton list instead of an empty list. So now it is safe to get and invoke String methods on the first element of the returned list.

### Additional Reviewers

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.