### PR TITLE
chore: ConnectionStringHostListProvider to not support identifyConnection() since it is not used

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/hostlistprovider/ConnectionStringHostListProvider.java
@@ -115,27 +115,7 @@ public class ConnectionStringHostListProvider implements StaticHostListProvider 
 
   @Override
   public HostSpec identifyConnection(Connection connection) throws SQLException {
-    try (final Statement stmt = connection.createStatement();
-        final ResultSet resultSet = stmt.executeQuery(this.hostListProviderService.getDialect().getHostAliasQuery())) {
-      if (resultSet.next()) {
-        final String instance = resultSet.getString(1);
-
-        final List<HostSpec> topology = this.refresh(connection);
-
-        if (topology == null) {
-          return null;
-        }
-
-        return topology
-            .stream()
-            .filter(host -> Objects.equals(instance, host.getHostId()))
-            .findAny()
-            .orElse(null);
-      }
-    } catch (final SQLException e) {
-      throw new SQLException(Messages.get("ConnectionStringHostListProvider.errorIdentifyConnection"), e);
-    }
-
-    throw new SQLException(Messages.get("ConnectionStringHostListProvider.errorIdentifyConnection"));
+    throw new UnsupportedOperationException(
+        Messages.get("ConnectionStringHostListProvider.unsupportedIdentifyConnection"));
   }
 }

--- a/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
+++ b/wrapper/src/main/resources/aws_advanced_jdbc_wrapper_messages.properties
@@ -84,7 +84,7 @@ ClusterAwareWriterFailoverHandler.alreadyWriter=Current reader connection is act
 
 # Connection String Host List Provider
 ConnectionStringHostListProvider.parsedListEmpty=Can''t parse connection string: ''{0}''.
-ConnectionStringHostListProvider.errorIdentifyConnection=An error occurred while obtaining the connection's host ID.
+ConnectionStringHostListProvider.unsupportedIdentifyConnection=ConnectionStringHostListProvider does not support identifyConnection.
 
 # Connection Plugin Manager
 ConnectionPluginManager.releaseResources=Releasing resources.


### PR DESCRIPTION
### Summary

chore: ConnectionStringHostListProvider to not support identifyConnection() since it is not used

### Description

remove code from ConnectionStringHostListProvider.identifyConnection() and throw UnsupportedOperationException() since it is not used. 

### Additional Reviewers

<!-- Any additional reviewers -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.