### PR TITLE
chore: target driver dialect in closed connections

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -417,9 +417,6 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
    */
   private boolean allowedOnClosedConnection(final String methodName) {
     TargetDriverDialect dialect = this.pluginService.getTargetDriverDialect();
-    if (dialect == null) {
-      return false;
-    }
     return dialect.getAllowedOnConnectionMethodNames().contains(methodName);
   }
 

--- a/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/plugin/failover/FailoverConnectionPlugin.java
@@ -42,6 +42,7 @@ import software.amazon.jdbc.PropertyDefinition;
 import software.amazon.jdbc.hostavailability.HostAvailability;
 import software.amazon.jdbc.plugin.AbstractConnectionPlugin;
 import software.amazon.jdbc.plugin.staledns.AuroraStaleDnsHelper;
+import software.amazon.jdbc.targetdriverdialect.TargetDriverDialect;
 import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.RdsUrlType;
 import software.amazon.jdbc.util.RdsUtils;
@@ -76,10 +77,6 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
         }
       });
 
-  private static final String METHOD_GET_AUTO_COMMIT = "Connection.getAutoCommit";
-  private static final String METHOD_GET_CATALOG = "Connection.getCatalog";
-  private static final String METHOD_GET_SCHEMA = "Connection.getSchema";
-  private static final String METHOD_GET_TRANSACTION_ISOLATION = "Connection.getTransactionIsolation";
   static final String METHOD_ABORT = "Connection.abort";
   static final String METHOD_CLOSE = "Connection.close";
   static final String METHOD_IS_CLOSED = "Connection.isClosed";
