### PR TITLE
refactor: reduce regex checks to improve performance

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/RdsUtils.java
@@ -18,6 +18,7 @@ package software.amazon.jdbc.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -111,8 +112,8 @@ public class RdsUtils {
           "^(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,5})?)"
               + "::(([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,5})?)$");
 
-  private static final Map<String, Matcher> cachedPatterns = new HashMap<>();
-  private static final Map<String, String> cachedDnsPatterns = new HashMap<>();
+  private static final Map<String, Matcher> cachedPatterns = new ConcurrentHashMap<>();
+  private static final Map<String, String> cachedDnsPatterns = new ConcurrentHashMap<>();
 
   private static final String INSTANCE_GROUP = "instance";
   private static final String DNS_GROUP = "dns";

--- a/wrapper/src/test/java/integration/container/TestDriverProvider.java
+++ b/wrapper/src/test/java/integration/container/TestDriverProvider.java
@@ -57,6 +57,7 @@ import software.amazon.jdbc.dialect.DialectManager;
 import software.amazon.jdbc.plugin.efm.MonitorThreadContainer;
 import software.amazon.jdbc.plugin.efm2.MonitorServiceImpl;
 import software.amazon.jdbc.targetdriverdialect.TargetDriverDialectManager;
+import software.amazon.jdbc.util.RdsUtils;
 
 public class TestDriverProvider implements TestTemplateInvocationContextProvider {
   private static final Logger LOGGER = Logger.getLogger(TestDriverProvider.class.getName());
@@ -216,6 +217,8 @@ public class TestDriverProvider implements TestTemplateInvocationContextProvider
                   TargetDriverDialectManager.resetCustomDialect();
                   MonitorThreadContainer.releaseInstance();
                   MonitorServiceImpl.clearCache();
+                  software.amazon.jdbc.plugin.efm2.MonitorServiceImpl.clearCache();
+                  RdsUtils.clearCache();
                 }
                 if (tracesEnabled) {
                     AWSXRay.endSegment();

--- a/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/RdsUtilsTests.java
@@ -72,6 +72,7 @@ public class RdsUtilsTests {
 
   @BeforeEach
   public void setupTests() {
+    RdsUtils.clearCache();
     target = new RdsUtils();
   }
 


### PR DESCRIPTION
### Summary

Reduce number of calls to Matcher.find to improve performance.

### Description

Baseline performance:
![image](https://github.com/awslabs/aws-advanced-jdbc-wrapper/assets/64801825/e99d1e29-d35f-4b07-82a7-aec0e45e2f4c)
Identifying the cluster type takes longer than executing statements.
After the refactoring:
![image](https://github.com/awslabs/aws-advanced-jdbc-wrapper/assets/64801825/4cc46d65-7d9b-48b3-9332-8258c88d5a0c)

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.