### PR TITLE
fix: SqlMethodAnalyzer to handle empty SQL query and not throw IndexOutOfBoundsException

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/SqlMethodAnalyzer.java
@@ -47,7 +47,11 @@ public class SqlMethodAnalyzer {
   }
 
   private String getFirstSqlStatement(final String sql) {
-    String statement = parseMultiStatementQueries(sql).get(0);
+    List<String> statementList = parseMultiStatementQueries(sql);
+    if (statementList.isEmpty()) {
+      return sql;
+    }
+    String statement = statementList.get(0);
     statement = statement.toUpperCase();
     statement = statement.replaceAll("\\s*/\\*(.*?)\\*/\\s*", " ").trim();
     return statement;

--- a/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/SqlMethodAnalyzerTest.java
@@ -16,6 +16,7 @@
 
 package software.amazon.jdbc.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,6 +35,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 class SqlMethodAnalyzerTest {
+  private static final String EXECUTE_METHOD = "execute";
+  private static final String EMPTY_SQL = "";
 
   @Mock Connection conn;
 
@@ -68,6 +71,11 @@ class SqlMethodAnalyzerTest {
     assertEquals(expected, actual);
   }
 
+  @Test
+  void testOpenTransactionWithEmptySqlDoesNotThrow() {
+    assertDoesNotThrow(() -> sqlMethodAnalyzer.doesOpenTransaction(conn, EXECUTE_METHOD, new String[]{EMPTY_SQL}));
+  }
+
   @ParameterizedTest
   @MethodSource("closeTransactionQueries")
   void testCloseTransaction(final String methodName, final String sql, final boolean expected) {
@@ -80,6 +88,11 @@ class SqlMethodAnalyzerTest {
 
     final boolean actual = sqlMethodAnalyzer.doesCloseTransaction(conn, methodName, args);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void testCloseTransactionWithEmptySqlDoesNotThrow() {
+    assertDoesNotThrow(() -> sqlMethodAnalyzer.doesCloseTransaction(conn, EXECUTE_METHOD, new String[]{EMPTY_SQL}));
   }
 
   @Test
@@ -123,6 +136,11 @@ class SqlMethodAnalyzerTest {
     assertEquals(expected, actual);
   }
 
+  @Test
+  void testIsStatementSettingAutoCommitWithEmptySqlDoesNotThrow() {
+    assertDoesNotThrow(() -> sqlMethodAnalyzer.isStatementSettingAutoCommit(EXECUTE_METHOD, new String[]{EMPTY_SQL}));
+  }
+
   @ParameterizedTest
   @MethodSource("getAutoCommitQueries")
   void testGetAutoCommit(final String sql, final Boolean expected) {
@@ -135,6 +153,11 @@ class SqlMethodAnalyzerTest {
 
     final Boolean actual = sqlMethodAnalyzer.getAutoCommitValueFromSqlStatement(args);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetAutoCommitWithEmptySqlDoesNotThrow() {
+    assertDoesNotThrow(() -> sqlMethodAnalyzer.getAutoCommitValueFromSqlStatement(new String[]{EMPTY_SQL}));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
…utOfBoundsException

### Summary

<!--- General summary / title -->

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.