### PR TITLE
fix: hibernate-orm and standard-integration tests to publish results even if failing

### DIFF
--- a/.github/workflows/run-hibernate-orm-tests.yml
+++ b/.github/workflows/run-hibernate-orm-tests.yml
@@ -45,14 +45,14 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-hibernate-only
       - name: 'Archive junit results'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
+        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
         uses: actions/upload-artifact@v4
         with:
           name: junit-report
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive html summary report'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
+        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
         uses: actions/upload-artifact@v4
         with:
           name: html-summary-report

--- a/.github/workflows/run-standard-integration-tests.yml
+++ b/.github/workflows/run-standard-integration-tests.yml
@@ -46,14 +46,14 @@ jobs:
         run: |
           ./gradlew --no-parallel --no-daemon test-all-docker
       - name: 'Archive junit results'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
+        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
         uses: actions/upload-artifact@v4
         with:
           name: junit-report
           path: ./wrapper/build/test-results
           retention-days: 5
       - name: 'Archive html summary report'
-        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false'}}
+        if: ${{steps.changed-files.outputs.ONLY_DOCS && steps.changed-files.outputs.ONLY_DOCS == 'false' && !cancelled()}}
         uses: actions/upload-artifact@v4
         with:
           name: html-summary-report


### PR DESCRIPTION
…even if failing

### Summary

fix: hibernate-orm and standard-integration tests to publish results even if failing.

Fixes issue https://github.com/orgs/awslabs/projects/91/views/13?pane=issue&itemId=52456842

### Description

For those tests, added `!canceled()` to the status check expression of the publishing steps so that even if the previous steps fail, it will still publish results. 

NOTE: also included a change to an integration test that is expected to fail for testing. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.