### PR TITLE
feat: HostSpec to not default lastUpdateTime. Handle null lastUpdateTime in RdsHostListProvider

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/HostSpecBuilder.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/HostSpecBuilder.java
@@ -89,7 +89,6 @@ public class HostSpecBuilder {
 
   public HostSpec build() {
     checkHostIsSet();
-    setDefaultLastUpdateTime();
     return new HostSpec(this.host, this.port, this.hostId, this.role, this.availability,
         this.weight, this.lastUpdateTime, this.hostAvailabilityStrategy);
   }
@@ -97,12 +96,6 @@ public class HostSpecBuilder {
   private void checkHostIsSet() {
     if (this.host == null) {
       throw new IllegalArgumentException("host parameter must be set.");
-    }
-  }
-
-  private void setDefaultLastUpdateTime() {
-    if (this.lastUpdateTime == null) {
-      this.lastUpdateTime = Timestamp.from(Instant.now());
     }
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/RdsHostListProvider.java
@@ -404,7 +404,7 @@ public class RdsHostListProvider implements DynamicHostListProvider {
     } else {
       // Take the latest updated writer node as the current writer. All others will be ignored.
       List<HostSpec> sortedWriters = writers.stream()
-          .sorted(Comparator.comparing(HostSpec::getLastUpdateTime).reversed())
+          .sorted(Comparator.comparing(HostSpec::getLastUpdateTime, Comparator.nullsLast(Comparator.reverseOrder())))
           .collect(Collectors.toList());
       hosts.add(sortedWriters.get(0));
     }


### PR DESCRIPTION
### Summary

feat: HostSpec to not default lastUpdateTime. Handle null lastUpdateTime in RdsHostListProvider

### Description

No more defaultLastUpdateTime in the HostSpecBuilder (previously it would default if lastUpdateTime was `null`).
In the `RdsHostListProvider#processQueryResults` where it sorts writer hosts based on `lastUpdateTime`, it handles null `lastUpdateTime` values by sorting/deprioritizing them to last. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.