### PR TITLE
fix: add update candidates for the maria db dialect; fix rds mysql dialect incorrectly returning false in isDialect method

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/MariaDbDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/MariaDbDialect.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -29,7 +30,11 @@ import software.amazon.jdbc.exceptions.MariaDBExceptionHandler;
 import software.amazon.jdbc.hostlistprovider.ConnectionStringHostListProvider;
 
 public class MariaDbDialect implements Dialect {
-
+  private static final List<String> dialectUpdateCandidates = Arrays.asList(
+      DialectCodes.AURORA_MYSQL,
+      DialectCodes.RDS_MULTI_AZ_MYSQL_CLUSTER,
+      DialectCodes.RDS_MYSQL,
+      DialectCodes.MYSQL);
   private static MariaDBExceptionHandler mariaDBExceptionHandler;
 
   @Override
@@ -91,7 +96,7 @@ public class MariaDbDialect implements Dialect {
 
   @Override
   public List<String> getDialectUpdateCandidates() {
-    return null;
+    return dialectUpdateCandidates;
   }
 
   public HostListProviderSupplier getHostListProvider() {

--- a/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMysqlDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/dialect/RdsMysqlDialect.java
@@ -30,7 +30,17 @@ public class RdsMysqlDialect extends MysqlDialect {
 
   @Override
   public boolean isDialect(final Connection connection) {
-    if (!super.isDialect(connection)) {
+    if (super.isDialect(connection)) {
+      // MysqlDialect and RdsMysqlDialect use the same server version query to determine the dialect.
+      // The `SHOW VARIABLES LIKE 'version_comment'` either outputs
+      // | Variable_name   | value                        |
+      // |-----------------|------------------------------|
+      // | version_comment | MySQL Community Server (GPL) |
+      // for community Mysql, or
+      // | Variable_name   | value               |
+      // |-----------------|---------------------|
+      // | version_comment | Source distribution |
+      // for RDS MySQL. If super.idDialect returns true there is no need to check for RdsMysqlDialect.
       return false;
     }
     Statement stmt = null;

--- a/wrapper/src/test/java/integration/util/ContainerHelper.java
+++ b/wrapper/src/test/java/integration/util/ContainerHelper.java
@@ -50,7 +50,7 @@ import software.amazon.jdbc.util.StringUtils;
 
 public class ContainerHelper {
 
-  private static final String MYSQL_CONTAINER_IMAGE_NAME = "mysql:latest";
+  private static final String MYSQL_CONTAINER_IMAGE_NAME = "mysql:8.0.36";
   private static final String POSTGRES_CONTAINER_IMAGE_NAME = "postgres:latest";
   private static final String MARIADB_CONTAINER_IMAGE_NAME = "mariadb:10";
   private static final DockerImageName TOXIPROXY_IMAGE =

--- a/wrapper/src/test/java/software/amazon/jdbc/DialectDetectionTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/DialectDetectionTests.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.jdbc.dialect.AuroraMysqlDialect;
+import software.amazon.jdbc.dialect.AuroraPgDialect;
+import software.amazon.jdbc.dialect.Dialect;
+import software.amazon.jdbc.dialect.DialectManager;
+import software.amazon.jdbc.dialect.MariaDbDialect;
+import software.amazon.jdbc.dialect.MysqlDialect;
+import software.amazon.jdbc.dialect.PgDialect;
+import software.amazon.jdbc.dialect.RdsMultiAzDbClusterMysqlDialect;
+import software.amazon.jdbc.dialect.RdsMultiAzDbClusterPgDialect;
+import software.amazon.jdbc.dialect.RdsMysqlDialect;
+import software.amazon.jdbc.dialect.RdsPgDialect;
+import software.amazon.jdbc.exceptions.ExceptionManager;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
+
+public class DialectDetectionTests {
+  private static final String LOCALHOST = "localhost";
+  private static final String RDS_DATABASE = "database-1.xyz.us-east-2.rds.amazonaws.com";
+  private static final String RDS_AURORA_DATABASE = "database-2.cluster-xyz.us-east-2.rds.amazonaws.com";
+  private static final String MYSQL_PROTOCOL = "jdbc:mysql://";
+  private static final String PG_PROTOCOL = "jdbc:postgresql://";
+  private static final String MARIA_PROTOCOL = "jdbc:mariadb://";
+  @Mock private Connection mockConnection;
+  @Mock private Statement mockStatement;
+  @Mock private ResultSet successResultSet;
+  @Mock private ResultSet failResultSet;
+  @Mock private HostSpec mockHost;
+  @Mock private ConnectionPluginManager pluginManager;
+  @Mock private TargetDriverDialect mockTargetDriverDialect;
+  @Mock private ResultSetMetaData mockResultSetMetaData;
+  private final DialectManager dialectManager = new DialectManager(null);
+  private final Properties props = new Properties();
+  private AutoCloseable closeable;
+
+  @BeforeEach
+  void setUp() throws SQLException {
+    closeable = MockitoAnnotations.openMocks(this);
+    when(this.mockConnection.createStatement()).thenReturn(this.mockStatement);
+    when(this.mockHost.getUrl()).thenReturn("url");
+    when(this.failResultSet.next()).thenReturn(false);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+  }
+
+  @AfterEach
+  void cleanUp() throws Exception {
+    closeable.close();
+    DialectManager.resetEndpointCache();
+  }
+
+  PluginServiceImpl getPluginService(String host, String protocol) throws SQLException {
+    return spy(
+        new PluginServiceImpl(
+            pluginManager,
+            new ExceptionManager(),
+            props,
+            host,
+            protocol,
+            null,
+            mockTargetDriverDialect,
+            null,
+            null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getInitialDialectArguments")
+  public void testInitialDialectDetection(String protocol, String host, Object expectedDialect) throws SQLException {
+    final Dialect dialect = dialectManager.getDialect(protocol, host, new Properties());
+    assertEquals(expectedDialect, dialect.getClass());
+  }
+
+  static Stream<Arguments> getInitialDialectArguments() {
+    return Stream.of(
+        Arguments.of(MYSQL_PROTOCOL, LOCALHOST, MysqlDialect.class),
+        Arguments.of(MYSQL_PROTOCOL, RDS_DATABASE, RdsMysqlDialect.class),
+        Arguments.of(MYSQL_PROTOCOL, RDS_AURORA_DATABASE, AuroraMysqlDialect.class),
+        Arguments.of(PG_PROTOCOL, LOCALHOST, PgDialect.class),
+        Arguments.of(PG_PROTOCOL, RDS_DATABASE, RdsPgDialect.class),
+        Arguments.of(PG_PROTOCOL, RDS_AURORA_DATABASE, AuroraPgDialect.class),
+        Arguments.of(MARIA_PROTOCOL, LOCALHOST, MariaDbDialect.class),
+        Arguments.of(MARIA_PROTOCOL, RDS_DATABASE, MariaDbDialect.class),
+        Arguments.of(MARIA_PROTOCOL, RDS_AURORA_DATABASE, MariaDbDialect.class)
+    );
+  }
+
+  @Test
+  void testUpdateDialectMysqlUnchanged() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MYSQL_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(MysqlDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMysqlToRds() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    when(mockStatement.executeQuery("SHOW VARIABLES LIKE 'version_comment'")).thenReturn(successResultSet);
+    when(successResultSet.getString(1)).thenReturn("Source distribution");
+    when(successResultSet.next()).thenReturn(true, false, true, false);
+    when(successResultSet.getMetaData()).thenReturn(mockResultSetMetaData);
+    when(failResultSet.next()).thenReturn(false);
+    when(mockResultSetMetaData.getColumnCount()).thenReturn(1);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MYSQL_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(RdsMysqlDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMysqlToTaz() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet, successResultSet);
+    when(successResultSet.next()).thenReturn(true);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MYSQL_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(RdsMultiAzDbClusterMysqlDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMysqlToAurora() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    when(mockStatement.executeQuery("SHOW VARIABLES LIKE 'aurora_version'")).thenReturn(successResultSet);
+    when(successResultSet.next()).thenReturn(true, false);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MYSQL_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(AuroraMysqlDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectPgUnchanged() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, PG_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(PgDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectPgToRds() throws SQLException {
+    when(mockStatement.executeQuery(any()))
+        .thenReturn(successResultSet, failResultSet, failResultSet, successResultSet);
+    when(successResultSet.getBoolean(any())).thenReturn(false);
+    when(successResultSet.getBoolean("rds_tools")).thenReturn(true);
+    when(successResultSet.getBoolean("aurora_stat_utils")).thenReturn(false);
+    when(successResultSet.next()).thenReturn(true);
+    when(failResultSet.next()).thenReturn(false);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, PG_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(RdsPgDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectPgToTaz() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(successResultSet);
+    when(successResultSet.getBoolean(any())).thenReturn(false);
+    when(successResultSet.next()).thenReturn(true);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, PG_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(RdsMultiAzDbClusterPgDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectPgToAurora() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(successResultSet);
+    when(successResultSet.next()).thenReturn(true);
+    when(successResultSet.getBoolean(any())).thenReturn(true);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, PG_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(AuroraPgDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMariaUnchanged() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MARIA_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(MariaDbDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMariaToMysqlRds() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    when(mockStatement.executeQuery("SHOW VARIABLES LIKE 'version_comment'")).thenReturn(successResultSet);
+    when(successResultSet.getString(1)).thenReturn("Source distribution");
+    when(successResultSet.next()).thenReturn(true, false, true, false);
+    when(successResultSet.getMetaData()).thenReturn(mockResultSetMetaData);
+    when(failResultSet.next()).thenReturn(false);
+    when(mockResultSetMetaData.getColumnCount()).thenReturn(1);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MARIA_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(RdsMysqlDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMariaToMysqlTaz() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet, successResultSet);
+    when(successResultSet.next()).thenReturn(true);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MARIA_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(RdsMultiAzDbClusterMysqlDialect.class, target.dialect.getClass());
+  }
+
+  @Test
+  void testUpdateDialectMariaToMysqlAurora() throws SQLException {
+    when(mockStatement.executeQuery(any())).thenReturn(failResultSet);
+    when(mockStatement.executeQuery("SHOW VARIABLES LIKE 'aurora_version'")).thenReturn(successResultSet);
+    when(successResultSet.next()).thenReturn(true, false);
+    final PluginServiceImpl target = getPluginService(LOCALHOST, MARIA_PROTOCOL);
+    target.setInitialConnectionHostSpec(mockHost);
+    target.updateDialect(mockConnection);
+    assertEquals(AuroraMysqlDialect.class, target.dialect.getClass());
+  }
+}


### PR DESCRIPTION
### Summary

Add update candidates for the MariaDB dialect and fix the RDS MySQL dialect incorrectly returning false in the isDialect method

### Description

- Added update candidates for the MariaDB dialect in order to swap to MySQL dialects in the case of using a MySQL database with the protocol `jdbc:aws-wrapper:mariadb://`.
- Fixed the isDialect method of the RDS MySQL dialect. The method would return false if the MySQL dialect `isDialect` method also returned false. The MySQL isDialect method depends on whether the `version_comment` variable contains the value `mysql` but the RDS MySQL isDialect methods depends on whether the `version_comment` variable is equal to `Source distribution`.

Related to #789 
### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.