@@ -419,11 +416,11 @@ public class FailoverConnectionPlugin extends AbstractConnectionPlugin {
    * @return true if the given method is allowed on closed connections
    */
   private boolean allowedOnClosedConnection(final String methodName) {
-    // TODO: consider to use target driver dialect
-    return methodName.equals(METHOD_GET_AUTO_COMMIT)
-        || methodName.equals(METHOD_GET_CATALOG)
-        || methodName.equals(METHOD_GET_SCHEMA)
-        || methodName.equals(METHOD_GET_TRANSACTION_ISOLATION);
+    TargetDriverDialect dialect = this.pluginService.getTargetDriverDialect();
+    if (dialect == null) {
+      return false;
+    }
+    return dialect.getAllowedOnConnectionMethodNames().contains(methodName);
   }
 
   /**

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -39,6 +39,14 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
 
   private static final Logger LOGGER =
       Logger.getLogger(GenericTargetDriverDialect.class.getName());
+  public static final List<String> ALLOWED_ON_CLOSED_METHODS = Arrays.asList(
+      "Connection.isClosed",
+      "Statement.getConnection",
+      "Statement.getFetchDirection",
+      "Statement.getResultSetHoldability",
+      "Statement.isClosed",
+      "Statement.getLargeMaxRows"
+  );
   public static final String CONN_GET_AUTO_COMMIT = "Connection.getAutoCommit";
   public static final String CONN_GET_CATALOG = "Connection.getCatalog";
   public static final String CONN_GET_SCHEMA = "Connection.getSchema";
@@ -96,14 +104,6 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   public static final String CALL_WAS_NULL = "CallableStatement.wasNull";
   public static final String PREP_ADD_BATCH = "PreparedStatement.addBatch";
   public static final String PREP_CLEAR_PARAMS = "PreparedStatement.clearParameters";
-  public static final List<String> COMMON_CLOSED_METHODS = Arrays.asList(
-      "Connection.isClosed",
-      "Statement.getConnection",
-      "Statement.getFetchDirection",
-      "Statement.getResultSetHoldability",
-      "Statement.isClosed",
-      "Statement.getLargeMaxRows"
-  );
 
   @Override
   public boolean isDialect(Driver driver) {
@@ -179,7 +179,7 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
-        addAll(COMMON_CLOSED_METHODS);
+        addAll(ALLOWED_ON_CLOSED_METHODS);
       }
     });
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -21,7 +21,10 @@ import static software.amazon.jdbc.util.ConnectionUrlBuilder.buildUrl;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -34,6 +37,70 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
 
   private static final Logger LOGGER =
       Logger.getLogger(GenericTargetDriverDialect.class.getName());
+  public static final String CONN_GET_AUTO_COMMIT = "Connection.getAutoCommit";
+  public static final String CONN_GET_CATALOG = "Connection.getCatalog";
+  public static final String CONN_GET_SCHEMA = "Connection.getSchema";
+  public static final String CONN_GET_TRANSACTION_ISOLATION = "Connection.getTransactionIsolation";
+  public static final String CONN_GET_NETWORK_TIMEOUT = "Connection.getNetworkTimeout";
+  public static final String CONN_GET_METADATA = "Connection.getMetaData";
+  public static final String CONN_IS_READ_ONLY = "Connection.isReadOnly";
+  public static final String CONN_GET_HOLDABILITY = "Connection.getHoldability";
+  public static final String CONN_GET_CLIENT_INFO = "Connection.getClientInfo";
+  public static final String CONN_GET_TYPE_MAP = "Connection.getTypeMap";
+  public static final String CONN_CREATE_CLOB = "Connection.createClob";
+  public static final String CONN_CREATE_BLOB = "Connection.createBlob";
+  public static final String CONN_CREATE_NCLOB = "Connection.createNClob";
+  public static final String CONN_IS_CLOSED = "Connection.isClosed";
+  public static final String CONN_CLEAR_WARNINGS = "Connection.clearWarnings";
+  public static final String CONN_SET_HOLDABILITY = "Connection.setHoldability";
+  public static final String CONN_SET_SCHEMA = "Connection.setSchema";
+  public static final String STATEMENT_CLEAR_WARNINGS = "Statement.clearWarnings";
+  public static final String STATEMENT_GET_CONNECTION = "Statement.getConnection";
+  public static final String STATEMENT_GET_FETCH_DIRECTION = "Statement.getFetchDirection";
+  public static final String STATEMENT_GET_FETCH_SIZE = "Statement.getFetchSize";
+  public static final String STATEMENT_GET_MAX_FIELD_SIZE = "Statement.getMaxFieldSize";
+  public static final String STATEMENT_GET_RESULT_SET_HOLDABILITY = "Statement.getResultSetHoldability";
+  public static final String STATEMENT_GET_RESULT_SET_TYPE = "Statement.getResultSetType";
+  public static final String STATEMENT_IS_CLOSED = "Statement.isClosed";
+  public static final String STATEMENT_IS_CLOSE_ON_COMPLETION = "Statement.isCloseOnCompletion";
+  public static final String STATEMENT_CLEAR_BATCH = "Statement.clearBatch";
+  public static final String STATEMENT_CLOSE_ON_COMPLETION = "Statement.closeOnCompletion";
+  public static final String STATEMENT_GET_LARGE_MAX_ROWS = "Statement.getLargeMaxRows";
+  public static final String STATEMENT_GET_GENERATED_KEYS = "Statement.getGeneratedKeys";
+  public static final String STATEMENT_GET_MAX_ROWS = "Statement.getMaxRows";
+  public static final String STATEMENT_GET_MORE_RESULTS = "Statement.getMoreResults";
+  public static final String STATEMENT_GET_QUERY_TIMEOUT = "Statement.getQueryTimeout";
+  public static final String STATEMENT_GET_RESULT_SET = "Statement.getResultSet";
+  public static final String STATEMENT_GET_RESULT_SET_CONCURRENCY = "Statement.getResultSetConcurrency";
+  public static final String STATEMENT_GET_UPDATE_COUNT = "Statement.getUpdateCount";
+  public static final String STATEMENT_GET_WARNINGS = "Statement.getWarnings";
+  public static final String STATEMENT_ADD_BATCH = "Statement.addBatch";
+  public static final String CALL_GET_ARRAY = "CallableStatement.getArray";
+  public static final String CALL_GET_BIG_DECIMAL = "CallableStatement.getBigDecimal";
+  public static final String CALL_GET_BLOB = "CallableStatement.getBlob";
+  public static final String CALL_GET_BOOLEAN = "CallableStatement.getBoolean";
+  public static final String CALL_GET_BYTE = "CallableStatement.getByte";
+  public static final String CALL_GET_BYTES = "CallableStatement.getBytes";
+  public static final String CALL_GET_CHARACTER_STREAM = "CallableStatement.getCharacterStream";
+  public static final String CALL_GET_CLOB = "CallableStatement.getClob";
+  public static final String CALL_GET_DATE = "CallableStatement.getDate";
+  public static final String CALL_GET_DOUBLE = "CallableStatement.getDouble";
+  public static final String CALL_GET_FLOAT = "CallableStatement.getFloat";
+  public static final String CALL_GET_INT = "CallableStatement.getInt";
+  public static final String CALL_GET_LONG = "CallableStatement.getLong";
+  public static final String CALL_GET_N_CLOB = "CallableStatement.getNClob";
+  public static final String CALL_GET_N_CHAR = "CallableStatement.getNCharacterStream";
+  public static final String CALL_GET_N_STRING = "CallableStatement.getNString";
+  public static final String CALL_GET_OBJECT = "CallableStatement.getObject";
+  public static final String CALL_GET_SHORT = "CallableStatement.getShort";
+  public static final String CALL_GET_SQLXML = "CallableStatement.getSQLXML";
+  public static final String CALL_GET_TIME = "CallableStatement.getTime";
+  public static final String CALL_GET_STRING = "CallableStatement.getString";
+  public static final String CALL_GET_TIMESTAMP = "CallableStatement.getTimestamp";
+  public static final String CALL_GET_URL = "CallableStatement.getURL";
+  public static final String CALL_WAS_NULL = "CallableStatement.wasNull";
+  public static final String PREP_ADD_BATCH = "PreparedStatement.addBatch";
+  public static final String PREP_CLEAR_PARAMS = "PreparedStatement.clearParameters";
 
   @Override
   public boolean isDialect(Driver driver) {
@@ -103,5 +170,17 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
     } catch (SQLException e) {
       return false;
     }
+  }
+
+  @Override
+  public Set<String> getAllowedOnConnectionMethodNames() {
+    return Collections.unmodifiableSet(new HashSet<String>() {
+      {
+        add(CONN_GET_SCHEMA);
+        add(CONN_GET_CATALOG);
+        add(CONN_GET_AUTO_COMMIT);
+        add(CONN_GET_TRANSACTION_ISOLATION);
+      }
+    });
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/GenericTargetDriverDialect.java
@@ -21,8 +21,10 @@ import static software.amazon.jdbc.util.ConnectionUrlBuilder.buildUrl;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -40,7 +42,6 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   public static final String CONN_GET_AUTO_COMMIT = "Connection.getAutoCommit";
   public static final String CONN_GET_CATALOG = "Connection.getCatalog";
   public static final String CONN_GET_SCHEMA = "Connection.getSchema";
-  public static final String CONN_GET_TRANSACTION_ISOLATION = "Connection.getTransactionIsolation";
   public static final String CONN_GET_NETWORK_TIMEOUT = "Connection.getNetworkTimeout";
   public static final String CONN_GET_METADATA = "Connection.getMetaData";
   public static final String CONN_IS_READ_ONLY = "Connection.isReadOnly";
@@ -50,22 +51,16 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   public static final String CONN_CREATE_CLOB = "Connection.createClob";
   public static final String CONN_CREATE_BLOB = "Connection.createBlob";
   public static final String CONN_CREATE_NCLOB = "Connection.createNClob";
-  public static final String CONN_IS_CLOSED = "Connection.isClosed";
   public static final String CONN_CLEAR_WARNINGS = "Connection.clearWarnings";
   public static final String CONN_SET_HOLDABILITY = "Connection.setHoldability";
   public static final String CONN_SET_SCHEMA = "Connection.setSchema";
   public static final String STATEMENT_CLEAR_WARNINGS = "Statement.clearWarnings";
-  public static final String STATEMENT_GET_CONNECTION = "Statement.getConnection";
-  public static final String STATEMENT_GET_FETCH_DIRECTION = "Statement.getFetchDirection";
   public static final String STATEMENT_GET_FETCH_SIZE = "Statement.getFetchSize";
   public static final String STATEMENT_GET_MAX_FIELD_SIZE = "Statement.getMaxFieldSize";
-  public static final String STATEMENT_GET_RESULT_SET_HOLDABILITY = "Statement.getResultSetHoldability";
   public static final String STATEMENT_GET_RESULT_SET_TYPE = "Statement.getResultSetType";
-  public static final String STATEMENT_IS_CLOSED = "Statement.isClosed";
   public static final String STATEMENT_IS_CLOSE_ON_COMPLETION = "Statement.isCloseOnCompletion";
   public static final String STATEMENT_CLEAR_BATCH = "Statement.clearBatch";
   public static final String STATEMENT_CLOSE_ON_COMPLETION = "Statement.closeOnCompletion";
-  public static final String STATEMENT_GET_LARGE_MAX_ROWS = "Statement.getLargeMaxRows";
   public static final String STATEMENT_GET_GENERATED_KEYS = "Statement.getGeneratedKeys";
   public static final String STATEMENT_GET_MAX_ROWS = "Statement.getMaxRows";
   public static final String STATEMENT_GET_MORE_RESULTS = "Statement.getMoreResults";
@@ -101,6 +96,14 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   public static final String CALL_WAS_NULL = "CallableStatement.wasNull";
   public static final String PREP_ADD_BATCH = "PreparedStatement.addBatch";
   public static final String PREP_CLEAR_PARAMS = "PreparedStatement.clearParameters";
+  public static final List<String> COMMON_CLOSED_METHODS = Arrays.asList(
+      "Connection.isClosed",
+      "Statement.getConnection",
+      "Statement.getFetchDirection",
+      "Statement.getResultSetHoldability",
+      "Statement.isClosed",
+      "Statement.getLargeMaxRows"
+  );
 
   @Override
   public boolean isDialect(Driver driver) {
@@ -176,10 +179,7 @@ public class GenericTargetDriverDialect implements TargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
-        add(CONN_GET_SCHEMA);
-        add(CONN_GET_CATALOG);
-        add(CONN_GET_AUTO_COMMIT);
-        add(CONN_GET_TRANSACTION_ISOLATION);
+        addAll(COMMON_CLOSED_METHODS);
       }
     });
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -102,6 +102,7 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
+        addAll(COMMON_CLOSED_METHODS);
         add(CONN_GET_CATALOG);
         add(CONN_GET_METADATA);
         add(CONN_IS_READ_ONLY);
@@ -114,22 +115,16 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
         add(CONN_CREATE_CLOB);
         add(CONN_CREATE_BLOB);
         add(CONN_CREATE_NCLOB);
-        add(CONN_IS_CLOSED);
         add(CONN_CLEAR_WARNINGS);
         add(CONN_SET_HOLDABILITY);
         add(CONN_SET_SCHEMA);
         add(STATEMENT_CLEAR_WARNINGS);
-        add(STATEMENT_GET_CONNECTION);
-        add(STATEMENT_GET_FETCH_DIRECTION);
         add(STATEMENT_GET_FETCH_SIZE);
         add(STATEMENT_GET_MAX_FIELD_SIZE);
-        add(STATEMENT_GET_RESULT_SET_HOLDABILITY);
         add(STATEMENT_GET_RESULT_SET_TYPE);
-        add(STATEMENT_IS_CLOSED);
         add(STATEMENT_IS_CLOSE_ON_COMPLETION);
         add(STATEMENT_CLEAR_BATCH);
         add(STATEMENT_CLOSE_ON_COMPLETION);
-        add(STATEMENT_GET_LARGE_MAX_ROWS);
         add(STATEMENT_GET_GENERATED_KEYS);
         add(STATEMENT_GET_MAX_ROWS);
         add(STATEMENT_GET_MORE_RESULTS);

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -18,7 +18,10 @@ package software.amazon.jdbc.targetdriverdialect;
 
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
@@ -93,5 +96,74 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
   public void registerDriver() throws SQLException {
     final MariadbDriverHelper helper = new MariadbDriverHelper();
     helper.registerDriver();
+  }
+
+  @Override
+  public Set<String> getAllowedOnConnectionMethodNames() {
+    return Collections.unmodifiableSet(new HashSet<String>() {
+      {
+        add(CONN_GET_CATALOG);
+        add(CONN_GET_METADATA);
+        add(CONN_IS_READ_ONLY);
+        add(CONN_GET_SCHEMA);
+        add(CONN_GET_AUTO_COMMIT);
+        add(CONN_GET_HOLDABILITY);
+        add(CONN_GET_CLIENT_INFO);
+        add(CONN_GET_NETWORK_TIMEOUT);
+        add(CONN_GET_TYPE_MAP);
+        add(CONN_CREATE_CLOB);
+        add(CONN_CREATE_BLOB);
+        add(CONN_CREATE_NCLOB);
+        add(CONN_IS_CLOSED);
+        add(CONN_CLEAR_WARNINGS);
+        add(CONN_SET_HOLDABILITY);
+        add(CONN_SET_SCHEMA);
+        add(STATEMENT_CLEAR_WARNINGS);
+        add(STATEMENT_GET_CONNECTION);
+        add(STATEMENT_GET_FETCH_DIRECTION);
+        add(STATEMENT_GET_FETCH_SIZE);
+        add(STATEMENT_GET_MAX_FIELD_SIZE);
+        add(STATEMENT_GET_RESULT_SET_HOLDABILITY);
+        add(STATEMENT_GET_RESULT_SET_TYPE);
+        add(STATEMENT_IS_CLOSED);
+        add(STATEMENT_IS_CLOSE_ON_COMPLETION);
+        add(STATEMENT_CLEAR_BATCH);
+        add(STATEMENT_CLOSE_ON_COMPLETION);
+        add(STATEMENT_GET_LARGE_MAX_ROWS);
+        add(STATEMENT_GET_GENERATED_KEYS);
+        add(STATEMENT_GET_MAX_ROWS);
+        add(STATEMENT_GET_MORE_RESULTS);
+        add(STATEMENT_GET_QUERY_TIMEOUT);
+        add(STATEMENT_GET_RESULT_SET);
+        add(STATEMENT_GET_RESULT_SET_CONCURRENCY);
+        add(STATEMENT_GET_UPDATE_COUNT);
+        add(STATEMENT_ADD_BATCH);
+        add(CALL_GET_ARRAY);
+        add(CALL_GET_BIG_DECIMAL);
+        add(CALL_GET_BLOB);
+        add(CALL_GET_BOOLEAN);
+        add(CALL_GET_BYTE);
+        add(CALL_GET_BYTES);
+        add(CALL_GET_CHARACTER_STREAM);
+        add(CALL_GET_CLOB);
+        add(CALL_GET_DATE);
+        add(CALL_GET_DOUBLE);
+        add(CALL_GET_FLOAT);
+        add(CALL_GET_INT);
+        add(CALL_GET_LONG);
+        add(CALL_GET_N_CHAR);
+        add(CALL_GET_N_CLOB);
+        add(CALL_GET_N_STRING);
+        add(CALL_GET_OBJECT);
+        add(CALL_GET_SHORT);
+        add(CALL_GET_TIME);
+        add(CALL_GET_STRING);
+        add(CALL_GET_TIMESTAMP);
+        add(CALL_GET_URL);
+        add(CALL_WAS_NULL);
+        add(PREP_ADD_BATCH);
+        add(PREP_CLEAR_PARAMS);
+      }
+    });
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MariadbTargetDriverDialect.java
@@ -102,7 +102,7 @@ public class MariadbTargetDriverDialect extends GenericTargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
-        addAll(COMMON_CLOSED_METHODS);
+        addAll(ALLOWED_ON_CLOSED_METHODS);
         add(CONN_GET_CATALOG);
         add(CONN_GET_METADATA);
         add(CONN_IS_READ_ONLY);

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -21,7 +21,10 @@ import java.sql.Driver;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
@@ -102,5 +105,30 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
     } catch (SQLException e) {
       return false;
     }
+  }
+
+  @Override
+  public Set<String> getAllowedOnConnectionMethodNames() {
+    return Collections.unmodifiableSet(new HashSet<String>() {
+      {
+        add(CONN_GET_CATALOG);
+        add(CONN_IS_READ_ONLY);
+        add(CONN_GET_AUTO_COMMIT);
+        add(CONN_GET_HOLDABILITY);
+        add(CONN_GET_CLIENT_INFO);
+        add(CONN_GET_NETWORK_TIMEOUT);
+        add(CONN_GET_TYPE_MAP);
+        add(CONN_CREATE_CLOB);
+        add(CONN_CREATE_BLOB);
+        add(CONN_CREATE_NCLOB);
+        add(CONN_IS_CLOSED);
+        add(CONN_SET_HOLDABILITY);
+        add(STATEMENT_GET_CONNECTION);
+        add(STATEMENT_GET_FETCH_DIRECTION);
+        add(STATEMENT_GET_RESULT_SET_HOLDABILITY);
+        add(STATEMENT_IS_CLOSED);
+        add(STATEMENT_GET_LARGE_MAX_ROWS);
+      }
+    });
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -111,6 +111,7 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
+        addAll(COMMON_CLOSED_METHODS);
         add(CONN_GET_CATALOG);
         add(CONN_IS_READ_ONLY);
         add(CONN_GET_AUTO_COMMIT);
@@ -121,13 +122,7 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
         add(CONN_CREATE_CLOB);
         add(CONN_CREATE_BLOB);
         add(CONN_CREATE_NCLOB);
-        add(CONN_IS_CLOSED);
         add(CONN_SET_HOLDABILITY);
-        add(STATEMENT_GET_CONNECTION);
-        add(STATEMENT_GET_FETCH_DIRECTION);
-        add(STATEMENT_GET_RESULT_SET_HOLDABILITY);
-        add(STATEMENT_IS_CLOSED);
-        add(STATEMENT_GET_LARGE_MAX_ROWS);
       }
     });
   }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/MysqlConnectorJTargetDriverDialect.java
@@ -111,7 +111,7 @@ public class MysqlConnectorJTargetDriverDialect extends GenericTargetDriverDiale
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
-        addAll(COMMON_CLOSED_METHODS);
+        addAll(ALLOWED_ON_CLOSED_METHODS);
         add(CONN_GET_CATALOG);
         add(CONN_IS_READ_ONLY);
         add(CONN_GET_AUTO_COMMIT);

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -122,7 +122,7 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
-        addAll(COMMON_CLOSED_METHODS);
+        addAll(ALLOWED_ON_CLOSED_METHODS);
         add(STATEMENT_CLEAR_WARNINGS);
         add(STATEMENT_GET_FETCH_SIZE);
         add(STATEMENT_GET_MAX_FIELD_SIZE);

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.targetdriverdialect;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -27,7 +28,6 @@ import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
 import software.amazon.jdbc.PropertyDefinition;
-import software.amazon.jdbc.util.Messages;
 import software.amazon.jdbc.util.PropertyUtils;
 
 public class PgTargetDriverDialect extends GenericTargetDriverDialect {
@@ -116,5 +116,54 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   public void registerDriver() throws SQLException {
     final PgDriverHelper helper = new PgDriverHelper();
     helper.registerDriver();
+  }
+
+  @Override
+  public Set<String> getAllowedOnConnectionMethodNames() {
+    return Collections.unmodifiableSet(new HashSet<String>() {
+      {
+        add(CONN_IS_CLOSED);
+        add(STATEMENT_CLEAR_WARNINGS);
+        add(STATEMENT_GET_CONNECTION);
+        add(STATEMENT_GET_FETCH_DIRECTION);
+        add(STATEMENT_GET_FETCH_SIZE);
+        add(STATEMENT_GET_MAX_FIELD_SIZE);
+        add(STATEMENT_GET_RESULT_SET_HOLDABILITY);
+        add(STATEMENT_GET_RESULT_SET_TYPE);
+        add(STATEMENT_IS_CLOSED);
+        add(STATEMENT_IS_CLOSE_ON_COMPLETION);
+        add(STATEMENT_CLEAR_BATCH);
+        add(STATEMENT_CLOSE_ON_COMPLETION);
+        add(STATEMENT_GET_LARGE_MAX_ROWS);
+        add(STATEMENT_GET_GENERATED_KEYS);
+        add(STATEMENT_GET_MAX_ROWS);
+        add(STATEMENT_GET_MORE_RESULTS);
+        add(STATEMENT_GET_QUERY_TIMEOUT);
+        add(STATEMENT_GET_RESULT_SET);
+        add(STATEMENT_GET_RESULT_SET_CONCURRENCY);
+        add(STATEMENT_GET_UPDATE_COUNT);
+        add(STATEMENT_GET_WARNINGS);
+        add(STATEMENT_ADD_BATCH);
+        add(CALL_GET_ARRAY);
+        add(CALL_GET_BIG_DECIMAL);
+        add(CALL_GET_BOOLEAN);
+        add(CALL_GET_BYTE);
+        add(CALL_GET_BYTES);
+        add(CALL_GET_DATE);
+        add(CALL_GET_DOUBLE);
+        add(CALL_GET_FLOAT);
+        add(CALL_GET_INT);
+        add(CALL_GET_LONG);
+        add(CALL_GET_OBJECT);
+        add(CALL_GET_SHORT);
+        add(CALL_GET_SQLXML);
+        add(CALL_GET_TIME);
+        add(CALL_GET_STRING);
+        add(CALL_GET_TIMESTAMP);
+        add(CALL_WAS_NULL);
+        add(PREP_ADD_BATCH);
+        add(PREP_CLEAR_PARAMS);
+      }
+    });
   }
 }

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/PgTargetDriverDialect.java
@@ -122,19 +122,14 @@ public class PgTargetDriverDialect extends GenericTargetDriverDialect {
   public Set<String> getAllowedOnConnectionMethodNames() {
     return Collections.unmodifiableSet(new HashSet<String>() {
       {
-        add(CONN_IS_CLOSED);
+        addAll(COMMON_CLOSED_METHODS);
         add(STATEMENT_CLEAR_WARNINGS);
-        add(STATEMENT_GET_CONNECTION);
-        add(STATEMENT_GET_FETCH_DIRECTION);
         add(STATEMENT_GET_FETCH_SIZE);
         add(STATEMENT_GET_MAX_FIELD_SIZE);
-        add(STATEMENT_GET_RESULT_SET_HOLDABILITY);
         add(STATEMENT_GET_RESULT_SET_TYPE);
-        add(STATEMENT_IS_CLOSED);
         add(STATEMENT_IS_CLOSE_ON_COMPLETION);
         add(STATEMENT_CLEAR_BATCH);
         add(STATEMENT_CLOSE_ON_COMPLETION);
-        add(STATEMENT_GET_LARGE_MAX_ROWS);
         add(STATEMENT_GET_GENERATED_KEYS);
         add(STATEMENT_GET_MAX_ROWS);
         add(STATEMENT_GET_MORE_RESULTS);

--- a/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/targetdriverdialect/TargetDriverDialect.java
@@ -19,6 +19,7 @@ package software.amazon.jdbc.targetdriverdialect;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import software.amazon.jdbc.HostSpec;
@@ -53,4 +54,6 @@ public interface TargetDriverDialect {
    * @return True, if operation is succeeded. False, otherwise.
    */
   boolean ping(final @NonNull Connection connection);
+
+  Set<String> getAllowedOnConnectionMethodNames();
 }


### PR DESCRIPTION
### Summary

Add check for target dialect specific method calls allowed on closed connections

### Description

Used Hashset to store allowed methods. Change to check dialect specific methods instead of generic ones

### Additional Reviewers

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.