### PR TITLE
fix: statement cancel not working with mysql driver

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/AsynchronousMethodsHelper.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/AsynchronousMethodsHelper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.jdbc.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AsynchronousMethodsHelper {
+  public static final List<String> ASYNCHRONOUS_METHODS = Arrays.asList(
+      "Statement.cancel",
+      "PreparedStatement.cancel"
+  );
+}

--- a/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/WrapperUtils.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.jdbc.ConnectionPluginManager;
 import software.amazon.jdbc.JdbcCallable;
@@ -83,6 +84,8 @@ public class WrapperUtils {
       new ConcurrentHashMap<>();
   private static final ConcurrentMap<Class<?>, Boolean> isJdbcInterfaceCache =
       new ConcurrentHashMap<>();
+
+  private static final ReentrantLock lock = new ReentrantLock();
 
   private static final Map<Class<?>, Class<?>> availableWrappers =
       new HashMap<Class<?>, Class<?>>() {
@@ -182,7 +185,9 @@ public class WrapperUtils {
       final JdbcCallable<T, RuntimeException> jdbcMethodFunc,
       final Object... jdbcMethodArgs) {
 
-    pluginManager.lock();
+    if (!AsynchronousMethodsHelper.ASYNCHRONOUS_METHODS.contains(methodName)) {
+      lock.lock();
+    }
     TelemetryFactory telemetryFactory = pluginManager.getTelemetryFactory();
     TelemetryContext context = null;
 
@@ -208,7 +213,9 @@ public class WrapperUtils {
         throw new RuntimeException(e);
       }
     } finally {
-      pluginManager.unlock();
+      if (lock.isHeldByCurrentThread()) {
+        lock.unlock();
+      }
       if (context != null) {
         context.closeContext();
       }
@@ -225,7 +232,9 @@ public class WrapperUtils {
       final Object... jdbcMethodArgs)
       throws E {
 
-    pluginManager.lock();
+    if (!AsynchronousMethodsHelper.ASYNCHRONOUS_METHODS.contains(methodName)) {
+      lock.lock();
+    }
     TelemetryFactory telemetryFactory = pluginManager.getTelemetryFactory();
     TelemetryContext context = null;
 
@@ -251,7 +260,9 @@ public class WrapperUtils {
       }
 
     } finally {
-      pluginManager.unlock();
+      if (lock.isHeldByCurrentThread()) {
+        lock.unlock();
+      }
       if (context != null) {
         context.closeContext();
       }

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -90,7 +90,7 @@ ConnectionStringHostListProvider.errorIdentifyConnection=An error occurred while
 ConnectionPluginManager.releaseResources=Releasing resources.
 ConnectionPluginManager.unknownPluginCode=Unknown plugin code: ''{0}''.
 ConnectionPluginManager.unableToLoadPlugin=Unable to load connection plugin factory: ''{0}''.
-ConnectionPluginManager.methodInvokedAgainstOldConnection=The internal connection has changed since ''{0}'' was created. This is likely due to failover or read-write splitting functionality. To ensure you are using the updated connection, please re-create Statement and ResultSet objects after failover and/or calling setReadOnly.
+ConnectionPluginManager.invokedAgainstOldConnection=The internal connection has changed since ''{0}'' was created. This is likely due to failover or read-write splitting functionality. To ensure you are using the updated connection, please re-create Statement and ResultSet objects after failover and/or calling setReadOnly.
 
 # Connection Provider
 ConnectionProvider.noConnection=The target driver did not return a connection.


### PR DESCRIPTION
### Summary

Statement cancel not working with MySQL driver

### Description

The Statement.cancel method currently does not function with the MySQL community driver due to locking the ConnectionPluginManager. The MySQL driver also synchronizes on the Statement.getConnection method, which blocks any Statement.cancel executions. This PR moves the lock location and skips executing Statement.getConnection when running Statement.cancel.

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.