### PR TITLE
fix: change EFM2 MonitorImpl to use ConcurrentHashMap instead of Hash…

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/MonitorImpl.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/efm2/MonitorImpl.java
@@ -20,10 +20,11 @@ import java.lang.ref.WeakReference;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -58,7 +59,8 @@ public class MonitorImpl implements Monitor {
   protected static final Executor ABORT_EXECUTOR = Executors.newSingleThreadExecutor();
 
   private final Queue<WeakReference<MonitorConnectionContext>> activeContexts = new ConcurrentLinkedQueue<>();
-  private final HashMap<Long, Queue<WeakReference<MonitorConnectionContext>>> newContexts = new HashMap<>();
+  private final Map<Long, Queue<WeakReference<MonitorConnectionContext>>> newContexts =
+      new ConcurrentHashMap<>();
   private final PluginService pluginService;
   private final TelemetryFactory telemetryFactory;
   private final Properties properties;


### PR DESCRIPTION
…Map to address ConcurrentModificationException

### Summary

fix: change EFM2 MonitorImpl to use ConcurrentHashMap instead of HashMap to address ConcurrentModificationException.

Addresses issue https://github.com/awslabs/aws-advanced-jdbc-wrapper/issues/855

### Description

fix: change EFM2 MonitorImpl to use ConcurrentHashMap instead of HashMap to address ConcurrentModificationException

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.