### PR TITLE
chore: re-add java.sql.Driver service to wrapper jar task

### DIFF
--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -215,6 +215,14 @@ tasks.jar {
             """
         )
     }
+
+    doFirst {
+        mkdir("${buildDir}/META-INF/services/")
+        val driverFile = File("${buildDir}/META-INF/services/java.sql.Driver")
+        if (driverFile.createNewFile()) {
+            driverFile.writeText("software.amazon.jdbc.Driver")
+        }
+    }
 }
 
 junitHtmlReport {


### PR DESCRIPTION
### Summary

chore: re-add java.sql.Driver service to wrapper jar task

### Description

chore: re-add java.sql.Driver service to wrapper jar task

This is to address that gradle `build` task did not include the java.sql.Driver service, despite the publish task doing so. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.