### PR TITLE
fix: parse nested options

### DIFF
--- a/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
+++ b/wrapper/src/main/java/software/amazon/jdbc/util/ConnectionUrlParser.java
@@ -166,13 +166,15 @@ public class ConnectionUrlParser {
 
     final String[] listOfParameters = urlParameters[1].split("&");
     for (final String param : listOfParameters) {
-      final String[] currentParameter = param.split("=");
+      final int pos = param.indexOf("=");
       String currentParameterValue = "";
 
-      if (currentParameter.length > 1) {
-        currentParameterValue = urlDecode(currentParameter[1]);
+      if (pos == -1) {
+        props.setProperty(param, currentParameterValue);
+        continue;
       }
 
+      currentParameterValue = urlDecode(param.substring(pos + 1));
       if (currentParameterValue == null) {
         continue;
       }
@@ -183,7 +185,8 @@ public class ConnectionUrlParser {
       if (matcher.matches()) {
         currentParameterValue = "";
       }
-      props.setProperty(currentParameter[0], currentParameterValue);
+      final String currentParameterName = param.substring(0, pos);
+      props.setProperty(currentParameterName, currentParameterValue);
     }
   }
 

--- a/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlParserTest.java
+++ b/wrapper/src/test/java/software/amazon/jdbc/util/ConnectionUrlParserTest.java
@@ -34,6 +34,7 @@ import software.amazon.jdbc.HostSpecBuilder;
 import software.amazon.jdbc.hostavailability.SimpleHostAvailabilityStrategy;
 
 class ConnectionUrlParserTest {
+
   @ParameterizedTest
   @MethodSource("testGetHostsFromConnectionUrlArguments")
   void testGetHostsFromConnectionUrl_returnCorrectHostList(String testUrl, List<HostSpec> expected) {
@@ -101,6 +102,14 @@ class ConnectionUrlParserTest {
     assertEquals(expected, props.getProperty("param"));
   }
 
+  @ParameterizedTest
+  @MethodSource("urlWithNestedParams")
+  void testParsingUrlWithNestedParams(final String url, final String expected) {
+    Properties props = new Properties();
+    ConnectionUrlParser.parsePropertiesFromUrl(url, props);
+    assertEquals(expected, props.getProperty("param"));
+  }
+
   private static Stream<Arguments> testGetHostsFromConnectionUrlArguments() {
     return Stream.of(
         Arguments.of("protocol//", new ArrayList<HostSpec>()),
@@ -160,6 +169,15 @@ class ConnectionUrlParserTest {
         Arguments.of("protocol//host/db?param=foo", "foo"),
         Arguments.of("protocol//host:1234/db?param=?.foo", "?.foo"),
         Arguments.of("protocol//host?param=?", "?")
+    );
+  }
+
+  private static Stream<Arguments> urlWithNestedParams() {
+    return Stream.of(
+        Arguments.of("protocol//host/db?param=-c%20foo=1000", "-c foo=1000"),
+        Arguments.of("protocol//host/db?param=-c foo=1000", "-c foo=1000"),
+        Arguments.of("protocol//host/db?param=-c%20foo=a,b,c%20-c%20bar=10", "-c foo=a,b,c -c bar=10"),
+        Arguments.of("protocol//host/db?param=-c foo=a,b,c -c bar=10", "-c foo=a,b,c -c bar=10")
     );
   }
 }


### PR DESCRIPTION

### Description

The driver was incorrectly truncating nested connection options when parsing connection urls.
Connecting with a string similar to `?options=-c%20search_path=test,public,pg_catalog%20-c%20statement_timeout=90000` would result in unexpected errors:
```
Exception in thread "main" org.postgresql.util.PSQLException: FATAL: -c search_path requires a value
```

This PR updates the parsing logic to properly handle nested options.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.