### PR TITLE
chore: update PGJDBC version to 42.7.2

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
     jmhImplementation(project(":aws-advanced-jdbc-wrapper"))
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("mysql:mysql-connector-java:8.0.33")
     implementation("org.mariadb.jdbc:mariadb-java-client:3.3.2")
     implementation("com.zaxxer:HikariCP:4.0.3")

--- a/examples/AWSDriverExample/build.gradle.kts
+++ b/examples/AWSDriverExample/build.gradle.kts
@@ -16,7 +16,7 @@
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc:2.7.13") // 2.7.13 is the last version compatible with Java 8
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("mysql:mysql-connector-java:8.0.33")
     implementation("software.amazon.awssdk:rds:2.24.6")
     implementation("software.amazon.awssdk:secretsmanager:2.24.1")

--- a/examples/HikariExample/build.gradle.kts
+++ b/examples/HikariExample/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("mysql:mysql-connector-java:8.0.33")
     implementation(project(":aws-advanced-jdbc-wrapper"))
     implementation("com.zaxxer:HikariCP:4.0.3")

--- a/examples/ReadWriteSplittingSample/build.gradle.kts
+++ b/examples/ReadWriteSplittingSample/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("mysql:mysql-connector-java:8.0.33")
     implementation("com.zaxxer:HikariCP:4.0.3")
     implementation(project(":aws-advanced-jdbc-wrapper"))

--- a/examples/SpringBootHikariExample/build.gradle.kts
+++ b/examples/SpringBootHikariExample/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
 	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("org.postgresql:postgresql:42.7.1")
+	implementation("org.postgresql:postgresql:42.7.2")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 
 }

--- a/examples/SpringHibernateBalancedReaderOneDataSourceExample/build.gradle.kts
+++ b/examples/SpringHibernateBalancedReaderOneDataSourceExample/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.retry:spring-retry")
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("software.amazon.awssdk:rds:2.24.6")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/SpringHibernateBalancedReaderTwoDataSourceExample/build.gradle.kts
+++ b/examples/SpringHibernateBalancedReaderTwoDataSourceExample/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.retry:spring-retry")
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("software.amazon.awssdk:rds:2.24.6")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/SpringHibernateExample/build.gradle.kts
+++ b/examples/SpringHibernateExample/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("software.amazon.awssdk:rds:2.24.6")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/SpringWildflyExample/spring/build.gradle.kts
+++ b/examples/SpringWildflyExample/spring/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-web")
     runtimeOnly("org.springframework.boot:spring-boot-devtools")
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation("software.amazon.awssdk:rds:2.24.6")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }

--- a/examples/VertxExample/build.gradle.kts
+++ b/examples/VertxExample/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("io.vertx:vertx-jdbc-client")
     implementation("io.vertx:vertx-web")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
-    implementation("org.postgresql:postgresql:42.7.1")
+    implementation("org.postgresql:postgresql:42.7.2")
     implementation(project(":aws-advanced-jdbc-wrapper"))
 }
 

--- a/wrapper/build.gradle.kts
+++ b/wrapper/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     compileOnly("software.amazon.awssdk:secretsmanager:2.24.1")
     compileOnly("com.fasterxml.jackson.core:jackson-databind:2.16.1")
     compileOnly("mysql:mysql-connector-java:8.0.33")
-    compileOnly("org.postgresql:postgresql:42.7.1")
+    compileOnly("org.postgresql:postgresql:42.7.2")
     compileOnly("org.mariadb.jdbc:mariadb-java-client:3.3.2")
     compileOnly("org.osgi:org.osgi.core:6.0.0")
     compileOnly("org.osgi:org.osgi.core:6.0.0")
@@ -55,7 +55,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
     testImplementation("org.apache.commons:commons-dbcp2:2.11.0")
-    testImplementation("org.postgresql:postgresql:42.7.1")
+    testImplementation("org.postgresql:postgresql:42.7.2")
     testImplementation("mysql:mysql-connector-java:8.0.33")
     testImplementation("org.mariadb.jdbc:mariadb-java-client:3.3.2")
     testImplementation("com.zaxxer:HikariCP:4.0.3") // Version 4.+ is compatible with Java 8


### PR DESCRIPTION
### Summary

Update PGJDBC version to 42.7.2. The updated dependency addresses a [CVE-2024-1597](https://www.cve.org/CVERecord?id=CVE-2024-1597) and [Security Advisory](https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56) found in the PGJDBC driver. The vulnerability occurs only in non-default `preferQueryMode=simple` mode and only if a negative place holder `-? `is used. See the security advisory for details

### Description

<!--- Details of what you changed -->

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.