### PR TITLE
feat: node fastest response time strategy

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginChainBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginChainBuilder.java
@@ -41,8 +41,8 @@ import software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPluginFactory;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPluginFactory;
 import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingPluginFactory;
 import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsPluginFactory;
+import software.amazon.jdbc.plugin.strategy.fastestresponse.FastestResponseStrategyPluginFactory;
 import software.amazon.jdbc.profile.ConfigurationProfile;
-import software.amazon.jdbc.profile.DriverConfigurationProfiles;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.SqlState;
 import software.amazon.jdbc.util.StringUtils;
@@ -71,6 +71,7 @@ public class ConnectionPluginChainBuilder {
           put("driverMetaData", DriverMetaDataConnectionPluginFactory.class);
           put("connectTime", ConnectTimeConnectionPluginFactory.class);
           put("dev", DeveloperConnectionPluginFactory.class);
+          put("fastestResponseStrategy", FastestResponseStrategyPluginFactory.class);
         }
       };
 
@@ -90,9 +91,10 @@ public class ConnectionPluginChainBuilder {
           put(ReadWriteSplittingPluginFactory.class, 600);
           put(FailoverConnectionPluginFactory.class, 700);
           put(HostMonitoringConnectionPluginFactory.class, 800);
-          put(IamAuthConnectionPluginFactory.class, 900);
-          put(AwsSecretsManagerConnectionPluginFactory.class, 1000);
-          put(LogQueryConnectionPluginFactory.class, 1100);
+          put(FastestResponseStrategyPluginFactory.class, 900);
+          put(IamAuthConnectionPluginFactory.class, 1000);
+          put(AwsSecretsManagerConnectionPluginFactory.class, 1100);
+          put(LogQueryConnectionPluginFactory.class, 1200);
           put(ConnectTimeConnectionPluginFactory.class, WEIGHT_RELATIVE_TO_PRIOR_PLUGIN);
           put(ExecutionTimeConnectionPluginFactory.class, WEIGHT_RELATIVE_TO_PRIOR_PLUGIN);
           put(DeveloperConnectionPluginFactory.class, WEIGHT_RELATIVE_TO_PRIOR_PLUGIN);

--- a/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/ConnectionPluginManager.java
@@ -43,6 +43,7 @@ import software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPlugin;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPlugin;
 import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingPlugin;
 import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsPlugin;
+import software.amazon.jdbc.plugin.strategy.fastestresponse.FastestResponseStrategyPlugin;
 import software.amazon.jdbc.profile.ConfigurationProfile;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.SqlMethodAnalyzer;
@@ -75,6 +76,7 @@ public class ConnectionPluginManager implements CanReleaseResources, Wrapper {
           put(AwsSecretsManagerConnectionPlugin.class, "plugin:awsSecretsManager");
           put(AuroraStaleDnsPlugin.class, "plugin:auroraStaleDns");
           put(ReadWriteSplittingPlugin.class, "plugin:readWriteSplitting");
+          put(FastestResponseStrategyPlugin.class, "plugin:fastestResponseStrategy");
           put(DefaultConnectionPlugin.class, "plugin:targetDriver");
         }
       };

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -509,7 +509,7 @@ public class RdsHostListProvider implements DynamicHostListProvider {
         : this.hostListProviderService.getCurrentConnection();
 
     final FetchTopologyResult results = getTopology(currentConnection, false);
-    LOGGER.finest(() -> Utils.logTopology(results.hosts));
+    LOGGER.finest(() -> Utils.logTopology(results.hosts, results.isCachedData ? "[From cache] " : ""));
 
     this.hostList = results.hosts;
     return Collections.unmodifiableList(hostList);

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/AbstractConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/AbstractConnectionPlugin.java
@@ -76,7 +76,7 @@ public abstract class AbstractConnectionPlugin implements ConnectionPlugin {
 
   @Override
   public HostSpec getHostSpecByStrategy(final HostRole role, final String strategy)
-      throws UnsupportedOperationException {
+      throws SQLException, UnsupportedOperationException {
     throw new UnsupportedOperationException("getHostSpecByStrategy is not supported by this plugin.");
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm/HostMonitoringConnectionPlugin.java
@@ -82,7 +82,6 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
   protected @NonNull Properties properties;
   private final @NonNull Supplier<MonitorService> monitorServiceSupplier;
   private final @NonNull PluginService pluginService;
-  private final @NonNull TelemetryFactory telemetryFactory;
   private MonitorService monitorService;
   private final RdsUtils rdsHelper;
   private HostSpec monitoringHostSpec;
@@ -119,7 +118,6 @@ public class HostMonitoringConnectionPlugin extends AbstractConnectionPlugin
       throw new IllegalArgumentException("monitorServiceSupplier");
     }
     this.pluginService = pluginService;
-    this.telemetryFactory = pluginService.getTelemetryFactory();
     this.properties = properties;
     this.monitorServiceSupplier = monitorServiceSupplier;
     this.rdsHelper = rdsHelper;

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/FastestResponseStrategyPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/FastestResponseStrategyPlugin.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.strategy.fastestresponse;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.AwsWrapperProperty;
+import software.amazon.jdbc.HostRole;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.JdbcCallable;
+import software.amazon.jdbc.NodeChangeOptions;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.PropertyDefinition;
+import software.amazon.jdbc.RandomHostSelector;
+import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
+import software.amazon.jdbc.util.CacheMap;
+
+public class FastestResponseStrategyPlugin extends AbstractConnectionPlugin {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(FastestResponseStrategyPlugin.class.getName());
+
+  public static final String FASTEST_RESPONSE_STRATEGY_NAME = "fastestResponse";
+
+  private static final Set<String> subscribedMethods =
+      Collections.unmodifiableSet(new HashSet<String>() {
+        {
+          add("notifyNodeListChanged");
+          add("acceptsStrategy");
+          add("getHostSpecByStrategy");
+        }
+      });
+
+  public static final AwsWrapperProperty RESPONSE_MEASUREMENT_INTERVAL_MILLIS =
+      new AwsWrapperProperty(
+          "responseMeasurementIntervalMs",
+          "30000",
+          "Interval in millis between measuring response time to a database node.");
+
+  protected static final CacheMap<String, HostSpec> cachedFastestResponseHostByRole = new CacheMap<>();
+  protected static final RandomHostSelector randomHostSelector = new RandomHostSelector();
+
+  protected final @NonNull PluginService pluginService;
+  protected final @NonNull Properties properties;
+  protected final @NonNull HostResponseTimeService hostResponseTimeService;
+  protected long cacheExpirationNano;
+
+  protected List<HostSpec> hosts = new ArrayList<>();
+
+  static {
+    PropertyDefinition.registerPluginProperties(FastestResponseStrategyPlugin.class);
+    PropertyDefinition.registerPluginProperties("frt-");
+  }
+
+  public FastestResponseStrategyPlugin(final PluginService pluginService, final @NonNull Properties properties) {
+    this(pluginService,
+        properties,
+        new HostResponseTimeServiceImpl(
+            pluginService,
+            properties,
+            RESPONSE_MEASUREMENT_INTERVAL_MILLIS.getInteger(properties)));
+  }
+
+  public FastestResponseStrategyPlugin(
+      final PluginService pluginService,
+      final @NonNull Properties properties,
+      final @NonNull HostResponseTimeService hostResponseTimeService) {
+
+    this.pluginService = pluginService;
+    this.properties = properties;
+    this.hostResponseTimeService = hostResponseTimeService;
+    this.cacheExpirationNano = TimeUnit.MILLISECONDS.toNanos(
+        RESPONSE_MEASUREMENT_INTERVAL_MILLIS.getInteger(this.properties));
+  }
+
+  @Override
+  public Set<String> getSubscribedMethods() {
+    return subscribedMethods;
+  }
+
+  @Override
+  public Connection connect(
+      final String driverProtocol,
+      final HostSpec hostSpec,
+      final Properties props,
+      final boolean isInitialConnection,
+      final JdbcCallable<Connection, SQLException> connectFunc)
+      throws SQLException {
+
+    Connection conn = connectFunc.call();
+    if (isInitialConnection) {
+      this.hostResponseTimeService.setHosts(this.pluginService.getHosts());
+    }
+    return conn;
+  }
+
+  @Override
+  public Connection forceConnect(
+      final String driverProtocol,
+      final HostSpec hostSpec,
+      final Properties props,
+      final boolean isInitialConnection,
+      final JdbcCallable<Connection, SQLException> forceConnectFunc)
+      throws SQLException {
+
+    Connection conn = forceConnectFunc.call();
+    if (isInitialConnection) {
+      this.hostResponseTimeService.setHosts(this.pluginService.getHosts());
+    }
+    return conn;
+  }
+
+  @Override
+  public boolean acceptsStrategy(HostRole role, String strategy) {
+    return FASTEST_RESPONSE_STRATEGY_NAME.equalsIgnoreCase(strategy);
+  }
+
+  @Override
+  public HostSpec getHostSpecByStrategy(final HostRole role, final String strategy)
+      throws SQLException, UnsupportedOperationException {
+
+    if (!acceptsStrategy(role, strategy)) {
+      return null;
+    }
+
+    // The cache holds a host with the fastest response time.
+    // If cache doesn't have a host for a role, it's necessary to find the fastest node in the topology.
+    final HostSpec fastestResponseHost = cachedFastestResponseHostByRole.get(role.name());
+
+    if (fastestResponseHost != null) {
+      // Found a fastest host. Let find it in the the latest topology.
+      HostSpec foundHostSpec = this.pluginService.getHosts().stream()
+          .filter(x -> x.equals(fastestResponseHost))
+          .findAny()
+          .orElse(null);
+
+      if (foundHostSpec != null) {
+        // Found a host in the topology.
+        return foundHostSpec;
+      }
+
+      // It seems that the fastest cached host isn't in the latest topology.
+      // Let's ignore cached results and find the fastest host.
+    }
+
+    // Cached result isn't available. Need to find the fastest response time host.
+
+    final HostSpec calculatedFastestResponseHost = this.pluginService.getHosts().stream()
+        .filter(x -> role.equals(x.getRole()))
+        .map(x -> new ResponseTimeTuple(x, this.hostResponseTimeService.getResponseTime(x)))
+        .sorted(Comparator.comparingInt(x -> x.responseTime))
+        .map(x -> x.hostSpec)
+        .findFirst()
+        .orElse(null);
+
+    if (calculatedFastestResponseHost == null) {
+      // Unable to identify the fastest response host.
+      // As a last resort, let's use a random host selector.
+      return randomHostSelector.getHost(this.hosts, role, properties);
+    }
+
+    cachedFastestResponseHostByRole.put(role.name(), calculatedFastestResponseHost, this.cacheExpirationNano);
+
+    return calculatedFastestResponseHost;
+  }
+
+  @Override
+  public void notifyNodeListChanged(final Map<String, EnumSet<NodeChangeOptions>> changes) {
+    this.hosts = this.pluginService.getHosts();
+    this.hostResponseTimeService.setHosts(this.hosts);
+  }
+
+  private static class ResponseTimeTuple {
+    public HostSpec hostSpec;
+    public int responseTime;
+
+    public ResponseTimeTuple(final HostSpec hostSpec, int responseTime) {
+      this.hostSpec = hostSpec;
+      this.responseTime = responseTime;
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/FastestResponseStrategyPluginFactory.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/FastestResponseStrategyPluginFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.strategy.fastestresponse;
+
+import java.util.Properties;
+import software.amazon.jdbc.ConnectionPlugin;
+import software.amazon.jdbc.ConnectionPluginFactory;
+import software.amazon.jdbc.PluginService;
+
+public class FastestResponseStrategyPluginFactory implements ConnectionPluginFactory {
+
+  @Override
+  public ConnectionPlugin getInstance(final PluginService pluginService, final Properties props) {
+    return new FastestResponseStrategyPlugin(pluginService, props);
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/HostResponseTimeService.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/HostResponseTimeService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.strategy.fastestresponse;
+
+import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
+
+public interface HostResponseTimeService {
+
+  /**
+   * Return a response time in milliseconds to the host.
+   * Return Integer.MAX_VALUE if response time is not available.
+   *
+   * @param hostSpec the host details
+   * @return response time in milliseconds for a desired host. It should return Integer.MAX_VALUE if
+   *            response time couldn't be measured.
+   */
+  int getResponseTime(final HostSpec hostSpec);
+
+  /**
+   * Provides an updated host list to a service.
+   */
+  void setHosts(final @NonNull List<HostSpec> hosts);
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/HostResponseTimeServiceImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/HostResponseTimeServiceImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.strategy.fastestresponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.SlidingExpirationCacheWithCleanupThread;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryGauge;
+
+public class HostResponseTimeServiceImpl implements HostResponseTimeService {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(HostResponseTimeServiceImpl.class.getName());
+
+  protected static final long CACHE_EXPIRATION_NANO = TimeUnit.MINUTES.toNanos(10);
+  protected static final long CACHE_CLEANUP_NANO = TimeUnit.MINUTES.toNanos(1);
+
+  protected static final SlidingExpirationCacheWithCleanupThread<String, NodeResponseTimeMonitor> monitoringNodes
+      = new SlidingExpirationCacheWithCleanupThread<>(
+          (monitor) -> true,
+          (monitor) -> {
+            try {
+              monitor.close();
+            } catch (Exception ex) {
+              // ignore
+            }
+          },
+          CACHE_CLEANUP_NANO);
+  protected static final ReentrantLock cacheLock = new ReentrantLock();
+
+  protected int intervalMs;
+
+  protected List<HostSpec> hosts = new ArrayList<>();
+
+  protected final @NonNull PluginService pluginService;
+
+  protected final @NonNull Properties props;
+
+  protected final TelemetryFactory telemetryFactory;
+  private final TelemetryGauge nodeCountGauge;
+
+  public HostResponseTimeServiceImpl(
+      final @NonNull PluginService pluginService,
+      final @NonNull Properties props,
+      int intervalMs) {
+
+    this.pluginService = pluginService;
+    this.props = props;
+    this.intervalMs = intervalMs;
+    this.telemetryFactory = this.pluginService.getTelemetryFactory();
+    this.nodeCountGauge = telemetryFactory.createGauge("frt.nodes.count",
+        () -> (long) monitoringNodes.size());
+
+    monitoringNodes.setCleanupIntervalNanos(CACHE_CLEANUP_NANO);
+  }
+
+  @Override
+  public int getResponseTime(HostSpec hostSpec) {
+    final NodeResponseTimeMonitor monitor = monitoringNodes.get(hostSpec.getUrl(), CACHE_EXPIRATION_NANO);
+    if (monitor == null) {
+      return Integer.MAX_VALUE;
+    }
+
+    return monitor.getResponseTime();
+  }
+
+  @Override
+  public void setHosts(final @NonNull List<HostSpec> hosts) {
+    Set<String> oldHosts = this.hosts.stream().map(HostSpec::getUrl).collect(Collectors.toSet());
+    this.hosts = hosts;
+
+    // Going through all hosts in the topology and trying to find new ones.
+    this.hosts.stream()
+        // hostSpec is not in the set of hosts that already being monitored
+        .filter(hostSpec -> !oldHosts.contains(hostSpec.getUrl()))
+        .forEach(hostSpec -> {
+          cacheLock.lock();
+          try {
+            monitoringNodes.computeIfAbsent(
+                hostSpec.getUrl(),
+                (key) -> new NodeResponseTimeMonitor(this.pluginService, hostSpec, this.props, this.intervalMs),
+                CACHE_EXPIRATION_NANO);
+          } finally {
+            cacheLock.unlock();
+          }
+        });
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/NodeResponseTimeMonitor.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/strategy/fastestresponse/NodeResponseTimeMonitor.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.plugin.strategy.fastestresponse;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import software.amazon.jdbc.HostSpec;
+import software.amazon.jdbc.PluginService;
+import software.amazon.jdbc.util.Messages;
+import software.amazon.jdbc.util.PropertyUtils;
+import software.amazon.jdbc.util.StringUtils;
+import software.amazon.jdbc.util.telemetry.TelemetryContext;
+import software.amazon.jdbc.util.telemetry.TelemetryFactory;
+import software.amazon.jdbc.util.telemetry.TelemetryGauge;
+import software.amazon.jdbc.util.telemetry.TelemetryTraceLevel;
+
+public class NodeResponseTimeMonitor implements AutoCloseable, Runnable {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(NodeResponseTimeMonitor.class.getName());
+
+  private static final String MONITORING_PROPERTY_PREFIX = "frt-";
+  private static final int NUM_OF_MEASURES = 5;
+
+  private final int intervalMs;
+  private final @NonNull HostSpec hostSpec;
+
+  private final AtomicBoolean stopped = new AtomicBoolean(false);
+  private final AtomicInteger responseTime = new AtomicInteger(Integer.MAX_VALUE);
+  private final AtomicLong checkTimestamp = new AtomicLong(this.getCurrentTime());
+
+  private final @NonNull Properties props;
+  private final @NonNull PluginService pluginService;
+
+  private final TelemetryFactory telemetryFactory;
+  private final TelemetryGauge responseTimeMsGauge;
+
+
+  private Connection monitoringConn = null;
+
+  private final ExecutorService threadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
+    final Thread monitoringThread = new Thread(runnableTarget);
+    monitoringThread.setDaemon(true);
+    return monitoringThread;
+  });
+
+  public NodeResponseTimeMonitor(
+      final @NonNull PluginService pluginService,
+      final @NonNull HostSpec hostSpec,
+      final @NonNull Properties props,
+      int intervalMs) {
+
+    this.pluginService = pluginService;
+    this.hostSpec = hostSpec;
+    this.props = props;
+    this.intervalMs = intervalMs;
+    this.telemetryFactory = this.pluginService.getTelemetryFactory();
+
+    final String nodeId = StringUtils.isNullOrEmpty(this.hostSpec.getHostId())
+        ? this.hostSpec.getHost()
+        : this.hostSpec.getHostId();
+
+    // Report current response time (in milliseconds) to telemetry engine.
+    // Report -1 if response time couldn't be measured.
+    this.responseTimeMsGauge = telemetryFactory.createGauge(
+        String.format("frt.response.time.%s", nodeId),
+        () -> this.responseTime.get() == Integer.MAX_VALUE ? -1 : (long) this.responseTime.get());
+
+    this.threadPool.submit(this);
+    this.threadPool.shutdown(); // No more task are accepted by pool.
+  }
+
+  // Return node response time in milliseconds.
+  public int getResponseTime() {
+    return this.responseTime.get();
+  }
+
+  public long getCheckTimestamp() {
+    return this.checkTimestamp.get();
+  }
+
+  public HostSpec getHostSpec() {
+    return this.hostSpec;
+  }
+
+  @Override
+  public void close() throws Exception {
+    this.stopped.set(true);
+
+    // Waiting for 5s gives a thread enough time to exit monitoring loop and close database connection.
+    if (!this.threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+      this.threadPool.shutdownNow();
+    }
+    LOGGER.finest(() -> Messages.get(
+        "NodeResponseTimeMonitor.stopped",
+        new Object[] {this.hostSpec.getHost()}));
+  }
+
+  // The method is for testing purposes.
+  protected long getCurrentTime() {
+    return System.nanoTime();
+  }
+
+  @Override
+  public void run() {
+    TelemetryContext telemetryContext = telemetryFactory.openTelemetryContext(
+        "node response time thread", TelemetryTraceLevel.TOP_LEVEL);
+    telemetryContext.setAttribute("url", hostSpec.getUrl());
+
+    try {
+      while (!this.stopped.get()) {
+        this.openConnection();
+
+        if (this.monitoringConn != null) {
+
+          long responseTimeSum = 0;
+          int count = 0;
+          for (int i = 0; i < NUM_OF_MEASURES; i++) {
+            if (this.stopped.get()) {
+              break;
+            }
+            long startTime = this.getCurrentTime();
+            if (this.pluginService.getTargetDriverDialect().ping(this.monitoringConn)) {
+              long responseTime = this.getCurrentTime() - startTime;
+              responseTimeSum += responseTime;
+              count++;
+            }
+          }
+
+          if (count > 0) {
+            this.responseTime.set((int) TimeUnit.NANOSECONDS.toMillis(responseTimeSum / count));
+          } else {
+            this.responseTime.set(Integer.MAX_VALUE);
+          }
+          this.checkTimestamp.set(this.getCurrentTime());
+
+          LOGGER.finest(() -> Messages.get(
+              "NodeResponseTimeMonitor.responseTime",
+              new Object[] {this.hostSpec.getHost(), this.responseTime.get()}));
+        }
+
+        TimeUnit.MILLISECONDS.sleep(this.intervalMs);
+      }
+    } catch (final InterruptedException intEx) {
+      // exit thread
+      LOGGER.finest(
+          () -> Messages.get(
+              "NodeResponseTimeMonitor.interruptedExceptionDuringMonitoring",
+              new Object[] {this.hostSpec.getHost()}));
+    } catch (final Exception ex) {
+      // this should not be reached; log and exit thread
+      if (LOGGER.isLoggable(Level.FINEST)) {
+        LOGGER.log(
+            Level.FINEST,
+            Messages.get(
+                "NodeResponseTimeMonitor.exceptionDuringMonitoringStop",
+                new Object[]{this.hostSpec.getHost()}),
+            ex); // We want to print full trace stack of the exception.
+      }
+    } finally {
+      this.stopped.set(true);
+      if (this.monitoringConn != null) {
+        try {
+          this.monitoringConn.close();
+        } catch (final SQLException ex) {
+          // ignore
+        }
+      }
+      if (telemetryContext != null) {
+        telemetryContext.closeContext();
+      }
+    }
+  }
+
+  private void openConnection() {
+    try {
+      if (this.monitoringConn == null || this.monitoringConn.isClosed()) {
+        // open a new connection
+        final Properties monitoringConnProperties = PropertyUtils.copyProperties(this.props);
+
+        this.props.stringPropertyNames().stream()
+            .filter(p -> p.startsWith(MONITORING_PROPERTY_PREFIX))
+            .forEach(
+                p -> {
+                  monitoringConnProperties.put(
+                      p.substring(MONITORING_PROPERTY_PREFIX.length()),
+                      this.props.getProperty(p));
+                  monitoringConnProperties.remove(p);
+                });
+
+        LOGGER.finest(() -> Messages.get(
+                "NodeResponseTimeMonitor.openingConnection",
+                new Object[] {this.hostSpec.getUrl()}));
+        this.monitoringConn = this.pluginService.forceConnect(this.hostSpec, monitoringConnProperties);
+        LOGGER.finest(() -> Messages.get(
+            "NodeResponseTimeMonitor.openedConnection",
+            new Object[] {this.monitoringConn}));
+      }
+    } catch (SQLException ex) {
+      if (this.monitoringConn != null) {
+        try {
+          this.monitoringConn.close();
+        } catch (Exception e) {
+          // ignore
+        }
+        this.monitoringConn = null;
+      }
+    }
+  }
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/profile/DriverConfigurationProfiles.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/profile/DriverConfigurationProfiles.java
@@ -23,13 +23,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HikariPooledConnectionProvider;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.dialect.Dialect;
-import software.amazon.jdbc.exceptions.ExceptionHandler;
 import software.amazon.jdbc.plugin.AuroraConnectionTrackerPluginFactory;
 import software.amazon.jdbc.plugin.AuroraHostListConnectionPluginFactory;
 import software.amazon.jdbc.plugin.AuroraInitialConnectionStrategyPluginFactory;
@@ -38,7 +36,6 @@ import software.amazon.jdbc.plugin.efm.HostMonitoringConnectionPluginFactory;
 import software.amazon.jdbc.plugin.failover.FailoverConnectionPluginFactory;
 import software.amazon.jdbc.plugin.readwritesplitting.ReadWriteSplittingPluginFactory;
 import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsPluginFactory;
-import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
 
 public class DriverConfigurationProfiles {
 

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.targetdriverdialect;
 
 import static software.amazon.jdbc.util.ConnectionUrlBuilder.buildUrl;
 
+import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.Properties;
@@ -93,5 +94,14 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
 
   public void registerDriver() throws SQLException {
     throw new SQLException(Messages.get("TargetDriverDialect.unsupported"));
+  }
+
+  @Override
+  public boolean ping(@NonNull Connection connection) {
+    try {
+      return connection.isValid(10); // 10s
+    } catch (SQLException e) {
+      return false;
+    }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -16,8 +16,11 @@
 
 package software.amazon.jdbc.targetdriverdialect;
 
+import java.sql.Connection;
 import java.sql.Driver;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -87,5 +90,17 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
   public void registerDriver() throws SQLException {
     final MysqlConnectorJDriverHelper helper = new MysqlConnectorJDriverHelper();
     helper.registerDriver();
+  }
+
+  @Override
+  public boolean ping(@NonNull Connection connection) {
+    try {
+      try (final Statement statement = connection.createStatement();
+          final ResultSet resultSet = statement.executeQuery("/* ping */ SELECT 1")) {
+        return true;
+      }
+    } catch (SQLException e) {
+      return false;
+    }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -16,6 +16,7 @@
 
 package software.amazon.jdbc.targetdriverdialect;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
 import javax.sql.DataSource;
@@ -41,4 +42,15 @@ public interface TargetDriverDialect {
   boolean isDriverRegistered() throws SQLException;
 
   void registerDriver() throws SQLException;
+
+  /**
+   * Attempts to communicate to a database node in order to measure network latency.
+   * Some database protocols may not support the simplest "ping" packet. In this case,
+   * it's recommended to execute a simple connection validation, or the simplest SQL
+   * query like "SELECT 1".
+   *
+   * @param connection The database connection to a node to ping.
+   * @return True, if operation is succeeded. False, otherwise.
+   */
+  boolean ping(final @NonNull Connection connection);
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SlidingExpirationCacheWithCleanupThread.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+public class SlidingExpirationCacheWithCleanupThread<K, V> extends SlidingExpirationCache<K, V> {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(SlidingExpirationCacheWithCleanupThread.class.getName());
+
+  protected static final ExecutorService cleanupThreadPool = Executors.newFixedThreadPool(1, runnableTarget -> {
+    final Thread monitoringThread = new Thread(runnableTarget);
+    monitoringThread.setDaemon(true);
+    return monitoringThread;
+  });
+
+  public SlidingExpirationCacheWithCleanupThread() {
+    super();
+    this.initCleanupThread();
+  }
+
+  public SlidingExpirationCacheWithCleanupThread(
+      final ShouldDisposeFunc<V> shouldDisposeFunc,
+      final ItemDisposalFunc<V> itemDisposalFunc) {
+    super(shouldDisposeFunc, itemDisposalFunc);
+    this.initCleanupThread();
+  }
+
+  public SlidingExpirationCacheWithCleanupThread(
+      final ShouldDisposeFunc<V> shouldDisposeFunc,
+      final ItemDisposalFunc<V> itemDisposalFunc,
+      final long cleanupIntervalNanos) {
+    super(shouldDisposeFunc, itemDisposalFunc, cleanupIntervalNanos);
+    this.initCleanupThread();
+  }
+
+  protected void initCleanupThread() {
+    cleanupThreadPool.submit(() -> {
+      while (true) {
+        TimeUnit.NANOSECONDS.sleep(this.cleanupIntervalNanos);
+
+        LOGGER.finest("Cleaning up...");
+        this.cleanupTimeNanos.set(System.nanoTime() + cleanupIntervalNanos);
+        cache.forEach((key, value) -> {
+          try {
+            removeIfExpired(key);
+          } catch (Exception ex) {
+            // ignore
+          }
+        });
+      }
+    });
+    cleanupThreadPool.shutdown();
+  }
+
+  @Override
+  protected void cleanUp() {
+    // Intentionally do nothing. Cleanup thread does the job.
+  }
+}

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -277,3 +277,10 @@ MariadbDriverHelper.canNotRegister=Can''t register driver  org.mariadb.jdbc.Driv
 AuroraInitialConnectionStrategyPlugin.unsupportedStrategy=Unsupported host selection strategy ''{0}''.
 AuroraInitialConnectionStrategyPlugin.requireDynamicProvider=Dynamic host list provider is required.
 
+# Fastest Response Time Strategy Plugin
+NodeResponseTimeMonitor.stopped=Stopped Response time thread for node ''{0}''.
+NodeResponseTimeMonitor.responseTime=Response time for ''{0}'': {1} ms
+NodeResponseTimeMonitor.interruptedExceptionDuringMonitoring=Response time thread for node {0} was interrupted.
+NodeResponseTimeMonitor.exceptionDuringMonitoringStop=Stopping thread after unhandled exception was thrown in Response time thread for node {0}.
+NodeResponseTimeMonitor.openingConnection=Opening a Response time connection to ''{0}''.
+NodeResponseTimeMonitor.openedConnection=Opened Response time connection: {0}.


### PR DESCRIPTION
### Summary

Implement a new fastest response time strategy.

### Description

- Strategy is implemented as `FastestResponseStrategyPlugin`
- Node response time (milliseconds) is measured in a separate thread and is implemented in `NodeResponseTimeMonitor`. Configuration parameters for a database connection in that thread could be provided with a prefix `frt-` (similar to Host Monitoring Plugin).
- Node monitoring (measuring of response time) uses a sliding expiration approach. If it's not been called for a response time for 10 min, monitoring thread stops. When topology changes, new nodes will be added to monitoring.
- Thread reports current node response time to telemetry engine. Number of currently monitored nodes is reported as well.

### Additional Reviewers

@karenc-bq 
@aaron-congo 
@aaronchung-bitquill 
@brunos-bq 
@crystall-bitquill 

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.